### PR TITLE
fix(#19): curl-pipe-shell 룰이 안내용 문자열 리터럴을 오탐

### DIFF
--- a/internal/scanner/integration_test.go
+++ b/internal/scanner/integration_test.go
@@ -59,3 +59,45 @@ func TestDetectsTemplateVariableInjection(t *testing.T) {
 		t.Error("template variable 코드 주입(FIN-INJ-001)이 검출되지 않았다 — 회귀")
 	}
 }
+
+// 회귀(#19): curl|sh 룰이 실행되는 명령만 잡고, 안내용 문자열 리터럴은 잡지 않아야 한다.
+// 실코드 스캔에서 검출 7건 중 3건이 `info "설치 중: curl ... | sh"` 형태의 오탐이었다.
+func TestCurlPipeShellSkipsStringLiterals(t *testing.T) {
+	requireSemgrep(t)
+	dir, _ := filepath.Abs("../../rules/testdata/vuln-samples")
+
+	findings, err := CLI{}.Scan(context.Background(), rulesDir(t), dir)
+	if err != nil {
+		t.Fatalf("스캔 실패: %v", err)
+	}
+
+	// 정탐 픽스처의 실행 라인 — 하나라도 빠지면 recall 회귀다.
+	wantLines := map[int]bool{7: false, 10: false, 13: false, 16: false, 19: false, 22: false, 25: false}
+
+	for _, f := range findings {
+		base := filepath.Base(f.Path)
+		// 안내 문자열만 담은 픽스처는 어떤 룰에도 걸리면 안 된다.
+		if base == "safe_curl_pipe_shell_string.sh" {
+			t.Errorf("문자열 리터럴 픽스처가 %s 로 오검출됐다 (line %d)", f.RuleID, f.StartLine)
+			continue
+		}
+		if base != "curl_pipe_shell.sh" {
+			continue
+		}
+		if !strings.HasSuffix(f.RuleID, "finguard.shell.curl-pipe-shell") {
+			t.Errorf("정탐 픽스처가 예상 밖 룰 %s 로 검출됐다 (line %d)", f.RuleID, f.StartLine)
+			continue
+		}
+		if _, ok := wantLines[f.StartLine]; !ok {
+			t.Errorf("정탐 픽스처의 비대상 라인 %d 이 검출됐다", f.StartLine)
+			continue
+		}
+		wantLines[f.StartLine] = true
+	}
+
+	for line, hit := range wantLines {
+		if !hit {
+			t.Errorf("curl_pipe_shell.sh:%d 이 검출되지 않았다 — 회귀", line)
+		}
+	}
+}

--- a/rules/shell.yaml
+++ b/rules/shell.yaml
@@ -32,7 +32,16 @@ rules:
     message: 원격에서 내려받은 스크립트를 무결성 검증 없이 바로 셸로 실행합니다. 다운로드 후 체크섬 검증을 거쳐 실행해야 합니다.
     paths:
       include: ["*.sh", "*.bash", "*.zsh"]
