### PR TITLE
fix: ts.http-url XML 네임스페이스 URI 오탐 억제

### DIFF
--- a/rules/typescript.yaml
+++ b/rules/typescript.yaml
@@ -29,7 +29,10 @@ rules:
     message: 평문 HTTP URL 이 사용되고 있습니다. TLS(https) 로 전환해야 합니다.
     paths:
       include: ["*.ts", "*.tsx", "*.js", "*.jsx"]
-    pattern-regex: '(?im)^(?![ \t]*(?://|\*|/\*)).*["'']http://(?!localhost|127\.0\.0\.1|0\.0\.0\.0|schemas\.|xmlns|(?:www\.)?w3\.org|(?:[\w.]+\.)?apache\.org|[\w.]*xml\.org|java\.sun\.com|(?:www\.)?example\.(?:com|org)|(?:www\.)?unicode\.org|(?:www\.)?jflex\.de|purl\.org|iana\.org|ietf\.org|slf4j\.org|json-schema\.org)[^"'']+["'']'
+    # 평문 http 리터럴 검출. 단 XML 네임스페이스 URI(통신 주소가 아니라 스키마 식별자)는
+    # 제외한다 — 같은 줄에 xmlns 가 있거나, 잘 알려진 문서포맷 스키마 호스트(w3/apache/idpf/
+    # hancom/openxmlformats 등)인 경우. HWPX·OOXML·EPUB 은 XML 기반이라 네임스페이스가 도배된다.
+    pattern-regex: '(?im)^(?![ \t]*(?://|\*|/\*))(?!.*\bxmlns\b).*["'']http://(?!localhost|127\.0\.0\.1|0\.0\.0\.0|schemas\.|xmlns|(?:www\.)?w3\.org|(?:[\w.]+\.)?apache\.org|[\w.]*xml\.org|java\.sun\.com|(?:www\.)?example\.(?:com|org)|(?:www\.)?unicode\.org|(?:www\.)?jflex\.de|purl\.org|iana\.org|ietf\.org|slf4j\.org|json-schema\.org|(?:www\.)?hancom\.(?:co\.kr|com)|(?:www\.)?idpf\.org|openxmlformats\.org|(?:www\.)?oasis-open\.org|dublincore\.org|docbook\.org)[^"'']+["'']'
 
   - id: finguard.ts.os-command-injection
     languages: [ts, js]


### PR DESCRIPTION
Closes #3

## 문제
한국 문서포맷 라이브러리 `chrisryugj/kordoc`(HWPX/OWPML, 265 TS)로 검증 중 `ts.http-url`(FIN-TLS-005) 이 XML 네임스페이스 URI 를 평문 HTTP 통신으로 오인 — **오탐 8건**. 네임스페이스 URI 는 스키마 식별자라 https 로 바꾸면 문서가 깨진다.

## 수정
- 같은 줄에 `xmlns` 있으면 스킵
- 문서 스키마 네임스페이스 호스트(hancom/idpf/openxmlformats/oasis-open/dublincore/docbook) allowlist 추가

## 검증
- kordoc FIN-TLS-005 오탐 **8건 → 0건**
- 회귀: 실제 평문 http 통신(`fetch("http://...")`)은 그대로 검출 확인
- `go test ./...`·`semgrep --validate` 통과

Made with [Orca](https://github.com/stablyai/orca) 🐋
