### PR TITLE
test(#20): 파이썬 룰 8종 회귀 픽스처 + 통합 테스트

### DIFF
--- a/internal/scanner/integration_test.go
+++ b/internal/scanner/integration_test.go
@@ -2,7 +2,9 @@
 
 // 실제 semgrep 바이너리를 돌려 룰이 취약 패턴을 검출하는지 확인하는 통합 테스트.
 // 폐쇄망·CI 에는 semgrep 이 없을 수 있어 기본 go test 에서 제외한다.
-//   실행: go test -tags semgrep_integration ./internal/scanner/
+//
+//	실행: go test -tags semgrep_integration ./internal/scanner/
+//
 // semgrep 이 PATH 에 없으면 실패가 아니라 skip 한다.
 package scanner
 
@@ -98,6 +100,67 @@ func TestCurlPipeShellSkipsStringLiterals(t *testing.T) {
 	for line, hit := range wantLines {
 		if !hit {
 			t.Errorf("curl_pipe_shell.sh:%d 이 검출되지 않았다 — 회귀", line)
+		}
+	}
+}
+
+// 회귀(#20): 파이썬 룰 8종이 각각 정탐 픽스처를 정확히 검출하고, 오탐 방지
+// 픽스처는 어떤 룰에도 걸리지 않아야 한다. "실코드 스캔에서 파이썬 검출 0건"이
+// 나왔을 때 그것이 코드가 깨끗해서인지 룰이 죽어서인지 이 테스트가 판별한다.
+func TestPythonRulesDetectVulnsAndSkipSafeFixtures(t *testing.T) {
+	requireSemgrep(t)
+	dir, _ := filepath.Abs("../../rules/testdata/vuln-samples")
+
+	findings, err := CLI{}.Scan(context.Background(), rulesDir(t), dir)
+	if err != nil {
+		t.Fatalf("스캔 실패: %v", err)
+	}
+
+	// 룰ID(suffix) → python_vulns.py 에서 정탐이 기대되는 라인.
+	wantLine := map[string]int{
+		"finguard.python.hardcoded-secret":    14,
+		"finguard.python.weak-hash":           19,
+		"finguard.python.http-url":            23,
+		"finguard.python.sql-format":          28,
+		"finguard.python.subprocess-shell":    34,
+		"finguard.python.eval-exec":           39,
+		"finguard.python.tls-verify-disabled": 44,
+		"finguard.python.yaml-unsafe-load":    49,
+	}
+	hit := make(map[string]bool, len(wantLine))
+
+	for _, f := range findings {
+		base := filepath.Base(f.Path)
+
+		if base == "safe_python.py" {
+			t.Errorf("오탐 방지 픽스처가 %s 로 오검출됐다 (line %d)", f.RuleID, f.StartLine)
+			continue
+		}
+		if base != "python_vulns.py" {
+			continue
+		}
+
+		var matched string
+		for ruleID := range wantLine {
+			if strings.HasSuffix(f.RuleID, ruleID) {
+				matched = ruleID
+				break
+			}
+		}
+		if matched == "" {
+			t.Errorf("python_vulns.py 가 예상 밖 룰 %s 로 검출됐다 (line %d)", f.RuleID, f.StartLine)
+			continue
+		}
+		if f.StartLine != wantLine[matched] {
+			t.Errorf("%s 가 예상과 다른 라인 %d 에서 검출됐다 (기대: %d)", matched, f.StartLine, wantLine[matched])
+			continue
+		}
+		hit[matched] = true
+	}
+
+	for ruleID := range wantLine {
+		if !hit[ruleID] {
+			t.Errorf("python_vulns.py 에서 %s 가 검출되지 않았다 — 회귀", ruleID)
 		}
 	}
 }

--- a/rules/testdata/vuln-samples/python_vulns.py
+++ b/rules/testdata/vuln-samples/python_vulns.py
@@ -1,0 +1,49 @@
+"""finguard.python 룰 8종 정탐 픽스처 (#20).
+
+각 블록은 대응하는 룰 하나씩만 발화해야 한다. semgrep 이 정적으로만 읽는
+예제 코드라서 import 대상 모듈이 실제 설치돼 있지 않아도 무방하다.
+"""
+
+import hashlib
+import subprocess
+import requests
+import yaml
+
+
+# 1) finguard.python.hardcoded-secret — API 키가 코드에 직접 박혀 있다.
+PAYMENT_API_KEY = "sk-test-9f8e7d6c5b4a3210"
+
+
+# 2) finguard.python.weak-hash — MD5 로 비밀번호 해시를 생성한다.
+def hash_password(password: str) -> str:
+    return hashlib.md5(password.encode()).hexdigest()
+
+
+# 3) finguard.python.http-url — 평문 HTTP 로 내부 결제 API 를 호출한다.
+PAYMENT_ENDPOINT = "http://payment-gateway.corp.local/api/transfer"
+
+
+# 4) finguard.python.sql-format — f-string 으로 조립한 SQL 을 그대로 실행한다.
+def find_user(cursor, user_id):
+    cursor.execute(f"SELECT * FROM users WHERE id = {user_id}")
+
+
+# 5) finguard.python.subprocess-shell — 조립된 명령을 shell=True 로 실행한다.
+def list_dir(user_supplied_path):
+    cmd = "ls " + user_supplied_path
+    subprocess.run(cmd, shell=True)
+
+
+# 6) finguard.python.eval-exec — 동적으로 조립된 문자열을 eval 에 전달한다.
+def compute(user_expr):
+    return eval(user_expr)
+
+
+# 7) finguard.python.tls-verify-disabled — TLS 인증서 검증을 끈다.
+def fetch(url):
+    return requests.get(url, verify=False)
+
+
+# 8) finguard.python.yaml-unsafe-load — 안전하지 않은 로더로 역직렬화한다.
+def load_config(stream):
+    return yaml.load(stream, Loader=yaml.Loader)

--- a/rules/testdata/vuln-samples/safe_python.py
+++ b/rules/testdata/vuln-samples/safe_python.py
@@ -1,0 +1,65 @@
+"""finguard.python 룰 8종 오탐 방지 픽스처 (#20).
+
+아래 블록은 각 룰의 안전한 변형을 모아둔 것으로, python.yaml 룰 8종은 물론
+rules/ 전체 룰셋 어디에도 걸리면 안 된다.
+"""
+
+import ast
+import hashlib
+import os
+import subprocess
+
+import requests
+import yaml
+
+
+# 1) finguard.python.hardcoded-secret — 환경변수 조회, 빈 문자열, 플레이스홀더는 시크릿이 아니다.
+PAYMENT_API_KEY = os.getenv("PAYMENT_API_KEY")
+DB_PASSWORD = ""
+SECRET_PLACEHOLDER = "changeme"
+
+
+# 2) finguard.python.weak-hash — 비보안 용도(체크섬)로 명시한 MD5 는 대상이 아니다.
+def checksum(data: bytes) -> str:
+    return hashlib.md5(data, usedforsecurity=False).hexdigest()
+
+
+# 3) finguard.python.http-url — localhost 와 XML 네임스페이스 URI 는 대상이 아니다 (이슈 #3 계열).
+LOCAL_HEALTHCHECK_URL = "http://localhost:8000/health"
+SOAP_NAMESPACE = "http://schemas.xmlsoap.org/soap/envelope/"
+
+
+# 4) finguard.python.sql-format — 바인딩 파라미터를 쓰면 대상이 아니다.
+def find_user_safe(cursor, user_id):
+    cursor.execute("SELECT * FROM users WHERE id = ?", (user_id,))
+
+
+# 5) finguard.python.subprocess-shell — 리스트 인자 + shell=False 는 대상이 아니다.
+def list_dir_safe(path):
+    subprocess.run(["ls", path], shell=False)
+
+
+# 6) finguard.python.eval-exec — 리터럴 상수만 전달하거나 ast.literal_eval 을 쓰면 대상이 아니다.
+def compute_safe(user_expr):
+    return ast.literal_eval(user_expr)
+
+
+CONST_RESULT = eval("1 + 1")
+
+
+# 7) finguard.python.tls-verify-disabled — verify=True 명시 또는 기본값은 대상이 아니다.
+def fetch_verified(url):
+    return requests.get(url, verify=True)
+
+
+def fetch_default(url):
+    return requests.get(url)
+
+
+# 8) finguard.python.yaml-unsafe-load — safe_load 또는 SafeLoader 는 대상이 아니다.
+def load_config_safe(stream):
+    return yaml.safe_load(stream)
+
+
+def load_config_explicit_safe(stream):
+    return yaml.load(stream, Loader=yaml.SafeLoader)


### PR DESCRIPTION
Closes #20

## 배경

`rules/python.yaml` 룰 8종에 대응하는 테스트 픽스처가 없어 회귀 테스트 없이 방치돼 있었다. `semgrep --validate` 는 문법만 확인할 뿐, 실제 발화 여부·오탐 여부는 보증하지 못한다. 실코드 스캔에서 파이썬 검출 0건이 나왔을 때 코드가 깨끗해서인지 룰이 죽어서인지 판별할 수단이 없었다.

직전 커밋(#19, PR #21)이 셸 룰에 대해 같은 작업을 이미 해뒀기에 그 형식을 그대로 따랐다.

## 변경

- `rules/testdata/vuln-samples/python_vulns.py` — 룰 8종 정탐 픽스처(룰당 1블록)
- `rules/testdata/vuln-samples/safe_python.py` — 룰 8종 오탐 방지 픽스처(룰당 1블록)
- `internal/scanner/integration_test.go` — `TestPythonRulesDetectVulnsAndSkipSafeFixtures` 추가
  - 정탐 픽스처는 8종 전부가 기대 라인에서 정확히 검출돼야 통과
  - 오탐 방지 픽스처는 (파이썬 룰뿐 아니라) 전체 룰셋 어디에도 걸리면 실패

## 검증 결과

### 정탐/오탐 실스캔 (`semgrep --config=./rules`)

| 룰 ID | 정탐 (python_vulns.py) | 오탐 (safe_python.py) |
| :--- | :---: | :---: |
| `finguard.python.hardcoded-secret` | 1건 (line 14) | 0건 |
| `finguard.python.weak-hash` | 1건 (line 19) | 0건 |
| `finguard.python.http-url` | 1건 (line 23) | 0건 |
| `finguard.python.sql-format` | 1건 (line 28) | 0건 |
| `finguard.python.subprocess-shell` | 1건 (line 34) | 0건 |
| `finguard.python.eval-exec` | 1건 (line 39) | 0건 |
| `finguard.python.tls-verify-disabled` | 1건 (line 44) | 0건 |
| `finguard.python.yaml-unsafe-load` | 1건 (line 49) | 0건 |

8종 전부 미탐 없이 정확한 라인에서 발화했다. 기존 픽스처(`curl_pipe_shell.sh`, `safe_curl_pipe_shell_string.sh`, `template_variable_injection.ts`, `safe_template.ts`)에 대한 검출 결과는 변화 없음(기존 테스트 그대로 통과).

### 명령별 결과

| 명령 | 결과 |
| :--- | :---: |
| `semgrep --validate --config rules/` | 통과 (0 configuration error, 85 rules) |
| `python3 -m py_compile python_vulns.py safe_python.py` | 통과 |
| `go build -mod=vendor ./...` | 통과 |
| `go vet -mod=vendor ./...` | 통과 |
| `go test -race -mod=vendor ./...` | 통과 |
| `go test -race -mod=vendor -tags semgrep_integration ./internal/scanner/ -v` | 통과 (기존 2건 + 신규 1건 전부 PASS) |

## 범위 밖

이번 스캔에서 8종 전부 정상 발화(미탐 없음)를 확인했다. 룰 자체 수정은 없다 — 이 PR 은 픽스처와 테스트 추가만 다룬다.

Made with [Orca](https://github.com/stablyai/orca) 🐋
