### PR TITLE
feat(#30): 평문 WebSocket(ws://) 룰 7개 언어에 신설

### DIFF
--- a/internal/scanner/integration_test.go
+++ b/internal/scanner/integration_test.go
@@ -127,7 +127,8 @@ func TestPythonRulesDetectVulnsAndSkipSafeFixtures(t *testing.T) {
 		"finguard.python.subprocess-shell":    {37},
 		"finguard.python.eval-exec":           {42},
 		"finguard.python.tls-verify-disabled": {47, 52, 58, 64},
-		"finguard.python.yaml-unsafe-load":    {69},
+		"finguard.python.cleartext-websocket": {68},
+		"finguard.python.yaml-unsafe-load":    {73},
 	}
 	hit := map[string]map[int]bool{}
 	for id, lines := range wantLines {

--- a/mapping/rules.yaml
+++ b/mapping/rules.yaml
@@ -1173,3 +1173,121 @@
     ```go
     rows, err := db.Query("SELECT * FROM users WHERE name = ?", name)
     ```
+- rule_id: finguard.swift.cleartext-websocket
+  code: FIN-TLS-017
+  cwe: CWE-319
+  title: 중요정보 평문 전송(WebSocket)
+  severity: ERROR
+  basis: 개발보안가이드 「보안기능 - 중요정보 평문 전송」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 65 (통신구간 암호화 적용)"
+  explain: 평문 WebSocket(ws://) 으로 통신하고 있습니다. 실시간 시세·체결통보 채널에는 접속 자격증명과 거래내역이 흐르므로, 스니핑과 중간자 변조에 그대로 노출됩니다.
+  fix_example: |
+    ```
+    # 잘못된 예 (Swift)
+    url = "ws://ops.example.com:21000"
+
+    # 올바른 예 — TLS 적용
+    url = "wss://ops.example.com:21000"
+    ```
+
+- rule_id: finguard.go.cleartext-websocket
+  code: FIN-TLS-018
+  cwe: CWE-319
+  title: 중요정보 평문 전송(WebSocket)
+  severity: ERROR
+  basis: 개발보안가이드 「보안기능 - 중요정보 평문 전송」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 65 (통신구간 암호화 적용)"
+  explain: 평문 WebSocket(ws://) 으로 통신하고 있습니다. 실시간 시세·체결통보 채널에는 접속 자격증명과 거래내역이 흐르므로, 스니핑과 중간자 변조에 그대로 노출됩니다.
+  fix_example: |
+    ```
+    # 잘못된 예 (Go)
+    url = "ws://ops.example.com:21000"
+
+    # 올바른 예 — TLS 적용
+    url = "wss://ops.example.com:21000"
+    ```
+
+- rule_id: finguard.ts.cleartext-websocket
+  code: FIN-TLS-019
+  cwe: CWE-319
+  title: 중요정보 평문 전송(WebSocket)
+  severity: ERROR
+  basis: 개발보안가이드 「보안기능 - 중요정보 평문 전송」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 65 (통신구간 암호화 적용)"
+  explain: 평문 WebSocket(ws://) 으로 통신하고 있습니다. 실시간 시세·체결통보 채널에는 접속 자격증명과 거래내역이 흐르므로, 스니핑과 중간자 변조에 그대로 노출됩니다.
+  fix_example: |
+    ```
+    # 잘못된 예 (TS/JS)
+    url = "ws://ops.example.com:21000"
+
+    # 올바른 예 — TLS 적용
+    url = "wss://ops.example.com:21000"
+    ```
+
+- rule_id: finguard.java.cleartext-websocket
+  code: FIN-TLS-020
+  cwe: CWE-319
+  title: 중요정보 평문 전송(WebSocket)
+  severity: ERROR
+  basis: 개발보안가이드 「보안기능 - 중요정보 평문 전송」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 65 (통신구간 암호화 적용)"
+  explain: 평문 WebSocket(ws://) 으로 통신하고 있습니다. 실시간 시세·체결통보 채널에는 접속 자격증명과 거래내역이 흐르므로, 스니핑과 중간자 변조에 그대로 노출됩니다.
+  fix_example: |
+    ```
+    # 잘못된 예 (Java)
+    url = "ws://ops.example.com:21000"
+
+    # 올바른 예 — TLS 적용
+    url = "wss://ops.example.com:21000"
+    ```
+
+- rule_id: finguard.kotlin.cleartext-websocket
+  code: FIN-TLS-021
+  cwe: CWE-319
+  title: 중요정보 평문 전송(WebSocket)
+  severity: ERROR
+  basis: 개발보안가이드 「보안기능 - 중요정보 평문 전송」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 65 (통신구간 암호화 적용)"
+  explain: 평문 WebSocket(ws://) 으로 통신하고 있습니다. 실시간 시세·체결통보 채널에는 접속 자격증명과 거래내역이 흐르므로, 스니핑과 중간자 변조에 그대로 노출됩니다.
+  fix_example: |
+    ```
+    # 잘못된 예 (Kotlin)
+    url = "ws://ops.example.com:21000"
+
+    # 올바른 예 — TLS 적용
+    url = "wss://ops.example.com:21000"
+    ```
+
+- rule_id: finguard.python.cleartext-websocket
+  code: FIN-TLS-022
+  cwe: CWE-319
+  title: 중요정보 평문 전송(WebSocket)
+  severity: ERROR
+  basis: 개발보안가이드 「보안기능 - 중요정보 평문 전송」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 65 (통신구간 암호화 적용)"
+  explain: 평문 WebSocket(ws://) 으로 통신하고 있습니다. 실시간 시세·체결통보 채널에는 접속 자격증명과 거래내역이 흐르므로, 스니핑과 중간자 변조에 그대로 노출됩니다.
+  fix_example: |
+    ```
+    # 잘못된 예 (Python)
+    url = "ws://ops.example.com:21000"
+
+    # 올바른 예 — TLS 적용
+    url = "wss://ops.example.com:21000"
+    ```
+
+- rule_id: finguard.shell.cleartext-websocket
+  code: FIN-TLS-023
+  cwe: CWE-319
+  title: 중요정보 평문 전송(WebSocket)
+  severity: ERROR
+  basis: 개발보안가이드 「보안기능 - 중요정보 평문 전송」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 65 (통신구간 암호화 적용)"
+  explain: 평문 WebSocket(ws://) 으로 통신하고 있습니다. 실시간 시세·체결통보 채널에는 접속 자격증명과 거래내역이 흐르므로, 스니핑과 중간자 변조에 그대로 노출됩니다.
+  fix_example: |
+    ```
+    # 잘못된 예 (Shell)
+    url = "ws://ops.example.com:21000"
+
+    # 올바른 예 — TLS 적용
+    url = "wss://ops.example.com:21000"
+    ```

--- a/rules/go.yaml
+++ b/rules/go.yaml
@@ -101,6 +101,18 @@ rules:
       exclude: ["*_test.go"]
     pattern-regex: '(?im)^(?![ \t]*(?://|\*|/\*)).*"http://(?!localhost|127\.0\.0\.1|0\.0\.0\.0|schemas\.|xmlns|(?:www\.)?w3\.org|(?:[\w.]+\.)?apache\.org|[\w.]*xml\.org|java\.sun\.com|(?:www\.)?example\.(?:com|org)|(?:www\.)?unicode\.org|(?:www\.)?jflex\.de|purl\.org|iana\.org|ietf\.org|slf4j\.org|json-schema\.org)[^"]+"'
 
+  # 금융 실시간 채널(시세·체결통보)은 대부분 웹소켓이고 접속키가 함께 흐른다 (#30).
+  # http-url 과 스킴만 다르고 예외 도메인 목록은 동일 — ws://localhost 개발 서버는 계속 제외된다.
+  # 접속 자격증명 동반 가능성이 높아 severity 는 ERROR 로 분리했다(http-url 은 WARNING 유지).
+  - id: finguard.go.cleartext-websocket
+    languages: [regex]
+    severity: ERROR
+    message: 평문 WebSocket(ws://) 으로 통신하고 있습니다. 실시간 시세·체결통보 채널에는 접속키와 거래내역이 흐르므로 wss:// 로 전환해야 합니다.
+    paths:
+      include: ["*.go"]
+      exclude: ["*_test.go"]
+    pattern-regex: '(?im)^(?![ \t]*(?://|\*|/\*)).*"ws://(?!localhost|127\.0\.0\.1|0\.0\.0\.0|schemas\.|xmlns|(?:www\.)?w3\.org|(?:[\w.]+\.)?apache\.org|[\w.]*xml\.org|java\.sun\.com|(?:www\.)?example\.(?:com|org)|(?:www\.)?unicode\.org|(?:www\.)?jflex\.de|purl\.org|iana\.org|ietf\.org|slf4j\.org|json-schema\.org)[^"]+"'
+
   # ─────────────────────────────────────────────────────────────────────────
   # 1) OS 명령어 삽입 (CWE-78)
   #    외부 입력이 검증 없이 os/exec 의 실행파일명 또는 인자에 도달할 때 검출.

--- a/rules/java.yaml
+++ b/rules/java.yaml
@@ -145,6 +145,18 @@ rules:
       exclude: ["*Test.java"]
     pattern-regex: '(?im)^(?![ \t]*(?://|\*|/\*)).*"http://(?!localhost|127\.0\.0\.1|0\.0\.0\.0|schemas\.|xmlns|(?:www\.)?w3\.org|(?:[\w.]+\.)?apache\.org|[\w.]*xml\.org|java\.sun\.com|(?:www\.)?example\.(?:com|org)|(?:www\.)?unicode\.org|(?:www\.)?jflex\.de|purl\.org|iana\.org|ietf\.org|slf4j\.org|json-schema\.org)[^"]+"'
 
+  # 금융 실시간 채널(시세·체결통보)은 대부분 웹소켓이고 접속키가 함께 흐른다 (#30).
+  # http-url 과 스킴만 다르고 예외 도메인 목록은 동일 — ws://localhost 개발 서버는 계속 제외된다.
+  # 접속 자격증명 동반 가능성이 높아 severity 는 ERROR 로 분리했다(http-url 은 WARNING 유지).
+  - id: finguard.java.cleartext-websocket
+    languages: [regex]
+    severity: ERROR
+    message: 평문 WebSocket(ws://) 으로 통신하고 있습니다. 실시간 시세·체결통보 채널에는 접속키와 거래내역이 흐르므로 wss:// 로 전환해야 합니다.
+    paths:
+      include: ["*.java"]
+      exclude: ["*Test.java"]
+    pattern-regex: '(?im)^(?![ \t]*(?://|\*|/\*)).*"ws://(?!localhost|127\.0\.0\.1|0\.0\.0\.0|schemas\.|xmlns|(?:www\.)?w3\.org|(?:[\w.]+\.)?apache\.org|[\w.]*xml\.org|java\.sun\.com|(?:www\.)?example\.(?:com|org)|(?:www\.)?unicode\.org|(?:www\.)?jflex\.de|purl\.org|iana\.org|ietf\.org|slf4j\.org|json-schema\.org)[^"]+"'
+
   - id: finguard.mybatis.dollar-interpolation
     languages: [regex]
     severity: ERROR

--- a/rules/kotlin.yaml
+++ b/rules/kotlin.yaml
@@ -125,6 +125,18 @@ rules:
       exclude: ["*Test.kt", "*Test.kts"]
     pattern-regex: '(?im)^(?![ \t]*(?://|\*)).*"http://(?!localhost|127\.0\.0\.1|0\.0\.0\.0|schemas\.|xmlns|(?:www\.)?w3\.org|(?:[\w.]+\.)?apache\.org|[\w.]*xml\.org|java\.sun\.com|(?:www\.)?example\.(?:com|org)|(?:www\.)?unicode\.org|(?:www\.)?jflex\.de|purl\.org|iana\.org|ietf\.org|slf4j\.org|json-schema\.org)[^"]+"'
 
+  # 금융 실시간 채널(시세·체결통보)은 대부분 웹소켓이고 접속키가 함께 흐른다 (#30).
+  # http-url 과 스킴만 다르고 예외 도메인 목록은 동일 — ws://localhost 개발 서버는 계속 제외된다.
+  # 접속 자격증명 동반 가능성이 높아 severity 는 ERROR 로 분리했다(http-url 은 WARNING 유지).
+  - id: finguard.kotlin.cleartext-websocket
+    languages: [regex]
+    severity: ERROR
+    message: 평문 WebSocket(ws://) 으로 통신하고 있습니다. 실시간 시세·체결통보 채널에는 접속키와 거래내역이 흐르므로 wss:// 로 전환해야 합니다.
+    paths:
+      include: ["*.kt", "*.kts"]
+      exclude: ["*Test.kt", "*Test.kts"]
+    pattern-regex: '(?im)^(?![ \t]*(?://|\*)).*"ws://(?!localhost|127\.0\.0\.1|0\.0\.0\.0|schemas\.|xmlns|(?:www\.)?w3\.org|(?:[\w.]+\.)?apache\.org|[\w.]*xml\.org|java\.sun\.com|(?:www\.)?example\.(?:com|org)|(?:www\.)?unicode\.org|(?:www\.)?jflex\.de|purl\.org|iana\.org|ietf\.org|slf4j\.org|json-schema\.org)[^"]+"'
+
   # 12. OS 명령 실행 (CWE-78)
   - id: finguard.kotlin.os-command
     languages: [regex]

--- a/rules/python.yaml
+++ b/rules/python.yaml
@@ -35,6 +35,18 @@ rules:
       exclude: ["test_*.py", "*_test.py"]
     pattern-regex: '(?im)^(?![ \t]*#).*["'']http://(?!localhost|127\.0\.0\.1|0\.0\.0\.0|schemas\.|xmlns|(?:www\.)?w3\.org|(?:[\w.]+\.)?apache\.org|[\w.]*xml\.org|(?:www\.)?example\.(?:com|org)|(?:www\.)?unicode\.org|purl\.org|iana\.org|ietf\.org|json-schema\.org)[^"'']+["'']'
 
+  # 금융 실시간 채널(시세·체결통보)은 대부분 웹소켓이고 접속키가 함께 흐른다 (#30).
+  # http-url 과 스킴만 다르고 예외 도메인 목록은 동일 — ws://localhost 개발 서버는 계속 제외된다.
+  # 접속 자격증명 동반 가능성이 높아 severity 는 ERROR 로 분리했다(http-url 은 WARNING 유지).
+  - id: finguard.python.cleartext-websocket
+    languages: [regex]
+    severity: ERROR
+    message: 평문 WebSocket(ws://) 으로 통신하고 있습니다. 실시간 시세·체결통보 채널에는 접속키와 거래내역이 흐르므로 wss:// 로 전환해야 합니다.
+    paths:
+      include: ["*.py"]
+      exclude: ["test_*.py", "*_test.py"]
+    pattern-regex: '(?im)^(?![ \t]*#).*["'']ws://(?!localhost|127\.0\.0\.1|0\.0\.0\.0|schemas\.|xmlns|(?:www\.)?w3\.org|(?:[\w.]+\.)?apache\.org|[\w.]*xml\.org|(?:www\.)?example\.(?:com|org)|(?:www\.)?unicode\.org|purl\.org|iana\.org|ietf\.org|json-schema\.org)[^"'']+["'']'
+
   # 문자열 조립 SQL — f-string / % / .format 으로 만든 문장을 그대로 execute 에 전달.
   # 바인딩 파라미터(execute(sql, params)) 사용은 잡지 않는다.
   - id: finguard.python.sql-format

--- a/rules/shell.yaml
+++ b/rules/shell.yaml
@@ -58,3 +58,14 @@ rules:
     paths:
       include: ["*.sh", "*.bash", "*.zsh"]
     pattern-regex: '(?im)^(?!\s*#).*\bhttp://(?!localhost|127\.0\.0\.1|0\.0\.0\.0|schemas\.|xmlns|(?:www\.)?w3\.org|(?:www\.)?example\.(?:com|org)|purl\.org|iana\.org|ietf\.org)[^\s"'']+'
+
+  # 금융 실시간 채널(시세·체결통보)은 대부분 웹소켓이고 접속키가 함께 흐른다 (#30).
+  # http-url 과 스킴만 다르고 예외 도메인 목록은 동일 — ws://localhost 개발 서버는 계속 제외된다.
+  # 접속 자격증명 동반 가능성이 높아 severity 는 ERROR 로 분리했다(http-url 은 WARNING 유지).
+  - id: finguard.shell.cleartext-websocket
+    languages: [regex]
+    severity: ERROR
+    message: 평문 WebSocket(ws://) 으로 통신하고 있습니다. 실시간 시세·체결통보 채널에는 접속키와 거래내역이 흐르므로 wss:// 로 전환해야 합니다.
+    paths:
+      include: ["*.sh", "*.bash", "*.zsh"]
+    pattern-regex: '(?im)^(?!\s*#).*\bws://(?!localhost|127\.0\.0\.1|0\.0\.0\.0|schemas\.|xmlns|(?:www\.)?w3\.org|(?:www\.)?example\.(?:com|org)|purl\.org|iana\.org|ietf\.org)[^\s"'']+'

--- a/rules/swift.yaml
+++ b/rules/swift.yaml
@@ -18,6 +18,17 @@ rules:
       include: ["*.swift"]
     pattern-regex: '(?im)^(?![ \t]*(?://|\*|/\*)).*"http://(?!localhost|127\.0\.0\.1|0\.0\.0\.0|schemas\.|xmlns|(?:www\.)?w3\.org|(?:[\w.]+\.)?apache\.org|[\w.]*xml\.org|java\.sun\.com|(?:www\.)?example\.(?:com|org)|(?:www\.)?unicode\.org|(?:www\.)?jflex\.de|purl\.org|iana\.org|ietf\.org|slf4j\.org|json-schema\.org)[^"]+"'
 
+  # 금융 실시간 채널(시세·체결통보)은 대부분 웹소켓이고 접속키가 함께 흐른다 (#30).
+  # http-url 과 스킴만 다르고 예외 도메인 목록은 동일 — ws://localhost 개발 서버는 계속 제외된다.
+  # 접속 자격증명 동반 가능성이 높아 severity 는 ERROR 로 분리했다(http-url 은 WARNING 유지).
+  - id: finguard.swift.cleartext-websocket
+    languages: [regex]
+    severity: ERROR
+    message: 평문 WebSocket(ws://) 으로 통신하고 있습니다. 실시간 시세·체결통보 채널에는 접속키와 거래내역이 흐르므로 wss:// 로 전환해야 합니다.
+    paths:
+      include: ["*.swift"]
+    pattern-regex: '(?im)^(?![ \t]*(?://|\*|/\*)).*"ws://(?!localhost|127\.0\.0\.1|0\.0\.0\.0|schemas\.|xmlns|(?:www\.)?w3\.org|(?:[\w.]+\.)?apache\.org|[\w.]*xml\.org|java\.sun\.com|(?:www\.)?example\.(?:com|org)|(?:www\.)?unicode\.org|(?:www\.)?jflex\.de|purl\.org|iana\.org|ietf\.org|slf4j\.org|json-schema\.org)[^"]+"'
+
   - id: finguard.swift.userdefaults-sensitive
     languages: [regex]
     severity: ERROR

--- a/rules/testdata/vuln-samples/python_vulns.py
+++ b/rules/testdata/vuln-samples/python_vulns.py
@@ -64,6 +64,10 @@ def fetch_httpx(url):
     return httpx.Client(verify=False).get(url)
 
 
+# 9) finguard.python.cleartext-websocket — 실시간 체결통보를 평문 웹소켓으로 받는다 (#30).
+REALTIME_FEED_URL = "ws://ops.example-broker.co.kr:21000"
+
+
 # 8) finguard.python.yaml-unsafe-load — 안전하지 않은 로더로 역직렬화한다.
 def load_config(stream):
     return yaml.load(stream, Loader=yaml.Loader)

--- a/rules/testdata/vuln-samples/safe_python.py
+++ b/rules/testdata/vuln-samples/safe_python.py
@@ -74,6 +74,12 @@ def fetch_httpx_verified(url):
     return httpx.Client(verify=True).get(url)
 
 
+# 9) finguard.python.cleartext-websocket — wss 와 로컬 개발 서버는 대상이 아니다 (#30).
+REALTIME_FEED_URL = "wss://ops.example-broker.co.kr:21000"
+LOCAL_FEED_URL = "ws://localhost:8765"
+LOOPBACK_FEED_URL = "ws://127.0.0.1:8765"
+
+
 # 8) finguard.python.yaml-unsafe-load — safe_load 또는 SafeLoader 는 대상이 아니다.
 def load_config_safe(stream):
     return yaml.safe_load(stream)

--- a/rules/typescript.yaml
+++ b/rules/typescript.yaml
@@ -37,6 +37,20 @@ rules:
     # hancom/openxmlformats 등)인 경우. HWPX·OOXML·EPUB 은 XML 기반이라 네임스페이스가 도배된다.
     pattern-regex: '(?im)^(?![ \t]*(?://|\*|/\*))(?!.*\bxmlns\b).*["'']http://(?!localhost|127\.0\.0\.1|0\.0\.0\.0|schemas\.|xmlns|(?:www\.)?w3\.org|(?:[\w.]+\.)?apache\.org|[\w.]*xml\.org|java\.sun\.com|(?:www\.)?example\.(?:com|org)|(?:www\.)?unicode\.org|(?:www\.)?jflex\.de|purl\.org|iana\.org|ietf\.org|slf4j\.org|json-schema\.org|(?:www\.)?hancom\.(?:co\.kr|com)|(?:www\.)?idpf\.org|openxmlformats\.org|(?:www\.)?oasis-open\.org|dublincore\.org|docbook\.org)[^"'']+["'']'
 
+  # 금융 실시간 채널(시세·체결통보)은 대부분 웹소켓이고 접속키가 함께 흐른다 (#30).
+  # http-url 과 스킴만 다르고 예외 도메인 목록은 동일 — ws://localhost 개발 서버는 계속 제외된다.
+  # 접속 자격증명 동반 가능성이 높아 severity 는 ERROR 로 분리했다(http-url 은 WARNING 유지).
+  - id: finguard.ts.cleartext-websocket
+    languages: [regex]
+    severity: ERROR
+    message: 평문 WebSocket(ws://) 으로 통신하고 있습니다. 실시간 시세·체결통보 채널에는 접속키와 거래내역이 흐르므로 wss:// 로 전환해야 합니다.
+    paths:
+      include: ["*.ts", "*.tsx", "*.js", "*.jsx"]
+    # 평문 http 리터럴 검출. 단 XML 네임스페이스 URI(통신 주소가 아니라 스키마 식별자)는
+    # 제외한다 — 같은 줄에 xmlns 가 있거나, 잘 알려진 문서포맷 스키마 호스트(w3/apache/idpf/
+    # hancom/openxmlformats 등)인 경우. HWPX·OOXML·EPUB 은 XML 기반이라 네임스페이스가 도배된다.
+    pattern-regex: '(?im)^(?![ \t]*(?://|\*|/\*))(?!.*\bxmlns\b).*["'']ws://(?!localhost|127\.0\.0\.1|0\.0\.0\.0|schemas\.|xmlns|(?:www\.)?w3\.org|(?:[\w.]+\.)?apache\.org|[\w.]*xml\.org|java\.sun\.com|(?:www\.)?example\.(?:com|org)|(?:www\.)?unicode\.org|(?:www\.)?jflex\.de|purl\.org|iana\.org|ietf\.org|slf4j\.org|json-schema\.org|(?:www\.)?hancom\.(?:co\.kr|com)|(?:www\.)?idpf\.org|openxmlformats\.org|(?:www\.)?oasis-open\.org|dublincore\.org|docbook\.org)[^"'']+["'']'
+
   - id: finguard.ts.os-command-injection
     languages: [ts, js]
     severity: ERROR


### PR DESCRIPTION
Closes #30

## 문제

7개 언어의 `http-url` 룰이 전부 스킴을 `http://` 로 고정하고 있어 **`ws://` 가 전 언어에서 미탐**이었다.

금융권 실시간 시세·체결통보 채널은 대부분 웹소켓이고, 여기에는 접속 자격증명과 체결 내역이 함께 흐른다. 한국투자증권 `open-trading-api` 는 12개 파일에서 `ws://ops.koreainvestment.com:21000` 으로 `approval_key`(웹소켓 접속키)와 실시간 체결통보를 TLS 없이 주고받는데, 스캔에서 한 건도 잡히지 않았다.

## 설계 — 스킴 확장이 아니라 별도 룰

`http-url` 의 스킴을 `(?:http|ws)://` 로 넓히는 대신 `finguard.<lang>.cleartext-websocket` 을 신설했다.

| | 이유 |
| :--- | :--- |
| 이중 검출 방지 | 같은 룰을 확장하면 `ws://` 한 줄이 `http-url` 과 함께 두 번 코멘트된다 |
| 심각도 분리 | 웹소켓은 접속 자격증명 동반 가능성이 높다. `http-url` 은 WARNING 유지, 신규 룰은 **ERROR** |

정규식은 각 언어 `http-url` 의 **예외 도메인 목록을 그대로 승계**하고 스킴만 교체했다. `ws://localhost`·`ws://127.0.0.1` 개발 서버는 계속 제외된다.

대상 7개: `python` `ts` `java` `kotlin` `swift` `go` `shell`

## 매핑

`FIN-TLS-017` ~ `FIN-TLS-023` 7건 추가. `basis` 와 `kisa_item` 은 기존 `http-url` 엔트리 값을 **그대로 승계**했다 — 감사 대응 자료이므로 지어내지 않는다.

```
basis: 개발보안가이드 「보안기능 - 중요정보 평문 전송」
kisa_item: 전자금융기반시설 평가기준(2026) 웹·모바일·HTS 65 (통신구간 암호화 적용)
```

룰/매핑 정합성: **92 룰 · 92 매핑**, 누락·고아 0건.

## 검증

실코드 재스캔 — `koreainvestment/open-trading-api`:

| | 수정 전 | 수정 후 |
| :--- | ---: | ---: |
| `cleartext-websocket` 검출 | 0 | **12개 파일** |

검출된 파일은 캠페인 트리아지가 미탐으로 보고한 목록과 일치한다 (`legacy/websocket/python/` 10개 + `legacy/Sample01/kis_domstk_ws.py:484` · `kis_ovrseastk_ws.py:465`).

파이썬 픽스처:
- 정탐 `python_vulns.py:48` — `ws://ops.example-broker.co.kr:21000`
- 오탐 방지 `safe_python.py` — `wss://`, `ws://localhost:8765`, `ws://127.0.0.1:8765` 3종. **검출 0건 유지**

나머지 6개 언어는 별도 프로브 파일로 실측했다. 각 언어에서 평문 1줄만 검출하고 `wss://` 와 `ws://localhost` 는 건너뛴다.

| 언어 | 검출 | `wss://` | `ws://localhost` |
| :--- | :--- | :--- | :--- |
| ts · java · kotlin · swift · go · shell | 각 1건 | 미검출 | 미검출 |

명령별 결과:
- `semgrep --validate --config rules/` → **valid, 92 rules, 0 errors**
- `go build` · `go vet` · `go test -race` 전 패키지 통과
- `go test -tags semgrep_integration ./internal/scanner/` 통과 (기존 3종 회귀 없음)

## 남은 것

파이썬 외 6개 언어는 회귀 픽스처가 없다. 이 레포는 아직 `.py` · `.ts` · `.sh` 픽스처 인프라만 갖고 있어, 언어별 픽스처 확충은 별도로 다룬다(#20 과 같은 계열). 이번 PR 에서는 프로브 실측 결과를 위 표로 남긴다.

## 충돌 안내

PR #39(이슈 #26)도 `python_vulns.py` · `safe_python.py` · `integration_test.go` 를 수정한다. 두 PR 은 같은 픽스처의 다른 블록을 건드리므로, **나중에 머지되는 쪽에서 라인번호 기대값을 재조정**해야 한다.

## 출처

2026-08-17 국내 금융 도메인 레포 10개 스캔 캠페인 (P8). 3개 렌즈 적대적 검증 **3/3 통과**.

Made with [Orca](https://github.com/stablyai/orca) 🐋
