### PR TITLE
feat(#26): TLS 검증 무력화 룰에 대입형·컨텍스트 조작형 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 bin/
 
+# 파이썬 룰 픽스처 검증 부산물 — `python3 -m py_compile` 은 -B 여부와 무관하게 캐시를 쓴다
+__pycache__/
+*.pyc
+
 # 시크릿 — pre-commit 게이트(.claude/hooks/pre-commit.sh)와 이중 방어
 .env
 .env.*

--- a/internal/scanner/integration_test.go
+++ b/internal/scanner/integration_test.go
@@ -116,18 +116,26 @@ func TestPythonRulesDetectVulnsAndSkipSafeFixtures(t *testing.T) {
 		t.Fatalf("스캔 실패: %v", err)
 	}
 
-	// 룰ID(suffix) → python_vulns.py 에서 정탐이 기대되는 라인.
-	wantLine := map[string]int{
-		"finguard.python.hardcoded-secret":    14,
-		"finguard.python.weak-hash":           19,
-		"finguard.python.http-url":            23,
-		"finguard.python.sql-format":          28,
-		"finguard.python.subprocess-shell":    34,
-		"finguard.python.eval-exec":           39,
-		"finguard.python.tls-verify-disabled": 44,
-		"finguard.python.yaml-unsafe-load":    49,
+	// 룰ID(suffix) → python_vulns.py 에서 정탐이 기대되는 라인 집합.
+	// tls-verify-disabled 는 형태가 여럿이라 라인이 여러 개다 (#26):
+	// requests verify=False / 전역 기본 컨텍스트 교체 / verify_mode 직접 해제 / httpx.
+	wantLines := map[string][]int{
+		"finguard.python.hardcoded-secret":    {17},
+		"finguard.python.weak-hash":           {22},
+		"finguard.python.http-url":            {26},
+		"finguard.python.sql-format":          {31},
+		"finguard.python.subprocess-shell":    {37},
+		"finguard.python.eval-exec":           {42},
+		"finguard.python.tls-verify-disabled": {47, 52, 58, 64},
+		"finguard.python.yaml-unsafe-load":    {69},
 	}
-	hit := make(map[string]bool, len(wantLine))
+	hit := map[string]map[int]bool{}
+	for id, lines := range wantLines {
+		hit[id] = make(map[int]bool, len(lines))
+		for _, ln := range lines {
+			hit[id][ln] = false
+		}
+	}
 
 	for _, f := range findings {
 		base := filepath.Base(f.Path)
@@ -141,7 +149,7 @@ func TestPythonRulesDetectVulnsAndSkipSafeFixtures(t *testing.T) {
 		}
 
 		var matched string
-		for ruleID := range wantLine {
+		for ruleID := range wantLines {
 			if strings.HasSuffix(f.RuleID, ruleID) {
 				matched = ruleID
 				break
@@ -151,16 +159,18 @@ func TestPythonRulesDetectVulnsAndSkipSafeFixtures(t *testing.T) {
 			t.Errorf("python_vulns.py 가 예상 밖 룰 %s 로 검출됐다 (line %d)", f.RuleID, f.StartLine)
 			continue
 		}
-		if f.StartLine != wantLine[matched] {
-			t.Errorf("%s 가 예상과 다른 라인 %d 에서 검출됐다 (기대: %d)", matched, f.StartLine, wantLine[matched])
+		if _, ok := hit[matched][f.StartLine]; !ok {
+			t.Errorf("%s 가 예상 밖 라인 %d 에서 검출됐다 (기대: %v)", matched, f.StartLine, wantLines[matched])
 			continue
 		}
-		hit[matched] = true
+		hit[matched][f.StartLine] = true
 	}
 
-	for ruleID := range wantLine {
-		if !hit[ruleID] {
-			t.Errorf("python_vulns.py 에서 %s 가 검출되지 않았다 — 회귀", ruleID)
+	for ruleID, lines := range wantLines {
+		for _, ln := range lines {
+			if !hit[ruleID][ln] {
+				t.Errorf("python_vulns.py:%d 에서 %s 가 검출되지 않았다 — 회귀", ln, ruleID)
+			}
 		}
 	}
 }

--- a/rules/python.yaml
+++ b/rules/python.yaml
@@ -93,9 +93,24 @@ rules:
     message: TLS 인증서 검증을 비활성화하고 있습니다(verify=False / 미검증 컨텍스트). 중간자 공격(MITM)에 노출됩니다.
     paths:
       exclude: ["test_*.py", "*_test.py"]
+    # 호출형만 보면 가장 파급이 큰 관용구를 놓친다 (#26).
+    # `ssl._create_default_https_context = ssl._create_unverified_context` 는 호출 괄호가
+    # 없어 기존 패턴에 안 걸리는데, 프로세스 전역 기본 컨텍스트를 바꿔 이후 모든 https
+    # 호출을 MITM 에 노출시킨다. requests 외 클라이언트(httpx/aiohttp)와 컨텍스트 속성을
+    # 직접 끄는 형태도 같은 결과라 함께 본다.
     pattern-either:
       - pattern: requests.$F(..., verify=False, ...)
       - pattern: ssl._create_unverified_context(...)
+      # 전역 기본 컨텍스트 교체 — 호출이 아니라 함수 객체 대입
+      - pattern: ssl._create_default_https_context = ssl._create_unverified_context
+      # 컨텍스트 속성 직접 무력화
+      - pattern: $CTX.verify_mode = ssl.CERT_NONE
+      - pattern: $CTX.check_hostname = False
+      # requests 외 HTTP 클라이언트
+      - pattern: httpx.Client(..., verify=False, ...)
+      - pattern: httpx.AsyncClient(..., verify=False, ...)
+      - pattern: httpx.$F(..., verify=False, ...)
+      - pattern: aiohttp.TCPConnector(..., ssl=False, ...)
 
   - id: finguard.python.yaml-unsafe-load
     languages: [python]

--- a/rules/testdata/vuln-samples/python_vulns.py
+++ b/rules/testdata/vuln-samples/python_vulns.py
@@ -5,7 +5,10 @@
 """
 
 import hashlib
+import ssl
 import subprocess
+
+import httpx
 import requests
 import yaml
 
@@ -42,6 +45,23 @@ def compute(user_expr):
 # 7) finguard.python.tls-verify-disabled — TLS 인증서 검증을 끈다.
 def fetch(url):
     return requests.get(url, verify=False)
+
+
+# 7b) finguard.python.tls-verify-disabled — 전역 기본 컨텍스트를 미검증 팩토리로 교체한다 (#26).
+def disable_tls_globally():
+    ssl._create_default_https_context = ssl._create_unverified_context
+
+
+# 7c) finguard.python.tls-verify-disabled — 컨텍스트 속성을 직접 끈다.
+def build_lax_context():
+    ctx = ssl.create_default_context()
+    ctx.verify_mode = ssl.CERT_NONE
+    return ctx
+
+
+# 7d) finguard.python.tls-verify-disabled — requests 외 클라이언트도 결과는 같다.
+def fetch_httpx(url):
+    return httpx.Client(verify=False).get(url)
 
 
 # 8) finguard.python.yaml-unsafe-load — 안전하지 않은 로더로 역직렬화한다.

--- a/rules/testdata/vuln-samples/safe_python.py
+++ b/rules/testdata/vuln-samples/safe_python.py
@@ -7,8 +7,10 @@ rules/ 전체 룰셋 어디에도 걸리면 안 된다.
 import ast
 import hashlib
 import os
+import ssl
 import subprocess
 
+import httpx
 import requests
 import yaml
 
@@ -54,6 +56,22 @@ def fetch_verified(url):
 
 def fetch_default(url):
     return requests.get(url)
+
+
+# 7b) finguard.python.tls-verify-disabled — 기본 컨텍스트로 되돌리는 대입은 안전하다 (#26).
+def restore_tls_default():
+    ssl._create_default_https_context = ssl.create_default_context
+
+
+# 7c) finguard.python.tls-verify-disabled — 검증을 켜는 설정은 대상이 아니다.
+def build_strict_context():
+    ctx = ssl.create_default_context()
+    ctx.verify_mode = ssl.CERT_REQUIRED
+    return ctx
+
+
+def fetch_httpx_verified(url):
+    return httpx.Client(verify=True).get(url)
 
 
 # 8) finguard.python.yaml-unsafe-load — safe_load 또는 SafeLoader 는 대상이 아니다.


### PR DESCRIPTION
Closes #26

## 문제

`finguard.python.tls-verify-disabled` 의 `pattern-either` 가 호출형 두 가지만 정의돼 있었다.

```yaml
- pattern: requests.$F(..., verify=False, ...)
- pattern: ssl._create_unverified_context(...)
```

가장 파급이 큰 관용구는 호출이 아니라 **대입**이라 매칭되지 않았다.

```python
ssl._create_default_https_context = ssl._create_unverified_context
```

호출 괄호가 없어 두 패턴 어디에도 안 걸리는데, 프로세스 전역 기본 컨텍스트를 미검증 팩토리로 교체해 이후 모든 https 호출을 MITM 에 노출시킨다.

## 추가한 형태

| 형태 | 사유 |
| :--- | :--- |
| `ssl._create_default_https_context = ssl._create_unverified_context` | 전역 기본 컨텍스트 교체 |
| `$CTX.verify_mode = ssl.CERT_NONE` | 인증서 검증 해제 |
| `$CTX.check_hostname = False` | 호스트명 검증 해제 |
| `httpx.Client` / `httpx.AsyncClient` / `httpx.$F` 의 `verify=False` | requests 외 클라이언트 |
| `aiohttp.TCPConnector(ssl=False)` | 동상 |

## 일부러 넣지 않은 것

- **`ssl._create_default_https_context = $F` (일반형)** — 기본 컨텍스트로 되돌리는 정상 대입(`= ssl.create_default_context`)까지 잡아 오탐이 된다. 오탐 방지 픽스처에 이 케이스를 넣어 회귀를 막았다.
- **`urllib3.disable_warnings(...)`** — 경고 출력만 끌 뿐 검증을 끄지 않는다. 룰 문구("TLS 인증서 검증을 비활성화하고 있습니다")와 어긋나므로 제외했다.

## 검증

실코드 재스캔 — `koreainvestment/open-trading-api`:

| | 수정 전 | 수정 후 |
| :--- | ---: | ---: |
| `tls-verify-disabled` 검출 | 0 | **17** |

검출된 17개 파일은 캠페인 트리아지가 미탐으로 보고한 목록과 일치한다 (`stocks_info/` 16개 + `MCP/Kis Trading MCP/module/plugin/master_file.py:591`).

픽스처:
- 정탐 4종 추가 — `python_vulns.py:47`(requests) `:52`(전역 교체) `:58`(verify_mode) `:64`(httpx)
- 오탐 방지 3종 추가 — 기본 컨텍스트 복구 대입, `CERT_REQUIRED`, `httpx verify=True`
- `safe_python.py` 검출 **0건** 유지

명령별 결과:
- `semgrep --validate --config rules/` 통과
- `python3 -m py_compile` (픽스처 2종) 통과
- `go build -mod=vendor ./...` · `go vet -mod=vendor ./...` 통과
- `go test -race -mod=vendor ./...` 전 패키지 통과
- `go test -race -mod=vendor -tags semgrep_integration ./internal/scanner/` 통과 (기존 2종 + 파이썬 1종 회귀 없음)

기존 파이썬 테스트는 룰ID 당 라인 1개만 기대하는 구조라, 형태가 여럿인 룰을 표현하도록 라인 **집합**으로 바꿨다.

## 출처

2026-08-17 국내 금융 도메인 레포 10개 스캔 캠페인. 3개 렌즈(재현율·규제·구현가능성) 적대적 검증 **3/3 통과**, 반박 없음.

Made with [Orca](https://github.com/stablyai/orca) 🐋
