### PR TITLE
docs(#40): 브랜치 정리 함정·룰 검증 코퍼스 선정 기준 메모리 추가

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -4,6 +4,8 @@
 타입접두: `project_`/`feedback_`/`reference_`/`user_`. `user_*`만 개인(gitignore), 그 외 팀 공유.
 
 - [GitHub 개발 SSOT 전환](project_github-publish-flow.md) — 2026-08-17부터 GitHub 가 SSOT(PR 플로우·noreply 신원·main 보호), 구 스냅샷 force 퍼블리시 폐기, 내부 GitLab 은 아카이브
+- [머지 후 브랜치 정리](project_gh-merge-branch-cleanup.md) — `gh pr merge --delete-branch` 가 원격을 안 지움, 항상 수동 삭제 + `git branch -a` 확인
+- [룰 검증용 실코드 코퍼스](project_finguard-scan-corpus.md) — 국내 금융 Swift/Kotlin 고스타 레포는 없음, 대안 10개 목록과 테스트코드 1차 필터·룰 고정 요령
 - `user_reference_jaybbot.md` (개인 메모리, gitignore — 로컬에만 존재) — 외부 스캐너로 이 레포 점검하는 방법·상시 검출 1건 무시 사유
 
 <!-- 메모리 추가 시 아래에 한 줄씩:

--- a/.claude/memory/project_finguard-scan-corpus.md
+++ b/.claude/memory/project_finguard-scan-corpus.md
@@ -1,0 +1,26 @@
+---
+name: project-finguard-scan-corpus
+description: 룰 검증용 실코드 코퍼스 고르는 법 — 국내 금융 Swift/Kotlin 고스타 레포는 존재하지 않음, 대안 목록과 스캔 운용 요령
+metadata:
+  type: project
+---
+
+finguard 룰을 실코드로 검증할 때 쓸 코퍼스 선정 기준. 2026-08-17 GitHub 전수 탐색으로 확인했다.
+
+**"국내 + 금융 + Swift/Kotlin + 고스타" 교집합은 사실상 없다.** 한글 금융 키워드(`금융`/`주식`/`증권`/`가계부`/`은행`)로 Swift·Kotlin 을 검색하면 **최고 스타가 17**이고 부트캠프 과제·습작이 대부분이다. 반대로 국내 조직 고스타 레포(toss 11k, naver 7k, line 5k, kakao 1.4k)는 전부 TS/Python 이고 금융 도메인이 아니다. 셋 중 둘까지만 만족시킬 수 있으니 무엇을 우선할지 먼저 사용자에게 확정받아라.
+
+**Why**: "스타 많은 국내 금융 Swift 레포 찾아줘" 를 그대로 수행하려 하면 검색만 반복하다 빈손이 된다. 전제 자체가 성립하지 않는다는 사실을 먼저 보고하는 게 맞다.
+
+**How to apply**:
+
+- 금융 도메인 우선으로 갈 때 실제로 쓸 만한 10개(2026-08-17 기준 스타):
+  `koreainvestment/open-trading-api`(1563, Py) · `samchon/payments`(361, TS) ·
+  `DingdingKim/CoinNow`(219, Swift) · `Gosrock/DuDoong-Backend`(151, Kotlin, 토스페이먼츠 연동) ·
+  `iamport/iamport-rest-client-python`(133) · `banksalad/AXSnapshot`(111, Swift) ·
+  `namjug-kim/reactive-crypto`(101, Kotlin) · `sharebook-kr/pybithumb`(95) ·
+  `iamport/iamport-rest-client-java`(91) · `techinpark/upbitBar`(22, Swift)
+- 검색 축은 한글 키워드보다 **국내 PG·증권·거래소 SDK 이름**(iamport/portone, tosspayments, bootpay, upbit, bithumb, 한국투자 KIS)이 훨씬 잘 걸린다.
+- **스캔 결과의 1차 필터는 항상 테스트 코드다.** orca 스캔에서 202건 중 182건(90%)이 `.test.`·`fixtures/` 의 더미 값이었다. 트리아지 전에 경로로 먼저 갈라야 실제 신호가 보인다.
+- **백그라운드 에이전트가 이 레포를 만지는 동안 스캔하려면 룰을 커밋에서 떠서 고정한다** — 워킹트리의 `rules/` 를 그대로 쓰면 에이전트가 픽스처를 쓰는 중간 상태가 섞인다.
+  `git archive <sha> rules mapping | tar -x -C <tmpdir>` 후 `--rules=<tmpdir>/rules` 로 실행.
+- 관련: [[project-gh-merge-branch-cleanup]]

--- a/.claude/memory/project_gh-merge-branch-cleanup.md
+++ b/.claude/memory/project_gh-merge-branch-cleanup.md
@@ -1,0 +1,24 @@
+---
+name: project-gh-merge-branch-cleanup
+description: 이 레포에서 gh pr merge --delete-branch 는 원격 브랜치를 안 지운다 — 머지 후 항상 수동 삭제 + prune 확인
+metadata:
+  type: project
+---
+
+`gh pr merge <N> --squash --delete-branch` 를 써도 **원격 브랜치가 남는다.** 2026-08-17 PR #21·#22 에서 연속 재현했다. 로컬 브랜치 삭제만 시도하고(워크트리가 물고 있으면 그것마저 실패), 원격은 그대로다.
+
+**Why**: 머지 후 `git branch -a` 에 남은 `remotes/origin/<branch>` 를 stale ref 로 오해해 `git remote prune origin` 만 돌리면 아무 일도 일어나지 않는다. `gh api repos/<owner>/<repo>/branches` 로 확인하면 원격에 실제로 살아 있다. 쌓이면 다음 세션이 "브랜치 정리" 부터 해야 한다 — 실제로 이 세션이 머지된 브랜치 9개를 치우며 시작했다.
+
+**How to apply**: 머지 직후 항상 이 순서로 마감한다.
+
+```bash
+gh pr merge <N> --squash --delete-branch          # 실패해도 계속
+git worktree remove <path>                        # 워크트리가 브랜치를 물고 있으면 먼저
+git branch -D <branch>
+git push origin --delete <branch>                 # 이게 실제 삭제
+git remote prune origin && git branch -a          # 남은 게 없는지 눈으로 확인
+```
+
+- `git branch -a` 확인까지 해야 끝이다. prune 만으로는 원격 실물이 안 지워진다.
+- 서브에이전트가 워크트리에서 작업했으면 브랜치 삭제 전에 `git worktree remove` 가 선행돼야 한다(`cannot delete branch ... used by worktree` 로 막힘).
+- 관련: [[project-finguard-scan-corpus]]


### PR DESCRIPTION
Closes #40

2026-08-17 세션에서 반복 재현됐으나 코드·git 이력·AGENTS.md 어디에도 기록되지 않은 두 사실을 프로젝트 메모리에 남긴다.

## project_gh-merge-branch-cleanup.md

`gh pr merge --delete-branch` 가 이 레포에서 **원격 브랜치를 삭제하지 않는다.** PR #21·#22 에서 연속 재현했다.

핵심은 오진하기 쉽다는 점이다 — 머지 후 `git branch -a` 에 남은 `remotes/origin/<branch>` 를 stale ref 로 착각해 `git remote prune origin` 만 돌리면 아무 일도 일어나지 않는다. `gh api repos/<owner>/<repo>/branches` 로 보면 원격에 실물이 살아 있다. 실제로 이 세션은 그렇게 쌓인 브랜치 9개를 치우며 시작했다.

마감 순서를 명령어까지 적었고, 서브에이전트가 워크트리에서 작업한 경우 `git worktree remove` 가 브랜치 삭제보다 선행돼야 한다는 점(`cannot delete branch ... used by worktree`)도 포함했다.

## project_finguard-scan-corpus.md

룰을 실코드로 검증할 때 쓸 코퍼스 선정 기준.

- **"국내 + 금융 + Swift/Kotlin + 고스타" 교집합이 사실상 없다** — 한글 금융 키워드로 Swift/Kotlin 을 검색하면 최고 스타가 17이고, 국내 조직 고스타 레포는 전부 TS/Python 비금융이다. 전제가 성립하지 않는다는 사실을 먼저 보고해야 검색만 반복하지 않는다.
- 검색 축은 한글 키워드보다 **국내 PG·증권·거래소 SDK 이름**(iamport/portone, tosspayments, upbit, bithumb, 한국투자 KIS)이 잘 걸린다.
- 2026-08-17 캠페인에서 확정한 10개 목록을 스타와 함께 기록.
- **트리아지 1차 필터는 항상 테스트 코드다** — orca 스캔에서 202건 중 182건(90%)이 픽스처 더미 값이었다.
- 백그라운드 에이전트가 이 레포를 만지는 중 스캔하려면 `git archive <sha> rules mapping | tar -x -C <tmpdir>` 로 룰을 커밋에서 떠서 고정해야 한다. 워킹트리 `rules/` 를 그대로 쓰면 중간 상태가 섞인다.

## 검증

- `.claude/memory/` 타입접두(`project_`) 규약 준수, `MEMORY.md` 인덱스에 각 1줄 추가
- `python3 .claude/scripts/knowledge_graph.py --check` → **38 nodes · 15 edges · 0 broken links**

Made with [Orca](https://github.com/stablyai/orca) 🐋
