### PR TITLE
docs(#38): ATS 매핑 explain 을 Apple 플랫폼 전체로 정정

### DIFF
--- a/mapping/rules.yaml
+++ b/mapping/rules.yaml
@@ -106,7 +106,7 @@
   severity: ERROR
   basis: 개발보안가이드 「보안기능 - 중요정보 평문 전송」
   kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 65 (통신구간 암호화 적용)"
-  explain: NSAllowsArbitraryLoads=true 는 앱 전체에서 평문 HTTP 를 허용해 iOS 의 전송보안(ATS)을 무력화합니다. 예외가 필요하면 도메인 단위 예외로 좁혀야 합니다.
+  explain: NSAllowsArbitraryLoads=true 는 앱 전체에서 평문 HTTP 를 허용해 Apple 플랫폼(iOS/macOS/watchOS/tvOS)의 전송보안(ATS)을 무력화합니다. 예외가 필요하면 도메인 단위 예외로 좁혀야 합니다.
   fix_example: |
     ```xml
     <key>NSAppTransportSecurity</key>


### PR DESCRIPTION
Closes #38

## 문제

`finguard.plist.ats-arbitrary-loads` 는 `paths.include: ["*.plist"]` 라 **플랫폼을 가리지 않는다**(`rules/swift.yaml:77`). 그런데 매핑의 `explain` 은 iOS 만 언급했다.

```
iOS 의 전송보안(ATS)을 무력화합니다
```

ATS(App Transport Security)는 iOS·macOS·watchOS·tvOS 에 **동일하게 적용**된다. iOS 로만 서술하면 macOS 앱 담당자가 MR 코멘트를 보고 "우리는 해당 없음" 으로 넘길 수 있다.

이 룰은 2026-08-17 국내 금융 코퍼스 10개 스캔에서 **유일하게 나온 정탐**(`CoinNow/Info.plist:31`)을 만든 룰이다. 그 하나뿐인 신호가 문구 때문에 무시되면 도구의 존재 이유가 흔들린다.

## 수정

`explain` 첫 문장의 `iOS 의` → `Apple 플랫폼(iOS/macOS/watchOS/tvOS)의`.

`basis` 와 `kisa_item` 은 **손대지 않았다.** AGENTS.md 규약대로 근거는 매핑 테이블 값을 그대로 쓰며 감사 대응 자료이므로 임의로 바꾸지 않는다.

```
basis:     개발보안가이드 「보안기능 - 중요정보 평문 전송」   (불변)
kisa_item: 전자금융기반시설 평가기준(2026) 웹·모바일·HTS 65   (불변)
```

## 검증

- 변경 범위: `mapping/rules.yaml` **1줄**(`explain` 만). `git diff` 로 `basis`·`kisa_item` 무변경 확인
- `go test -race -mod=vendor ./internal/mapping/` 통과 (매핑 로더 파싱 정상)
- 룰 파일은 건드리지 않았으므로 검출 동작 변화 없음

## 범위 밖

이슈 본문은 `finguard.plist.ats-partial-exception`(부분 ATS 완화 키) 신설 시 같은 표현을 쓰라고 적고 있다. 그 룰은 **#33 에서 신설**되므로 매핑 문구도 거기서 함께 넣는다. 이 PR 은 기존 엔트리 정정만 다룬다.
