### PR TITLE
feat: zip-slip 룰 추가 (Java·TS)

### DIFF
--- a/mapping/rules.yaml
+++ b/mapping/rules.yaml
@@ -673,6 +673,39 @@
     el.textContent = value; // HTML 필요 시 DOMPurify.sanitize 사용
     ```
 
+- rule_id: finguard.java.zip-slip
+  code: FIN-PATH-004
+  cwe: CWE-22
+  title: 압축 해제 경로 조작(zip-slip, Java)
+  severity: ERROR
+  basis: 개발보안가이드 「입력데이터 검증 및 표현 - 경로 조작 및 자원 삽입」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 20 (악성파일 업로드)"
+  explain: 압축 파일의 엔트리명을 검증 없이 저장 경로로 사용하고 있습니다. 엔트리명은 아카이브 제작자가 임의로 정할 수 있어 상위 경로(..)로 기준 디렉터리를 벗어나 임의 위치에 파일을 덮어쓸 수 있습니다(zip-slip). 첨부파일 업로드 처리 경로에서 특히 위험합니다.
+  fix_example: |
+    ```java
+    File base = new File(destDir).getCanonicalFile();
+    File out = new File(base, entry.getName()).getCanonicalFile();
+    if (!out.toPath().startsWith(base.toPath())) {
+        throw new SecurityException("압축 경로 이탈: " + entry.getName());
+    }
+    ```
+
+- rule_id: finguard.ts.zip-slip
+  code: FIN-PATH-005
+  cwe: CWE-22
+  title: 압축 해제 경로 조작(zip-slip, TS/JS)
+  severity: ERROR
+  basis: 개발보안가이드 「입력데이터 검증 및 표현 - 경로 조작 및 자원 삽입」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 20 (악성파일 업로드)"
+  explain: 압축 파일의 엔트리명을 검증 없이 파일 쓰기 경로로 사용하고 있습니다. 엔트리명에 상위 경로(..)가 포함되면 기준 디렉터리 밖에 파일을 생성·덮어쓸 수 있습니다(zip-slip).
+  fix_example: |
+    ```ts
+    const base = path.resolve(outDir);
+    const out = path.resolve(base, entry.entryName);
+    if (!out.startsWith(base + path.sep)) throw new Error("압축 경로 이탈");
+    fs.writeFileSync(out, entry.getData());
+    ```
+
 - rule_id: finguard.ts.path-traversal
   code: FIN-PATH-003
   cwe: CWE-22

--- a/rules/java.yaml
+++ b/rules/java.yaml
@@ -325,6 +325,42 @@ rules:
       - pattern: Files.newInputStream(...)
       - pattern: Files.newOutputStream(...)
 
+  # zip-slip: 압축 엔트리명을 검증 없이 파일 경로로 사용 (CWE-22).
+  # ZIP 엔트리명은 아카이브 제작자가 임의로 정할 수 있어 "../" 로 기준 디렉터리를
+  # 탈출할 수 있다. 첨부파일(ZIP/HWPX/OOXML) 업로드 처리 경로에서 특히 위험하다.
+  # 정규화 후 기준 경로 검증(startsWith)을 한 코드는 잡지 않는다.
+  - id: finguard.java.zip-slip
+    languages: [java]
+    severity: ERROR
+    message: 압축 엔트리명이 검증 없이 파일 경로로 사용되고 있습니다(zip-slip). 엔트리명은 아카이브 제작자가 정하므로 상위 경로(..)로 기준 디렉터리를 벗어날 수 있습니다. 정규화(getCanonicalPath) 후 기준 디렉터리 하위인지 확인해야 합니다.
+    paths:
+      exclude: ["*Test.java"]
+    mode: taint
+    pattern-sources:
+      - pattern: $E.getName()
+      - pattern: $E.getEntry(...).getName()
+    pattern-sanitizers:
+      # 정규화(canonical)·파일명만 추출한 경우는 안전으로 본다.
+      # 정규화 뒤 기준 디렉터리 검증까지 하는 것이 정석이며, 정규화 자체를
+      # sanitizer 로 보아 검증 코드를 오탐하지 않게 한다.
+      - pattern: $P.getCanonicalPath()
+      - pattern: $P.getCanonicalFile()
+      - pattern: $P.toPath().normalize()
+      - pattern: $P.normalize()
+      - pattern: FilenameUtils.getName(...)
+      - pattern: new File(...).getName()
+    # sink 은 실제 파일 I/O 로 한정한다. new File()/Paths.get() 은 경로 객체 생성일
+    # 뿐이라 그 자체로 위험하지 않고, sink 로 두면 검증 코드까지 잡는 오탐이 된다.
+    pattern-sinks:
+      - patterns:
+          - pattern-either:
+              - pattern: new FileOutputStream(...)
+              - pattern: new FileWriter(...)
+              - pattern: new RandomAccessFile(...)
+              - pattern: Files.newOutputStream(...)
+              - pattern: Files.copy(...)
+              - pattern: Files.write(...)
+
   # ------------------------------------------------------------------
   # 8. 서버측 요청 위조(SSRF) (CWE-918)
   # ------------------------------------------------------------------

--- a/rules/typescript.yaml
+++ b/rules/typescript.yaml
@@ -159,3 +159,37 @@ rules:
               - pattern: readFileSync($P, ...)
               - pattern: createReadStream($P, ...)
           - focus-metavariable: $P
+
+  # zip-slip: 압축 엔트리명을 검증 없이 디스크 쓰기 경로로 사용 (CWE-22).
+  # 소스는 zip 라이브러리 고유 속성(adm-zip entryName, yauzl fileName)으로 한정해
+  # 흔한 이름(.path 등)으로 인한 오탐을 피한다. 엔트리명 대신 자체 생성 파일명을
+  # 쓰는 코드(안전한 구현)는 잡히지 않는다.
+  - id: finguard.ts.zip-slip
+    languages: [ts, js]
+    severity: ERROR
+    message: 압축 엔트리명이 검증 없이 파일 쓰기 경로로 사용되고 있습니다(zip-slip). 엔트리명은 아카이브 제작자가 정하므로 상위 경로(..)로 기준 디렉터리를 벗어날 수 있습니다. path.basename 으로 파일명만 취하거나, 정규화 후 기준 디렉터리 하위인지 확인해야 합니다.
+    metadata:
+      cwe: "CWE-22"
+      category: security
+    mode: taint
+    pattern-sources:
+      - pattern-either:
+          - pattern: $E.entryName
+          - pattern: $E.fileName
+          - pattern: $E.getEntries()
+    pattern-sanitizers:
+      - pattern: path.basename(...)
+      - pattern: basename(...)
+    pattern-sinks:
+      - patterns:
+          - pattern-either:
+              - pattern: $FS.writeFile($P, ...)
+              - pattern: $FS.writeFileSync($P, ...)
+              - pattern: $FS.createWriteStream($P, ...)
+              - pattern: $FS.mkdirSync($P, ...)
+              - pattern: $FS.mkdir($P, ...)
+              - pattern: writeFile($P, ...)
+              - pattern: writeFileSync($P, ...)
+              - pattern: createWriteStream($P, ...)
+              - pattern: mkdirSync($P, ...)
+          - focus-metavariable: $P


### PR DESCRIPTION
Closes #5

## 배경
`chrisryugj/kordoc`(HWPX=ZIP+XML 한국 문서포맷 라이브러리)을 codegraph 로 구조 분석하다 발견한 갭 — finguard 에 **zip 관련 룰이 전 언어 0건**이었다. 은행권은 ZIP·HWPX·OOXML 첨부 업로드 처리가 일상이라 zip-slip(CWE-22)은 실무 빈도가 높다.

## 추가 룰
- `finguard.java.zip-slip` (FIN-PATH-004)
- `finguard.ts.zip-slip` (FIN-PATH-005)
- 금보원 매핑: 웹·모바일·HTS **20 (악성파일 업로드)**

## 오탐 억제 설계 (중요)
초안에서 안전한 구현까지 잡는 오탐이 나와 두 가지를 고쳤다.
1. **sink 을 실제 파일 I/O 로 한정** — `new File()`/`Paths.get()` 은 경로 객체 생성일 뿐이라 sink 에서 제외. 두면 canonical 검증 코드가 그대로 걸린다.
2. **sanitizer 보강** — `getCanonicalFile()`, `toPath().normalize()` 추가.
3. TS 는 zip 라이브러리 고유 속성(`entryName`/`fileName`)만 소스로 — `.path` 같은 흔한 이름은 제외.

## 검증
| 대상 | 결과 |
|---|---|
| 합성 픽스처(취약/안전 쌍) | 취약만 검출, 안전(canonical 검증·basename) 미검출 |
| kordoc (265 TS, 안전 구현) | zip-slip 0건 |
| secure_study / LoaninfoProgram / egovframe | zip-slip 0건, 기존 검출 건수 변화 없음 |

`semgrep --validate`(85룰)·`go test ./...` 통과.

Made with [Orca](https://github.com/stablyai/orca) 🐋
