### PR TITLE
fix(#9): SQL 조립 휴리스틱 정규식이 영어 UI 문구를 오인하던 오탐 수정

### DIFF
--- a/rules/go.yaml
+++ b/rules/go.yaml
@@ -57,7 +57,7 @@ rules:
       - pattern: fmt.Sprintf($FMT, ...)
       - metavariable-regex:
           metavariable: $FMT
-          regex: '(?is)^"\s*(select|insert|update|delete|merge)\b.*%[sv]'
+          regex: '(?is)^"\s*(select\b.*\bfrom\b|insert\s+into\b|update\b.*\bset\b|delete\s+from\b|merge\s+into\b).*%[sv]'
 
   - id: finguard.go.hardcoded-secret
     languages: [regex]

--- a/rules/java.yaml
+++ b/rules/java.yaml
@@ -46,7 +46,7 @@ rules:
                   - pattern: $S.addBatch(String.format($FMT, ...))
               - metavariable-regex:
                   metavariable: $FMT
-                  regex: (?i).*(select|insert|update|delete|from|where)\s
+                  regex: (?is)^"?\s*(select\b.*\bfrom\b|insert\s+into\b|update\b.*\bset\b|delete\s+from\b|merge\s+into\b)
           # (2) 지역변수에 String.format 대입 후 execute
           - patterns:
               - pattern-either:
@@ -64,7 +64,7 @@ rules:
                       $S.execute($SQL);
               - metavariable-regex:
                   metavariable: $FMT
-                  regex: (?i).*(select|insert|update|delete|from|where)\s
+                  regex: (?is)^"?\s*(select\b.*\bfrom\b|insert\s+into\b|update\b.*\bset\b|delete\s+from\b|merge\s+into\b)
           # (3) execute 인자에 문자열 연결 직접 (SQL 리터럴 + 변수)
           - patterns:
               - pattern-either:
@@ -74,7 +74,7 @@ rules:
                   - pattern: $S.addBatch($LIT + $X)
               - metavariable-regex:
                   metavariable: $LIT
-                  regex: (?i)"\s*(select|insert|update|delete).*
+                  regex: (?is)^"\s*(select\b.*\bfrom\b|insert\s+into\b|update\b.*\bset\b|delete\s+from\b|merge\s+into\b)
           # (4) 지역변수에 문자열 연결 대입 후 execute
           - patterns:
               - pattern-either:
@@ -92,7 +92,7 @@ rules:
                       $S.execute($SQL);
               - metavariable-regex:
                   metavariable: $LIT
-                  regex: (?i)"\s*(select|insert|update|delete).*
+                  regex: (?is)^"\s*(select\b.*\bfrom\b|insert\s+into\b|update\b.*\bset\b|delete\s+from\b|merge\s+into\b)
 
   - id: finguard.java.hardcoded-secret
     languages: [regex]


### PR DESCRIPTION
키워드 단독 매치(select|insert|update|delete)를 SQL 구문 형태 요구로 교체. SELECT..FROM / INSERT INTO / UPDATE..SET / DELETE FROM / MERGE INTO 만 매치한다.

원인: SQL 키워드가 영어 일상어와 겹쳐, 문장 첫 단어가 Update/Select 인
사용자 안내 문구가 SQL 조립으로 오인됐다.
  fmt.Sprintf("Update tossctl %s -> %s?", ...)  ← SQL 아님

적용: go.sql-sprintf-heuristic 1곳, java.sql-string-build 4곳(동일 계열).

검증:
- 합성 픽스처: UI 문구 5종 미검출, 진짜 SQL 6종 전부 검출
- tossinvest-cli(Go 281파일) 오탐 2건 → 0건
- secure_study 의 진짜 SQLi 2건 유지, kordoc/LoaninfoProgram/egovframe 변동 없음