### PR TITLE
feat: Java SQLi 보조룰 (파일 경계 넘는 문자열 조립 SQL 탐지)

### DIFF
--- a/mapping/rules.yaml
+++ b/mapping/rules.yaml
@@ -264,6 +264,23 @@
     ps.setString(1, userId);
     ```
 
+- rule_id: finguard.java.sql-string-build
+  code: FIN-SQLI-004
+  cwe: CWE-89
+  title: SQL 삽입 의심(문자열 조립 실행)
+  severity: WARNING
+  basis: 개발보안가이드 「입력데이터 검증 및 표현 - SQL 삽입」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 19 (SQL Injection)"
+  explain: SQL 문을 String.format 또는 문자열 연결로 조립해 실행하고 있습니다. 조립 값이 외부 입력에서 유래하면 SQL 삽입 위험이 있습니다. 오염원이 다른 파일(예를 들어 Controller/Servlet)에 있으면 자동 오염 추적이 파일 경계에서 끊기므로, PreparedStatement 바인딩 여부를 수동 확인해야 합니다.
+  fix_example: |
+    ```java
+    // 문자열 조립 대신 바인딩 파라미터 사용
+    PreparedStatement ps = conn.prepareStatement(
+        "SELECT * FROM USERS WHERE ID = ? AND PASSWORD = ?");
+    ps.setString(1, id);
+    ps.setString(2, password);
+    ```
+
 - rule_id: finguard.java.hardcoded-secret
   code: FIN-KEY-004
   cwe: CWE-798

--- a/rules/java.yaml
+++ b/rules/java.yaml
@@ -25,6 +25,75 @@ rules:
               - pattern: $C.prepareCall($SQL, ...)
           - focus-metavariable: $SQL
 
+  # 보조룰(비-taint): SQL 을 String.format/문자열 연결로 조립해 execute 계열에 넘기는 패턴.
+  # jdbc-sqli 의 파일 단위 taint 가 Controller→DAO 파일 분리에서 끊기는 케이스를 보완한다.
+  # 내부 상수만 조립하는 경우도 포함될 수 있어 severity=WARNING + 수동 확인 문구.
+  # SQL 키워드가 포함된 리터럴로 한정해 오탐을 억제한다.
+  - id: finguard.java.sql-string-build
+    languages: [java]
+    severity: WARNING
+    message: SQL 문을 String.format 또는 문자열 연결로 조립해 실행하고 있습니다. 조립에 쓰인 값이 외부 입력에서 유래하면 SQL 삽입 위험이 있습니다. 파일 경계를 넘는 오염 추적은 자동 점검 범위를 벗어나므로 PreparedStatement 바인딩 여부를 수동 확인해야 합니다.
+    paths:
+      exclude: ["*Test.java"]
+    patterns:
+      - pattern-either:
+          # (1) execute 인자에 String.format 직접
+          - patterns:
+              - pattern-either:
+                  - pattern: $S.executeQuery(String.format($FMT, ...))
+                  - pattern: $S.executeUpdate(String.format($FMT, ...))
+                  - pattern: $S.execute(String.format($FMT, ...))
+                  - pattern: $S.addBatch(String.format($FMT, ...))
+              - metavariable-regex:
+                  metavariable: $FMT
+                  regex: (?i).*(select|insert|update|delete|from|where)\s
+          # (2) 지역변수에 String.format 대입 후 execute
+          - patterns:
+              - pattern-either:
+                  - pattern: |
+                      $T $SQL = String.format($FMT, ...);
+                      ...
+                      $S.executeQuery($SQL);
+                  - pattern: |
+                      $T $SQL = String.format($FMT, ...);
+                      ...
+                      $S.executeUpdate($SQL);
+                  - pattern: |
+                      $T $SQL = String.format($FMT, ...);
+                      ...
+                      $S.execute($SQL);
+              - metavariable-regex:
+                  metavariable: $FMT
+                  regex: (?i).*(select|insert|update|delete|from|where)\s
+          # (3) execute 인자에 문자열 연결 직접 (SQL 리터럴 + 변수)
+          - patterns:
+              - pattern-either:
+                  - pattern: $S.executeQuery($LIT + $X)
+                  - pattern: $S.executeUpdate($LIT + $X)
+                  - pattern: $S.execute($LIT + $X)
+                  - pattern: $S.addBatch($LIT + $X)
+              - metavariable-regex:
+                  metavariable: $LIT
+                  regex: (?i)"\s*(select|insert|update|delete).*
+          # (4) 지역변수에 문자열 연결 대입 후 execute
+          - patterns:
+              - pattern-either:
+                  - pattern: |
+                      $T $SQL = $LIT + $X;
+                      ...
+                      $S.executeQuery($SQL);
+                  - pattern: |
+                      $T $SQL = $LIT + $X;
+                      ...
+                      $S.executeUpdate($SQL);
+                  - pattern: |
+                      $T $SQL = $LIT + $X;
+                      ...
+                      $S.execute($SQL);
+              - metavariable-regex:
+                  metavariable: $LIT
+                  regex: (?i)"\s*(select|insert|update|delete).*
+
   - id: finguard.java.hardcoded-secret
     languages: [regex]
     severity: ERROR


### PR DESCRIPTION
Closes #1

## 요약
기존 taint 룰 `finguard.java.jdbc-sqli` 는 파일 단위 오염 추적이라 Controller/Servlet(소스) → DAO(sink) 로 분리된 SQLi 를 놓친다. 이를 보완하는 비-taint 휴리스틱 룰 추가.

## 실증 검증 (한국 OSS)
- `karadsik7/secure_study`(시큐어코딩 실습): 기존 룰이 놓친 SQLi 2건 검출 — `UserDao.java:20`(insert String.format), `:44`(login select)
- `parkyc70/egovframe`(전자정부, 626 java, MyBatis 기반): 재검증 시 이 룰 **오탐 0건**

## 변경
- `rules/java.yaml`: `finguard.java.sql-string-build` — String.format/문자열 연결(SQL 키워드 한정) → execute 계열, 4개 하위패턴
- `mapping/rules.yaml`: `FIN-SQLI-004` (WARNING, 금보원 웹·모바일·HTS 19 SQL Injection)
- `go test ./...` 통과 (매핑 1:1 커버리지 강제 포함), `semgrep --validate` 통과

Made with [Orca](https://github.com/stablyai/orca) 🐋