-    pattern-regex: '(?m)^(?!\s*#)[^\n]*\b(?:curl|wget)\b[^|\n]*\|\s*(?:sudo\s+)?(?:bash|sh|zsh|dash)\b'
+    # 실행되는 명령만 잡고, 안내용 문자열 리터럴은 제외한다 (#19).
+    # 설치 스크립트는 "지금 이 명령을 실행합니다" 를 출력한 뒤 실제로 실행하는 패턴이 흔해
+    # 정탐 1건마다 오탐 1건이 따라붙었다. 두 겹으로 억제한다.
+    #   1) 라인 선두가 출력 계열 명령(echo/printf/info/warn/log/...)이면 제외
+    #   2) curl 앞의 구간이 "따옴표 밖" 이어야 한다 — 완결된 인용구만 건너뛸 수 있어
+    #      열린 따옴표 안의 curl 에는 도달하지 못한다
+    # 단 `bash -c "curl ... | sh"` 는 실제 실행이므로, 라인이 셸 실행 명령으로 시작하면
+    # 2) 를 적용하지 않는다(첫 대안).
+    pattern-regex: |-
+      (?m)^(?!\s*#)(?:\s*(?:sudo\s+)?(?:bash|sh|zsh|dash|eval|ssh)\b[^\n]*?|(?!\s*(?:echo|printf|print|info|warn|warning|log|logger|error|debug|note|msg|say)\b)(?:[^"'\n]|"[^"\n]*"|'[^'\n]*')*?)\b(?:curl|wget)\b[^|\n]*\|\s*(?:sudo\s+)?(?:bash|sh|zsh|dash)\b
 
   - id: finguard.shell.eval-var
     languages: [regex]

--- a/rules/testdata/vuln-samples/curl_pipe_shell.sh
+++ b/rules/testdata/vuln-samples/curl_pipe_shell.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# finguard.shell.curl-pipe-shell 정탐 픽스처 (#19).
+# 아래 줄들은 모두 원격 스크립트를 무결성 검증 없이 실행하므로 반드시 검출돼야 한다.
+set -euo pipefail
+
+# 1) 기본형
+curl -LsSf https://example.com/install.sh | sh
+
+# 2) 들여쓰기 + 실패 폴백
+    curl -fsSL https://example.com/install.sh | sh || echo "설치 실패"
+
+# 3) bash 로 파이프
+curl -fsSL https://example.com/install.sh | bash
+
+# 4) wget
+wget -qO- https://example.com/install.sh | sh
+
+# 5) sudo 승격
+curl -sL https://example.com/install.sh | sudo bash
+
+# 6) 셸 실행 명령의 인자 — 따옴표 안이지만 실제로 실행된다
+bash -c "curl -fsSL https://example.com/install.sh | sh"
+
+# 7) 제어구문 안
+if [ ! -x /usr/local/bin/tool ]; then curl https://example.com/install.sh | sh; fi

--- a/rules/testdata/vuln-samples/safe_curl_pipe_shell_string.sh
+++ b/rules/testdata/vuln-samples/safe_curl_pipe_shell_string.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# finguard.shell.curl-pipe-shell 오탐 방지 픽스처 (#19).
+# 아래 줄들은 명령을 "실행" 하지 않는다 — 어떤 룰에도 걸리면 안 된다.
+set -euo pipefail
+
+info() { printf '[info] %s\n' "$1"; }
+warn() { printf '[warn] %s\n' "$1"; }
+
+# 1) 안내 로그 — 실코드(zusik setup.sh)에서 실제로 오탐났던 형태
+info "설치 중: curl -fsSL https://example.com/install.sh | sh"
+info "설치 중: curl -fsSL https://example.com/install.sh | bash"
+
+# 2) echo / printf 로 사용법 출력
+echo "수동 설치: curl -LsSf https://example.com/install.sh | sh"
+printf '%s\n' "curl https://example.com/install.sh | bash"
+
+# 3) 경고 문구 자체가 이 패턴을 인용
+warn "curl ... | sh 는 무결성 검증이 없어 권장하지 않습니다"
+
+# 4) 변수에 담기만 함
+INSTALL_HINT="curl https://example.com/install.sh | sh"
+
+# 5) 주석
+# curl https://example.com/install.sh | sh
+
+# 6) 권장 형태 — 다운로드와 실행을 분리하고 체크섬을 검증한다
+curl -fsSLo install.sh https://example.com/install.sh
+echo "0000000000000000000000000000000000000000000000000000000000000000  install.sh" \
+  | sha256sum -c - && bash install.sh


### PR DESCRIPTION
Closes #19

## 문제

`finguard.shell.curl-pipe-shell` 이 실행되지 않는 문자열 리터럴을 검출했다. 정규식이 주석(`^(?!\s*#)`)만 걸러낼 뿐, 매칭 대상이 셸이 실행할 명령인지 따옴표 안의 문구인지 구분하지 않았다.

설치 스크립트가 안내 후 실행하는 패턴이 흔해, 정탐 1건마다 오탐 1건이 붙었다.

```bash
info "설치 중: curl -fsSL https://example.com/install.sh | sh"   # 오탐 — 로그 출력
curl -fsSL https://example.com/install.sh | sh || warn "..."     # 정탐 — 실제 실행
```

## 수정

억제를 두 겹으로 둔다.

1. 라인 선두(공백 제외)가 출력 계열 명령(`echo`/`printf`/`info`/`warn`/`log`/...)이면 매칭 제외
2. `curl` 앞 구간은 완결된 인용구(`"..."`, `'...'`)만 건너뛸 수 있게 해, 열린 따옴표 안의 `curl` 에는 도달하지 못하게 한다

`bash -c "curl ... | sh"` 는 따옴표 안이지만 실제 실행이므로, 라인이 셸 실행 명령(`bash`/`sh`/`zsh`/`dash`/`eval`/`ssh`, `sudo` 접두 허용)으로 시작하면 2번을 적용하지 않는다.

## 검증

동일 실코드(공개 파이썬 프로젝트 `setup.sh`) 재스캔 결과:

| | 수정 전 | 수정 후 |
| :--- | ---: | ---: |
| 검출 | 7 | 4 |
| 정탐 | 4 | 4 |
| 오탐 | 3 | 0 |

- `semgrep --validate --config rules/` 통과
- `go build -mod=vendor ./...` · `go vet -mod=vendor ./...` 통과
- `go test -race -mod=vendor ./...` 통과
- `go test -race -mod=vendor -tags semgrep_integration ./internal/scanner/` 통과 (신규 테스트 포함)

## 추가된 픽스처

- `rules/testdata/vuln-samples/curl_pipe_shell.sh` — 정탐 7종(기본형·들여쓰기·`| bash`·`wget`·`| sudo bash`·`bash -c`·제어구문 내부)
- `rules/testdata/vuln-samples/safe_curl_pipe_shell_string.sh` — 오탐 방지 6종(`info`/`echo`/`printf`/`warn` 인자, 변수 대입, 주석, 체크섬 검증 권장형)

`TestCurlPipeShellSkipsStringLiterals` 가 정탐 라인번호 7종을 모두 요구하고, 오탐 방지 픽스처에서 검출이 하나라도 나오면 실패한다.

## 알려진 한계

`MSG=$(cat <<EOS ... EOS)` 같은 히어독 안의 안내 문구는 여전히 오탐 대상이다. 별도 케이스가 실제로 관측되면 후속 처리한다.

Made with [Orca](https://github.com/stablyai/orca) 🐋
