### PR TITLE
test: template() variable 코드 주입 회귀 픽스처 + 통합 테스트

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ BINARY  := finguard
 PKG     := ./cmd/finguard
 LDFLAGS := -s -w
 
-.PHONY: build build-linux test clean
+.PHONY: build build-linux test test-integration clean
 
 # 호스트(개발 머신)용 빌드
 build:
@@ -14,7 +14,12 @@ build-linux:
 		go build -trimpath -ldflags '$(LDFLAGS)' -o bin/$(BINARY)-linux-amd64 $(PKG)
 
 test:
-	go test ./...
+	go test -race ./...
+
+# 실제 semgrep 을 돌려 룰이 취약 패턴을 검출하는지 확인하는 통합 테스트.
+# semgrep 바이너리가 필요하다(없으면 각 테스트가 skip).
+test-integration:
+	go test -race -tags semgrep_integration ./...
 
 clean:
 	rm -rf bin/

--- a/internal/scanner/integration_test.go
+++ b/internal/scanner/integration_test.go
@@ -1,0 +1,61 @@
+//go:build semgrep_integration
+
+// 실제 semgrep 바이너리를 돌려 룰이 취약 패턴을 검출하는지 확인하는 통합 테스트.
+// 폐쇄망·CI 에는 semgrep 이 없을 수 있어 기본 go test 에서 제외한다.
+//   실행: go test -tags semgrep_integration ./internal/scanner/
+// semgrep 이 PATH 에 없으면 실패가 아니라 skip 한다.
+package scanner
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func rulesDir(t *testing.T) string {
+	t.Helper()
+	// internal/scanner/ → 저장소 루트의 rules/
+	p, err := filepath.Abs("../../rules")
+	if err != nil {
+		t.Fatalf("rules 경로 확인 실패: %v", err)
+	}
+	return p
+}
+
+func requireSemgrep(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("semgrep"); err != nil {
+		t.Skip("semgrep 바이너리가 없어 통합 테스트를 건너뛴다")
+	}
+}
+
+// 회귀: es-toolkit 에서 제보한 template() variable 코드 주입 패턴을
+// FIN-INJ-001(finguard.ts.eval)이 반드시 검출해야 한다.
+func TestDetectsTemplateVariableInjection(t *testing.T) {
+	requireSemgrep(t)
+	dir, _ := filepath.Abs("../../rules/testdata/vuln-samples")
+
+	findings, err := CLI{}.Scan(context.Background(), rulesDir(t), dir)
+	if err != nil {
+		t.Fatalf("스캔 실패: %v", err)
+	}
+
+	var hitInjection bool
+	for _, f := range findings {
+		// semgrep 이 디렉터리 config 에서 "rules." 접두어를 붙이므로 suffix 로 본다
+		if strings.HasSuffix(f.RuleID, "finguard.ts.eval") &&
+			filepath.Base(f.Path) == "template_variable_injection.ts" {
+			hitInjection = true
+		}
+		// 대조 픽스처는 어떤 룰에도 걸리지 않아야 한다
+		if filepath.Base(f.Path) == "safe_template.ts" {
+			t.Errorf("안전한 대조 픽스처가 %s 로 오검출됐다 (line %d)", f.RuleID, f.StartLine)
+		}
+	}
+
+	if !hitInjection {
+		t.Error("template variable 코드 주입(FIN-INJ-001)이 검출되지 않았다 — 회귀")
+	}
+}

--- a/rules/testdata/vuln-samples/safe_template.ts
+++ b/rules/testdata/vuln-samples/safe_template.ts
@@ -1,0 +1,12 @@
+// 대조 픽스처 — 취약하지 않은 안전한 구현.
+// eval 도 new Function 도 쓰지 않으므로 FIN-INJ-001 이 검출하면 안 된다.
+
+interface TemplateOptions {
+  variable?: string;
+}
+
+export function safeTemplate(source: string, _options: TemplateOptions) {
+  // 정적 치환만 — 동적 코드 컴파일 없음
+  return (data: Record<string, string>) =>
+    source.replace(/\{\{(\w+)\}\}/g, (_m, key) => data[key] ?? '');
+}

--- a/rules/testdata/vuln-samples/template_variable_injection.ts
+++ b/rules/testdata/vuln-samples/template_variable_injection.ts
@@ -1,0 +1,31 @@
+// 회귀 픽스처 — FIN-INJ-001 (finguard.ts.eval).
+//
+// 실제 사례: toss/es-toolkit 의 lodash 호환 template() 에서 발견해 제보한
+// 코드 주입 취약점(lodash CVE-2021-23337 동종). variable 옵션이 검증 없이
+// 컴파일되는 함수 시그니처에 보간되어 new Function 으로 실행된다.
+//
+//   template('', { variable: 'a = globalThis.__PWNED__ = true' })()  // 임의 코드 실행
+//
+// finguard 의 ts.eval 룰이 이 new Function 호출을 반드시 검출해야 한다.
+// 룰을 손볼 때 이 케이스가 조용히 빠지지 않도록 골든 테스트로 고정한다.
+
+interface TemplateOptions {
+  variable?: string;
+  imports?: Record<string, unknown>;
+}
+
+export function vulnerableTemplate(source: string, options: TemplateOptions) {
+  const imports = { ...options.imports };
+  const importsKeys = Object.keys(imports);
+  const importValues = Object.values(imports);
+
+  // variable 이 검증 없이 함수 헤더에 삽입된다 (취약 지점)
+  const compiledFunction = `function(${options.variable || 'obj'}) {
+    let __p = '';
+    ${options.variable ? source : `with(obj) {\n${source}\n}`}
+    return __p;
+  }`;
+
+  // FIN-INJ-001 이 검출해야 하는 지점
+  return new Function(...importsKeys, `return ${compiledFunction}`)(...importValues);
+}


### PR DESCRIPTION
Closes #17

toss/es-toolkit 에서 발견해 opensource@toss.im 에 제보한 실제 취약점(`template()` 의 `variable` 옵션 코드 주입, lodash CVE-2021-23337 동종)을 `FIN-INJ-001`(finguard.ts.eval)이 정확히 짚었다. 이 케이스를 골든 테스트로 고정해 룰 수정 시 놓치는 것을 막는다.

## 변경
- `rules/testdata/vuln-samples/template_variable_injection.ts` — 취약 패턴(`new Function` 에 검증 없이 보간된 `variable`), 제보 맥락 주석 포함
- `rules/testdata/vuln-samples/safe_template.ts` — 대조용(동적 컴파일 없음)
- `internal/scanner/integration_test.go` — 실제 semgrep 을 돌려 취약 픽스처는 `finguard.ts.eval` 로 검출, 안전 픽스처는 무검출임을 어서트
- 빌드 태그 `semgrep_integration` 으로 기본 `go test` 에서 제외(폐쇄망·CI 에 semgrep 부재 가능), semgrep 없으면 skip
- `Makefile`: `test-integration` 타깃 추가, `test` 는 `-race`

## 검증
- `make test-integration` → PASS (취약 검출 O, 안전 무검출 O)
- 기본 `go test -race ./...` 는 통합 테스트를 제외하고 통과

Made with [Orca](https://github.com/stablyai/orca) 🐋
