### PR TITLE
fix: RSA-OAEP·LAUNCHER 액티비티 오탐 수정

### DIFF
--- a/rules/android-manifest.yaml
+++ b/rules/android-manifest.yaml
@@ -71,4 +71,7 @@ rules:
         - "*/src/androidTest/*"
         - "*/src/test/*"
         - "*/src/*Debug/*"
-    pattern-regex: 'android:exported\s*=\s*"true"'
+    # 런처 액티비티는 반드시 exported 여야 하므로 제외한다(모든 앱에 하나씩 있다).
+    # 같은 <activity> 블록을 벗어나지 않도록 </activity> 를 만나면 탐색을 끊는다.
+    # 딥링크 핸들러는 실제 공격면이므로 계속 지적한다.
+    pattern-regex: 'android:exported\s*=\s*"true"(?!(?:(?!</activity>)[\s\S]){0,600}?android\.intent\.category\.LAUNCHER)'

--- a/rules/java.yaml
+++ b/rules/java.yaml
@@ -119,10 +119,13 @@ rules:
     languages: [regex]
     severity: ERROR
     message: 취약한 암호 알고리즘/운영모드(DES·RC4·ECB)를 사용하고 있습니다.
+    # RSA/ECB/... 는 제외한다 — RSA 는 블록암호가 아니라 운영모드 개념이 없고,
+    # 변환 문자열의 ECB 는 JCA 명명 규약상 자리를 채우는 토큰일 뿐이다.
+    # RSA/ECB/OAEPWith... 는 오히려 권장되는 안전한 형식이다.
     paths:
       include: ["*.java"]
       exclude: ["*Test.java"]
-    pattern-regex: 'Cipher\.getInstance\(\s*"(DES|DESede|RC4|ARCFOUR)[^"]*"|Cipher\.getInstance\(\s*"[^"]+/ECB/|Cipher\.getInstance\(\s*"(?!RSA")[A-Za-z][A-Za-z0-9]*"'
+    pattern-regex: 'Cipher\.getInstance\(\s*"(DES|DESede|RC4|ARCFOUR)[^"]*"|Cipher\.getInstance\(\s*"(?!RSA/)[^"]+/ECB/|Cipher\.getInstance\(\s*"(?!RSA")[A-Za-z][A-Za-z0-9]*"'
 
   - id: finguard.java.print-sensitive
     languages: [regex]


### PR DESCRIPTION
Closes #15

toss 조직의 **Swift·Kotlin·Java** 레포(toss-cert-java-sdk, toss-login-android-sdk, cache, toss-sdk-ios 등)까지 검증 범위를 넓혀 확인된 오탐 2종. 그동안 실코드 검증을 못 했던 언어 구간이다.

## 1. RSA-OAEP 를 취약 암호로 오인 — ERROR, 머지 차단
`toss-cert-java-sdk/.../RSACipher.java:31`
```java
Cipher.getInstance("RSA/ECB/OAEPWithSHA-1AndMGF1Padding");   // 올바른 사용
```
RSA 는 블록암호가 아니라 **운영모드 개념이 없다**. 변환 문자열의 `ECB` 는 JCA 명명 규약상 자리를 채우는 토큰이고, OAEP 는 권장 패딩이다. **인증서 SDK 가 제대로 짠 암호를 ERROR 로 막던 상황**이라 우선순위가 높았다.

ECB 대안에 `(?!RSA/)` 추가 — 룰의 세 번째 대안은 이미 `(?!RSA")` 로 RSA 를 고려하고 있었는데 ECB 쪽에만 빠져 있었다.

## 2. LAUNCHER 액티비티의 exported="true"
런처 액티비티는 **반드시 exported 여야 하고 모든 앱에 하나씩 있다** — 전부 지적하면 순수 노이즈다. 같은 `<activity>` 블록에 LAUNCHER 카테고리가 있으면 제외하되, `</activity>` 를 만나면 탐색을 끊어 블록을 벗어나지 않게 했다. **딥링크 핸들러(autoVerify)는 실제 공격면이라 계속 지적한다.**

## 검증
| 대상 | 이전 | 이후 |
|---|---|---|
| 픽스처 — RSA-OAEP·AES-GCM | 오탐 | **미검출** |
| 픽스처 — AES/ECB·DES·모드미지정 | 검출 | **검출 유지** |
| 픽스처 — 런처 액티비티 | 오탐 | **미검출** |
| 픽스처 — 딥링크·서비스 exported | 검출 | **검출 유지** |
| toss 신규 15개 | 13건 | **11건** |
| toss 기존 11개 | 16건 | **13건** |
| kordoc/secure_study/LoaninfoProgram/egovframe/tossinvest-cli | 1/4/1/284/0 | 변동 없음 |

사라진 항목이 전부 런처 액티비티·RSA-OAEP 임을 경로 대조로 확인했고 신규 발생은 0건이다.

`semgrep --validate`(85룰)·`go test -race ./...` 통과.

Made with [Orca](https://github.com/stablyai/orca) 🐋
