### PR TITLE
test: semgrep 인자 조립 테스트 추가 + CodeGraph 인덱스 도입

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,10 +46,24 @@
 
 ```bash
 go build -mod=vendor ./...     # 빌드
-go test -mod=vendor ./...      # 테스트
+go test -race -mod=vendor ./... # 테스트 (레이스 감지 포함)
 make build-linux               # 폐쇄망 반입용 정적 바이너리
 semgrep --validate --config rules/   # 룰 문법 검증
 ```
+
+## 코드 탐색 — CodeGraph
+
+이 레포는 CodeGraph 로 인덱싱돼 있다(`.codegraph/`, 전역 gitignore 로 커밋 제외).
+코드 위치를 찾거나 흐름을 파악할 때 grep/find 보다 먼저 쓴다.
+
+```bash
+codegraph explore "<질문 또는 심볼명>"   # 관련 심볼 소스 + 호출 경로 한 번에
+codegraph sync .                        # 코드 변경 후 인덱스 갱신
+```
+
+Semgrep·reviewdog 은 인터페이스로 추상화돼 있어 호출 흐름이 grep 으로 안 잡힌다
+(`scanner.Semgrep` → `CLI`, `runner.Reviewdog` → `CLI`). CodeGraph 는 이 동적 디스패치
+연결과 "테스트가 덮지 않는 심볼"까지 같이 알려준다.
 
 ## 아키텍처
 

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -18,21 +18,26 @@ type CLI struct {
 	Bin string // 비면 "semgrep"
 }
 
-func (c CLI) Scan(ctx context.Context, rulesPath, targetDir string) ([]Finding, error) {
-	bin := c.Bin
-	if bin == "" {
-		bin = "semgrep"
-	}
+// scanArgs 는 semgrep 실행 인자를 조립한다. 외부 프로세스 없이 검증할 수 있도록
+// 순수 함수로 분리했다 — 제외 경로가 조용히 누락되면 노이즈가 그대로 돌아온다.
+func scanArgs(rulesPath, targetDir string, excludes []string) []string {
 	args := []string{"scan",
 		"--sarif", "--quiet", "--metrics=off", "--disable-version-check",
 		"--config", rulesPath}
 	// 운영 코드가 아닌 경로(의존성·빌드 산출물·생성 파일)는 점검하지 않는다.
 	// 개발자가 고칠 수 없는 코드에 코멘트가 달리면 실제 지적이 묻힌다.
-	for _, ex := range DefaultExcludes {
+	for _, ex := range excludes {
 		args = append(args, "--exclude", ex)
 	}
-	args = append(args, targetDir)
-	cmd := exec.CommandContext(ctx, bin, args...)
+	return append(args, targetDir)
+}
+
+func (c CLI) Scan(ctx context.Context, rulesPath, targetDir string) ([]Finding, error) {
+	bin := c.Bin
+	if bin == "" {
+		bin = "semgrep"
+	}
+	cmd := exec.CommandContext(ctx, bin, scanArgs(rulesPath, targetDir, DefaultExcludes)...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -1,0 +1,81 @@
+package scanner
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestScanArgs(t *testing.T) {
+	args := scanArgs("/rules", "/target", []string{"node_modules", "*.min.js"})
+	joined := strings.Join(args, " ")
+
+	for _, want := range []string{
+		"scan", "--sarif", "--quiet", "--metrics=off", "--disable-version-check",
+	} {
+		if !contains(args, want) {
+			t.Errorf("필수 인자 누락: %s (전체: %s)", want, joined)
+		}
+	}
+
+	// --config 는 룰 경로를 값으로 받아야 한다
+	if i := indexOf(args, "--config"); i < 0 || i+1 >= len(args) || args[i+1] != "/rules" {
+		t.Errorf("--config 뒤에 룰 경로가 오지 않았다: %s", joined)
+	}
+
+	// 대상 디렉터리는 마지막 인자 — 그래야 semgrep 이 플래그가 아닌 대상으로 읽는다
+	if args[len(args)-1] != "/target" {
+		t.Errorf("대상 디렉터리가 마지막 인자가 아니다: %s", joined)
+	}
+}
+
+func TestScanArgsPassesEveryExclude(t *testing.T) {
+	excludes := []string{"node_modules", "target", "*.min.js"}
+	args := scanArgs("/r", "/t", excludes)
+
+	for _, ex := range excludes {
+		found := false
+		for i := 0; i+1 < len(args); i++ {
+			if args[i] == "--exclude" && args[i+1] == ex {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("제외 경로가 --exclude 로 전달되지 않았다: %s", ex)
+		}
+	}
+
+	if got, want := countOf(args, "--exclude"), len(excludes); got != want {
+		t.Errorf("--exclude 개수 불일치: got %d, want %d", got, want)
+	}
+}
+
+// 기본 제외 목록이 비면 노이즈가 그대로 돌아오므로, 대표 항목이 남아 있는지 지킨다.
+func TestDefaultExcludesCoversBuildOutputAndDeps(t *testing.T) {
+	for _, want := range []string{"node_modules", "vendor", "dist", "build", "target"} {
+		if !contains(DefaultExcludes, want) {
+			t.Errorf("기본 제외 목록에 %q 가 없다", want)
+		}
+	}
+}
+
+func contains(ss []string, s string) bool { return indexOf(ss, s) >= 0 }
+
+func indexOf(ss []string, s string) int {
+	for i, v := range ss {
+		if v == s {
+			return i
+		}
+	}
+	return -1
+}
+
+func countOf(ss []string, s string) int {
+	n := 0
+	for _, v := range ss {
+		if v == s {
+			n++
+		}
+	}
+	return n
+}


### PR DESCRIPTION
Closes #13

## 배경
레포에 CodeGraph 인덱스를 붙이고 `scan 파이프라인` 을 조회하니 `CLI.Scan`(internal/scanner/scanner.go) 이 **테스트 미커버**로 표시됐다. #11 에서 추가한 기본 제외 경로(`--exclude`) 배선이 여기 있는데, 조용히 누락돼도 알 수 없는 상태였다.

## 변경
- 인자 조립을 `scanArgs` **순수 함수**로 분리 — 외부 프로세스 없이 검증 가능
- 테스트 3종: 필수 플래그·`--config` 값·대상 디렉터리 위치 / 모든 `DefaultExcludes` 가 `--exclude` 로 전달되는지 / 기본 목록에 핵심 항목(node_modules·vendor·dist·build·target) 유지
- `AGENTS.md` 에 CodeGraph 사용 안내 추가. Semgrep·reviewdog 이 인터페이스로 추상화돼 호출 흐름이 grep 으로 안 잡히는 레포라(`scanner.Semgrep`→`CLI`, `runner.Reviewdog`→`CLI`) 특히 유효하다
- `AGENTS.md` 테스트 명령을 프로젝트 Go 규칙에 맞춰 `-race` 포함으로 정정

`.codegraph/` 는 전역 gitignore 로 커밋되지 않는 로컬 인덱스다.

`go test -race ./...` 전체 통과.

Made with [Orca](https://github.com/stablyai/orca) 🐋
