### PR TITLE
fix: 실코드 검증 오탐 3종 + 시크릿 룰 미탐 1종 수정

### DIFF
--- a/internal/scanner/exclude.go
+++ b/internal/scanner/exclude.go
@@ -1,0 +1,57 @@
+package scanner
+
+// DefaultExcludes 는 점검 대상에서 기본 제외하는 경로 패턴이다.
+//
+// 여기 실린 것은 "그 레포가 작성·소유한 운영 코드가 아닌 것"만이다 —
+// 빌드 산출물, 내려받은 의존성, 벤더링된 서드파티, 도구가 생성한 파일.
+// 이런 경로를 점검하면 개발자가 고칠 수 없는 코드에 코멘트가 달리고,
+// 실제 지적이 노이즈에 묻힌다.
+//
+// 판단이 갈리는 경로(example/·docs/·테스트 코드 등)는 여기 넣지 않는다.
+// 레포 사정에 따라 운영 코드일 수도 있으므로 `.finguard.yml` 의 ignore 로
+// 각 레포가 정한다.
+var DefaultExcludes = []string{
+	// 의존성 — 내려받은 코드
+	"node_modules",
+	"vendor",
+	"vendors",
+	"third_party",
+	"thirdparty",
+	"bower_components",
+	"Pods",
+	".venv",
+	"site-packages",
+
+	// 빌드 산출물
+	"dist",
+	"build",
+	"built",
+	"out",
+	"target",
+	".next",
+	".nuxt",
+	".output",
+	".gradle",
+	"DerivedData",
+
+	// 번들·압축 결과 — 원본이 따로 있다
+	"*.min.js",
+	"*.min.css",
+	"*.bundle.js",
+	"*.map",
+
+	// 도구 생성 파일 — 손으로 고치는 대상이 아니다
+	"*.pb.go",
+	"*_pb2.py",
+	"*.g.dart",
+	"*_generated.go",
+	"*.generated.ts",
+	"*.d.ts",
+
+	// VCS·캐시
+	".git",
+	".svn",
+	".mypy_cache",
+	".pytest_cache",
+	"__pycache__",
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -23,9 +23,16 @@ func (c CLI) Scan(ctx context.Context, rulesPath, targetDir string) ([]Finding, 
 	if bin == "" {
 		bin = "semgrep"
 	}
-	cmd := exec.CommandContext(ctx, bin, "scan",
+	args := []string{"scan",
 		"--sarif", "--quiet", "--metrics=off", "--disable-version-check",
-		"--config", rulesPath, targetDir)
+		"--config", rulesPath}
+	// 운영 코드가 아닌 경로(의존성·빌드 산출물·생성 파일)는 점검하지 않는다.
+	// 개발자가 고칠 수 없는 코드에 코멘트가 달리면 실제 지적이 묻힌다.
+	for _, ex := range DefaultExcludes {
+		args = append(args, "--exclude", ex)
+	}
+	args = append(args, targetDir)
+	cmd := exec.CommandContext(ctx, bin, args...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/rules/android-manifest.yaml
+++ b/rules/android-manifest.yaml
@@ -6,6 +6,15 @@ rules:
     message: AndroidManifest 에 android:debuggable="true" 가 설정되어 있습니다. 릴리스 빌드에서 반드시 제거해야 합니다.
     paths:
       include: ["AndroidManifest.xml"]
+      # 릴리스 APK 에 포함되지 않는 변형 소스셋은 제외한다.
+      # debug/androidTest/test 매니페스트는 개발·계측테스트용으로 의도적으로
+      # 느슨하게 설정하며(예: Metro 개발서버용 cleartext, androidx.test 의
+      # exported 컴포넌트), 이를 지적하면 고칠 수 없는 오탐이 된다.
+      exclude:
+        - "*/src/debug/*"
+        - "*/src/androidTest/*"
+        - "*/src/test/*"
+        - "*/src/*Debug/*"
     pattern-regex: 'android:debuggable\s*=\s*"true"'
 
   # 14. 백업 허용 (CWE-530)
@@ -15,6 +24,15 @@ rules:
     message: android:allowBackup="true" 로 앱 데이터가 adb backup 으로 유출될 수 있습니다. 민감 데이터를 다루면 false 로 설정해야 합니다.
     paths:
       include: ["AndroidManifest.xml"]
+      # 릴리스 APK 에 포함되지 않는 변형 소스셋은 제외한다.
+      # debug/androidTest/test 매니페스트는 개발·계측테스트용으로 의도적으로
+      # 느슨하게 설정하며(예: Metro 개발서버용 cleartext, androidx.test 의
+      # exported 컴포넌트), 이를 지적하면 고칠 수 없는 오탐이 된다.
+      exclude:
+        - "*/src/debug/*"
+        - "*/src/androidTest/*"
+        - "*/src/test/*"
+        - "*/src/*Debug/*"
     pattern-regex: 'android:allowBackup\s*=\s*"true"'
 
   # 15. 평문 트래픽 허용 (CWE-319)
@@ -24,6 +42,15 @@ rules:
     message: android:usesCleartextTraffic="true" 로 평문 HTTP 통신이 허용됩니다. false 로 설정하거나 networkSecurityConfig 로 통제해야 합니다.
     paths:
       include: ["AndroidManifest.xml"]
+      # 릴리스 APK 에 포함되지 않는 변형 소스셋은 제외한다.
+      # debug/androidTest/test 매니페스트는 개발·계측테스트용으로 의도적으로
+      # 느슨하게 설정하며(예: Metro 개발서버용 cleartext, androidx.test 의
+      # exported 컴포넌트), 이를 지적하면 고칠 수 없는 오탐이 된다.
+      exclude:
+        - "*/src/debug/*"
+        - "*/src/androidTest/*"
+        - "*/src/test/*"
+        - "*/src/*Debug/*"
     pattern-regex: 'android:usesCleartextTraffic\s*=\s*"true"'
 
   # 16. exported 컴포넌트 (CWE-926)
@@ -35,4 +62,13 @@ rules:
     message: android:exported="true" 컴포넌트가 있습니다. 외부 앱에 노출되므로 android:permission 보호 또는 exported=false 가 필요한지 확인해야 합니다.
     paths:
       include: ["AndroidManifest.xml"]
+      # 릴리스 APK 에 포함되지 않는 변형 소스셋은 제외한다.
+      # debug/androidTest/test 매니페스트는 개발·계측테스트용으로 의도적으로
+      # 느슨하게 설정하며(예: Metro 개발서버용 cleartext, androidx.test 의
+      # exported 컴포넌트), 이를 지적하면 고칠 수 없는 오탐이 된다.
+      exclude:
+        - "*/src/debug/*"
+        - "*/src/androidTest/*"
+        - "*/src/test/*"
+        - "*/src/*Debug/*"
     pattern-regex: 'android:exported\s*=\s*"true"'

--- a/rules/config.yaml
+++ b/rules/config.yaml
@@ -5,4 +5,7 @@ rules:
     message: 설정파일에 시크릿이 평문으로 들어 있습니다. 환경변수 치환(${VAR}) 또는 시크릿 저장소를 사용해야 합니다.
     paths:
       include: ["application*.yml", "application*.yaml", "*.properties"]
-    pattern-regex: '(?i)^\s*[\w.-]*(password|passwd|secret|token|api[_-]?key)[\w.-]*\s*[:=]\s*(?!\s*$)(?!\$\{)(?!ENC\()["'']?[^\s"''#][^#\n]{3,}'
+    patterns:
+      - pattern-regex: '(?i)^\s*[\w.-]*(password|passwd|secret|token|api[_-]?key)[\w.-]*\s*[:=]\s*(?!\s*$)(?!\$\{)(?!ENC\()["'']?[^\s"''#][^#\n]{3,}'
+      # 마스킹 플레이스홀더는 시크릿이 아니다 — 오히려 가리는 코드다
+      - pattern-not-regex: '(?i)["''`](\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|<[^>]*redact[^>]*>|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]|[:=]\s*(\*{3,}|•{3,}|#{3,})(?![\w-])'

--- a/rules/go.yaml
+++ b/rules/go.yaml
@@ -66,7 +66,10 @@ rules:
     paths:
       include: ["*.go"]
       exclude: ["*_test.go"]
-    pattern-regex: '(?i)\b\w*(password|passwd|secret|apikey|api_key|appsecret)\w*\s*(:?=)\s*"(?![A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+")(?![a-z]+(?:_[a-z]+)+")[^"%/][^"]{7,}"'
+    patterns:
+      - pattern-regex: '(?i)\b\w*(password|passwd|secret|apikey|api_key|appsecret)\w*\s*(:?=)\s*"(?!(?-i:[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)")(?!(?-i:[a-z]+(?:_[a-z]+)+)")[^"%/][^"]{7,}"'
+      # 마스킹 플레이스홀더는 시크릿이 아니다 — 오히려 가리는 코드다
+      - pattern-not-regex: '(?i)["''`](\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|<[^>]*redact[^>]*>|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]|[:=]\s*(\*{3,}|•{3,}|#{3,})(?![\w-])'
 
   - id: finguard.go.weak-crypto
     languages: [regex]

--- a/rules/java.yaml
+++ b/rules/java.yaml
@@ -101,7 +101,10 @@ rules:
     paths:
       include: ["*.java"]
       exclude: ["*Test.java"]
-    pattern-regex: '(?i)String\s+\w*(password|passwd|secret|apikey|api_key|appsecret)\w*\s*=\s*"(?![A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+")(?![a-z]+(?:_[a-z]+)+")[^"]{4,}"'
+    patterns:
+      - pattern-regex: '(?i)String\s+\w*(password|passwd|secret|apikey|api_key|appsecret)\w*\s*=\s*"(?!(?-i:[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)")(?!(?-i:[a-z]+(?:_[a-z]+)+)")[^"]{4,}"'
+      # 마스킹 플레이스홀더는 시크릿이 아니다 — 오히려 가리는 코드다
+      - pattern-not-regex: '(?i)["''`](\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|<[^>]*redact[^>]*>|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]|[:=]\s*(\*{3,}|•{3,}|#{3,})(?![\w-])'
 
   - id: finguard.java.weak-hash
     languages: [regex]

--- a/rules/kotlin.yaml
+++ b/rules/kotlin.yaml
@@ -10,7 +10,10 @@ rules:
     paths:
       include: ["*.kt", "*.kts"]
       exclude: ["*Test.kt", "*Test.kts"]
-    pattern-regex: '(?im)^\s*(?:private\s+|internal\s+|public\s+|protected\s+)?(?:const\s+)?(?:val|var)\s+\w*(?:password|passwd|secret|apikey|api_key|appsecret|privatekey)\w*\s*(?::\s*[\w<>?.]+)?\s*=\s*"(?![A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+")(?![a-z]+(?:_[a-z]+)+")[^"]{8,}"'
+    patterns:
+      - pattern-regex: '(?im)^\s*(?:private\s+|internal\s+|public\s+|protected\s+)?(?:const\s+)?(?:val|var)\s+\w*(?:password|passwd|secret|apikey|api_key|appsecret|privatekey)\w*\s*(?::\s*[\w<>?.]+)?\s*=\s*"(?!(?-i:[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)")(?!(?-i:[a-z]+(?:_[a-z]+)+)")[^"]{8,}"'
+      # 마스킹 플레이스홀더는 시크릿이 아니다 — 오히려 가리는 코드다
+      - pattern-not-regex: '(?i)["''`](\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|<[^>]*redact[^>]*>|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]|[:=]\s*(\*{3,}|•{3,}|#{3,})(?![\w-])'
 
   # 2. 취약 해시 (CWE-328)
   - id: finguard.kotlin.weak-hash

--- a/rules/python.yaml
+++ b/rules/python.yaml
@@ -6,7 +6,10 @@ rules:
     paths:
       include: ["*.py"]
       exclude: ["test_*.py", "*_test.py", "conftest.py"]
-    pattern-regex: '(?i)\b\w*(password|passwd|secret|apikey|api_key|appsecret)\w*\s*=\s*(?:"(?![A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+")(?![a-z]+(?:_[a-z]+)+")[^"%/{][^"]{7,}"|''(?![A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+'')(?![a-z]+(?:_[a-z]+)+'')[^''%/{][^'']{7,}'')'
+    patterns:
+      - pattern-regex: '(?i)\b\w*(password|passwd|secret|apikey|api_key|appsecret)\w*\s*=\s*(?:"(?!(?-i:[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)")(?!(?-i:[a-z]+(?:_[a-z]+)+)")[^"%/{][^"]{7,}"|''(?![A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+'')(?![a-z]+(?:_[a-z]+)+'')[^''%/{][^'']{7,}'')'
+      # 마스킹 플레이스홀더는 시크릿이 아니다 — 오히려 가리는 코드다
+      - pattern-not-regex: '(?i)["''`](\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|<[^>]*redact[^>]*>|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]|[:=]\s*(\*{3,}|•{3,}|#{3,})(?![\w-])'
 
   - id: finguard.python.weak-hash
     languages: [python]

--- a/rules/shell.yaml
+++ b/rules/shell.yaml
@@ -5,7 +5,10 @@ rules:
     message: 셸 스크립트에 비밀정보(비밀번호·API 키·토큰)가 하드코드되어 있습니다. 환경변수 주입 또는 시크릿 저장소를 사용해야 합니다.
     paths:
       include: ["*.sh", "*.bash", "*.zsh"]
-    pattern-regex: '(?im)^\s*(?:export\s+)?\w*(password|passwd|secret|apikey|api_key|token)\w*=["'']?(?!\$)(?![A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+["'']?\s*$)(?![a-z]+(?:_[a-z]+)+["'']?\s*$)[^"''\s#$][^"''\s#]{7,}'
+    patterns:
+      - pattern-regex: '(?im)^\s*(?:export\s+)?\w*(password|passwd|secret|apikey|api_key|token)\w*=["'']?(?!\$)(?![A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+["'']?\s*$)(?![a-z]+(?:_[a-z]+)+["'']?\s*$)[^"''\s#$][^"''\s#]{7,}'
+      # 마스킹 플레이스홀더는 시크릿이 아니다 — 오히려 가리는 코드다
+      - pattern-not-regex: '(?i)["''`](\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|<[^>]*redact[^>]*>|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]|[:=]\s*(\*{3,}|•{3,}|#{3,})(?![\w-])'
 
   - id: finguard.shell.curl-insecure
     languages: [regex]

--- a/rules/swift.yaml
+++ b/rules/swift.yaml
@@ -5,7 +5,10 @@ rules:
     message: 소스코드에 비밀정보(비밀번호·API 키·토큰)가 하드코드되어 있습니다.
     paths:
       include: ["*.swift"]
-    pattern-regex: '(?i)(let|var)\s+\w*(password|passwd|secret|api_?key|token|credential)\w*\s*=\s*"(?![A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+")(?![a-z]+(?:_[a-z]+)+")[^"]{4,}"'
+    patterns:
+      - pattern-regex: '(?i)(let|var)\s+\w*(password|passwd|secret|api_?key|token|credential)\w*\s*=\s*"(?!(?-i:[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)")(?!(?-i:[a-z]+(?:_[a-z]+)+)")[^"]{4,}"'
+      # 마스킹 플레이스홀더는 시크릿이 아니다 — 오히려 가리는 코드다
+      - pattern-not-regex: '(?i)["''`](\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|<[^>]*redact[^>]*>|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]|[:=]\s*(\*{3,}|•{3,}|#{3,})(?![\w-])'
 
   - id: finguard.swift.http-url
     languages: [regex]

--- a/rules/typescript.yaml
+++ b/rules/typescript.yaml
@@ -21,7 +21,10 @@ rules:
     message: 소스코드에 비밀정보(비밀번호·API 키·토큰)가 하드코드되어 있습니다.
     paths:
       include: ["*.ts", "*.tsx", "*.js", "*.jsx"]
-    pattern-regex: '(?i)\b(const|let|var)\s+\w*(password|passwd|secret|apikey|api_key)\w*\s*=\s*["''](?![A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+")(?![a-z]+(?:_[a-z]+)+")\S{8,}["'']'
+    patterns:
+      - pattern-regex: '(?i)\b(const|let|var)\s+\w*(password|passwd|secret|apikey|api_key)\w*\s*=\s*["''](?!(?-i:[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)")(?!(?-i:[a-z]+(?:_[a-z]+)+)")\S{8,}["'']'
+      # 마스킹 플레이스홀더는 시크릿이 아니다 — 오히려 가리는 코드다
+      - pattern-not-regex: '(?i)["''`](\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|<[^>]*redact[^>]*>|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]|[:=]\s*(\*{3,}|•{3,}|#{3,})(?![\w-])'
 
   - id: finguard.ts.http-url
     languages: [regex]


### PR DESCRIPTION
Closes #11

`github.com/toss` 조직 공개 라이브러리 11개(TS 약 4,000파일 + Go 51파일)로 검증한 결과 **25건 중 실질 유효 지적이 사실상 0~1건**이었다. 원인별로 수정했다.

## 1. 경로 스코프 부재 → scanner 기본 제외 도입
의존성(`node_modules`/`vendor`/`Pods`)·빌드 산출물(`dist`/`build`/`target`/`.next`)·minified·생성 파일을 `semgrep --exclude` 로 넘긴다.

**"그 레포가 소유한 운영 코드가 아닌 것"만** 넣었다. 판단이 갈리는 `example/`·`docs/`·테스트 코드는 레포 사정에 따라 운영 코드일 수 있어 `.finguard.yml` ignore 에 맡긴다.

## 2. Android 비운영 소스셋 (6건)
`src/debug`·`src/androidTest`·`src/test` 는 릴리스 APK 에 포함되지 않고 의도적으로 느슨하다 — Metro 개발서버용 cleartext, androidx.test 가 요구하는 `exported` 컴포넌트. 매니페스트 룰 4개에 exclude 추가.

## 3. 마스킹 플레이스홀더를 시크릿으로 오인 (1건)
```go
adapter.APIKey = "********"   // redact 함수 — 시크릿을 가리는 코드다
```
시크릿 룰 8개에 `pattern-not-regex` 추가. **semgrep 의 not-regex 는 `^`/`$` 앵커가 동작하지 않아** 따옴표로 값을 구획하는 방식으로 작성했다(실험으로 확인).

## 4. (미탐) `(?i)` 가 대소문자 기반 제외를 무력화
```
(?![A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+")   # SCREAMING_SNAKE 상수명 제외 의도
```
`(?i)` 아래서 `[A-Z]` 가 소문자도 매치해 **`sk_live_...` 같은 실제 키까지 놓치고 있었다**. `(?-i:)` 로 해당 구간만 대소문자 구분 복원 (6개 파일 12곳).

## 검증
| 대상 | 이전 | 이후 |
|---|---|---|
| 픽스처 — 마스킹·플레이스홀더·상수명 5종 | 오탐 | **0건** |
| 픽스처 — 진짜 시크릿 2종 | 1건만 검출 | **2건 검출** (sk_live_ 신규) |
| toss 11개 레포 | 25건 | **16건** |
| egovframe | 638건 | **284건** |
| kordoc / secure_study / LoaninfoProgram / tossinvest-cli | 1 / 4 / 1 / 0 | 변동 없음 |

egovframe 감소분 347건은 **전부 Maven `target/` 빌드 산출물**이며(`src/main/resources` 원본이 `target/classes` 로 복사되어 이중 계상되던 것), `src/` 원본 검출이 유지됨을 경로 대조로 확인했다 — 미탐 아님.

`semgrep --validate`(85룰)·`go test ./...` 통과.

Made with [Orca](https://github.com/stablyai/orca) 🐋
