### PR TITLE
feat(#35): 와일드카드 CORS + allow_credentials 룰 신설

### DIFF
--- a/mapping/rules.yaml
+++ b/mapping/rules.yaml
@@ -1464,4 +1464,53 @@
     ```ts
     // 사설 CA 는 검증을 끄는 대신 CA 인증서를 신뢰 목록에 추가한다
     const agent = new https.Agent({ ca: fs.readFileSync("/etc/ssl/internal-ca.pem") });
+
+- rule_id: finguard.python.cors-wildcard-credentials
+  code: FIN-CORS-001
+  cwe: CWE-942
+  title: 과도하게 허용된 교차출처 정책(CORS)
+  severity: ERROR
+  basis: 개발보안가이드 「보안기능 - 부적절한 인가」
+  kisa_item: ""
+  explain: |
+    허용 오리진을 와일드카드(*)로 두면서 자격증명(쿠키·Authorization 헤더) 동반 요청까지 허용하고 있습니다.
+    Starlette/FastAPI 의 CORSMiddleware 는 이 조합에서 Access-Control-Allow-Origin 에 "*" 를 그대로 내보내지 않고
+    요청 Origin 을 그대로 반향(echo)하면서 Access-Control-Allow-Credentials: true 를 붙입니다. "브라우저가
+    와일드카드와 자격증명의 조합을 거부하므로 무해하다" 는 통념과 달리, 이용자가 임의의 웹페이지를 방문하는 것만으로
+    그 페이지가 이용자의 세션을 실어 조회·주문 엔드포인트를 호출할 수 있습니다.
+    인증이 요청별 자격증명이 아니라 프로세스 전역 로그인 플래그로 구현된 서버라면 운영자가 한 번 로그인한 이후
+    모든 요청이 인증된 것으로 처리되므로 영향이 더 큽니다. 해당 서비스가 외부 인터페이스에 바인딩되어 있는지
+    (예: 0.0.0.0 바인딩), 인증이 요청 단위로 검증되는지도 함께 확인하십시오.
+  fix_example: |
+    ```python
+    ALLOWED_ORIGINS = ["https://desk.example.com"]
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=ALLOWED_ORIGINS,   # 와일드카드 금지 — 명시적 화이트리스트
+        allow_credentials=True,
+        allow_methods=["GET", "POST"],
+        allow_headers=["Authorization", "Content-Type"],
+    )
+    ```
+
+- rule_id: finguard.python.cors-wildcard-origin
+  code: FIN-CORS-002
+  cwe: CWE-942
+  title: 모든 출처를 허용한 교차출처 정책(CORS)
+  severity: WARNING
+  basis: 개발보안가이드 「보안기능 - 부적절한 인가」
+  kisa_item: ""
+  explain: |
+    허용 오리진이 와일드카드(*)로 설정되어 있습니다. 자격증명 동반 요청은 허용하지 않으므로 브라우저가 쿠키·인증
+    헤더를 싣지 않지만, 인증 없이 접근 가능한 엔드포인트의 응답은 임의 웹페이지가 읽을 수 있습니다.
+    공개 API 가 아니라면 허용 오리진을 명시적 화이트리스트로 제한해야 하며, 이후 자격증명 허용이 추가되면
+    즉시 심각한 취약점(FIN-CORS-001)이 됩니다. 해당 서비스가 외부 인터페이스에 바인딩되어 있는 경우 위험이 가중됩니다.
+  fix_example: |
+    ```python
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["https://desk.example.com"],   # 와일드카드 금지
+        allow_methods=["GET"],
+    )
     ```

--- a/rules/python.yaml
+++ b/rules/python.yaml
@@ -135,3 +135,50 @@ rules:
       - pattern: yaml.load($X, Loader=yaml.Loader)
       - pattern: yaml.load($X, Loader=yaml.UnsafeLoader)
       - pattern: yaml.unsafe_load(...)
+
+  # 와일드카드 CORS + 자격증명 허용 (#35).
+  # Starlette CORSMiddleware 는 allow_origins=["*"] 와 allow_credentials=True 가 함께 오면
+  # Access-Control-Allow-Origin 에 "*" 를 그대로 쓰지 않고 요청 Origin 을 반향(echo)하면서
+  # Access-Control-Allow-Credentials: true 를 붙인다. "브라우저가 와일드카드+자격증명을
+  # 거부하니 무해하다" 는 통념과 달리 임의 오리진이 자격증명 동반 요청에 성공한다.
+  # 화이트리스트를 쓰는 정상 구현은 $O 조건에서 자연 제외된다.
+  - id: finguard.python.cors-wildcard-credentials
+    languages: [python]
+    severity: ERROR
+    message: 모든 오리진을 허용(*)하면서 자격증명(쿠키·인증헤더) 동반 요청까지 허용하고 있습니다. 임의 웹페이지가 이용자의 브라우저를 통해 인증된 엔드포인트를 호출할 수 있습니다. 허용 오리진을 명시적 화이트리스트로 제한해야 합니다.
+    paths:
+      exclude: ["test_*.py", "*_test.py", "conftest.py"]
+    patterns:
+      - pattern-either:
+          - pattern: $APP.add_middleware(CORSMiddleware, ..., allow_origins=$O, ..., allow_credentials=True, ...)
+          - pattern: CORSMiddleware(..., allow_origins=$O, ..., allow_credentials=True, ...)
+          - pattern: CORS(..., origins=$O, ..., supports_credentials=True, ...)
+      - metavariable-pattern:
+          metavariable: $O
+          pattern-either:
+            - pattern: '["*"]'
+            - pattern: '"*"'
+
+  # 자격증명 없는 와일드카드 CORS (#35).
+  # 브라우저가 쿠키·Authorization 헤더를 싣지 않으므로 위험도가 다르다 — 게이트를 막지
+  # 않도록 WARNING 으로 분리한다. 자격증명까지 허용하는 경우는 위 ERROR 룰이 잡는다.
+  - id: finguard.python.cors-wildcard-origin
+    languages: [python]
+    severity: WARNING
+    message: 모든 오리진(*)에 CORS 를 허용하고 있습니다. 인증이 필요 없는 공개 API 가 아니라면 허용 오리진을 명시적 화이트리스트로 제한해야 합니다.
+    paths:
+      exclude: ["test_*.py", "*_test.py", "conftest.py"]
+    patterns:
+      - pattern-either:
+          - pattern: $APP.add_middleware(CORSMiddleware, ..., allow_origins=$O, ...)
+          - pattern: CORSMiddleware(..., allow_origins=$O, ...)
+          - pattern: CORS(..., origins=$O, ...)
+      - metavariable-pattern:
+          metavariable: $O
+          pattern-either:
+            - pattern: '["*"]'
+            - pattern: '"*"'
+      # 자격증명까지 허용하는 조합은 cors-wildcard-credentials(ERROR) 담당 — 중복 코멘트 방지
+      - pattern-not: $APP.add_middleware(CORSMiddleware, ..., allow_credentials=True, ...)
+      - pattern-not: CORSMiddleware(..., allow_credentials=True, ...)
+      - pattern-not: CORS(..., supports_credentials=True, ...)

--- a/testdata/rule-fixtures/python_cors.py
+++ b/testdata/rule-fixtures/python_cors.py
@@ -1,0 +1,44 @@
+# 룰 회귀 픽스처 — finguard.python.cors-wildcard-credentials / cors-wildcard-origin (#35)
+#
+# 기대값은 검출이 기대되는 줄 바로 위의 EXPECT 마커에 적는다.
+# semgrep 은 여러 줄에 걸친 호출을 호출 시작 줄로 보고하므로 마커는 호출 첫 줄 위에 둔다.
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from flask import Flask
+from flask_cors import CORS
+
+app = FastAPI()
+
+# 와일드카드 + 자격증명 — 요청 Origin 반향으로 실제 악용 가능
+# EXPECT: finguard.python.cors-wildcard-credentials
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# 키워드 인자 순서를 뒤집어도 같은 취약점이다
+# EXPECT: finguard.python.cors-wildcard-credentials
+app.add_middleware(
+    CORSMiddleware,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_origins=["*"],
+)
+
+flask_app = Flask(__name__)
+# EXPECT: finguard.python.cors-wildcard-credentials
+CORS(flask_app, origins="*", supports_credentials=True)
+
+# 자격증명 없는 와일드카드 — 위험도가 달라 WARNING 으로 분리된다
+# EXPECT: finguard.python.cors-wildcard-origin
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["GET"],
+)
+
+# EXPECT: finguard.python.cors-wildcard-origin
+CORS(flask_app, origins=["*"])

--- a/testdata/rule-fixtures/safe_python_cors.py
+++ b/testdata/rule-fixtures/safe_python_cors.py
@@ -1,0 +1,40 @@
+# 대조군 픽스처 — 어떤 룰에도 걸리면 안 된다 (#35).
+# 오리진 화이트리스트를 쓰는 정상 구현. safe_ 접두라 EXPECT 마커를 가질 수 없다.
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from flask import Flask
+from flask_cors import CORS
+
+app = FastAPI()
+
+ALLOWED_ORIGINS = [
+    "https://ops.example.com",
+    "https://desk.example.com",
+]
+
+# 자격증명을 허용하지만 오리진은 명시적 화이트리스트다
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=ALLOWED_ORIGINS,
+    allow_credentials=True,
+    allow_methods=["GET", "POST"],
+    allow_headers=["Authorization"],
+)
+
+# 리터럴 화이트리스트도 마찬가지로 정상이다
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["https://desk.example.com"],
+    allow_credentials=True,
+)
+
+flask_app = Flask(__name__)
+CORS(flask_app, origins=["https://ops.example.com"], supports_credentials=True)
+
+# 메서드만 와일드카드인 경우는 오리진 통제와 무관하다
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["https://ops.example.com"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)


### PR DESCRIPTION
Closes #35

FastAPI/Starlette·Flask-CORS 의 와일드카드 CORS 설정을 위험도별로 두 룰로 분리해 신설한다.

## 신설 룰

| 룰 ID | severity | 조건 |
| :--- | :--- | :--- |
| `finguard.python.cors-wildcard-credentials` | ERROR | `allow_origins=["*"]`(또는 `"*"`) + `allow_credentials=True` / flask-cors `origins="*"` + `supports_credentials=True` |
| `finguard.python.cors-wildcard-origin` | WARNING | 와일드카드 오리진 단독(자격증명 허용 없음) |

허용 오리진 판정은 `metavariable-pattern` 으로 리터럴 `["*"]` / `"*"` 일 때만 발화한다. 화이트리스트 상수나 리터럴 도메인 배열을 넘기는 정상 구현은 조건에서 자연 제외된다.

매핑은 `FIN-CORS-001` / `FIN-CORS-002` (CWE-942) 두 항목을 추가했다. 룰 94개 : 매핑 94개로 1:1 유지.

## 검증에서 나온 반박 반영 내역

1. **"브라우저가 와일드카드+자격증명을 거부하니 무해하다"는 오판 차단** (재현율 수호자·규제 심사관 공통 지적) — Starlette `CORSMiddleware` 는 이 조합에서 `Access-Control-Allow-Origin: *` 를 내보내지 않고 **요청 Origin 을 그대로 반향(echo)** 하면서 `Access-Control-Allow-Credentials: true` 를 붙인다. 이 메커니즘을 매핑 `explain` 본문에 명시해 리뷰어가 정탐을 오판으로 종결하지 못하게 했다.
2. **"같은 파일의 `uvicorn.run(host="0.0.0.0")` 여부를 explain 에 넣는다"는 원안은 구현 불가** — `explain` 은 스캔 대상과 무관한 정적 문구이고 semgrep 이 그 조건을 룰 밖으로 전달하지 않는다. 파일별 사실을 단정하는 대신 **"외부 인터페이스에 바인딩되어 있는지 함께 확인하십시오"** 라는 조건부 안내로만 서술했다(`mapping/rules.yaml` 헤더의 임의 생성 금지 규약 준수).
3. **위험도 분리** — 자격증명 없는 와일드카드는 WARNING 별도 룰로 분리해 기본 차단 게이트(`FINGUARD_BLOCK_ON=ERROR`)를 막지 않는다. 두 룰이 같은 줄에 이중 코멘트를 달지 않도록 WARNING 룰에 `pattern-not` 으로 자격증명 조합을 제외했다.
4. **`kisa_item` 은 빈 문자열** — 평가기준 66항목(`docs/평가기준_웹모바일HTS_66항목.md`)에 CORS 대응 항목을 확실히 특정할 수 없어, 기존 선례(`mapping/rules.yaml` 의 `kisa_item: ""`)를 따라 비워 두었다. `basis` 는 개발보안가이드의 실재 항목 「보안기능 - 부적절한 인가」를 사용했다.

## 실코드 검증 — 코퍼스 10개 수정 전/후 검출 수

| 레포 | 수정 전 | 수정 후 | 증감 |
| :--- | ---: | ---: | ---: |
| r0 koreainvestment/open-trading-api (Python) | 40 | 42 | +2 |
| r1 samchon/payments (TS) | 0 | 0 | 0 |
| r2 CoinNow (Swift) | 1 | 1 | 0 |
| r3 DuDoong-Backend (Kotlin) | 5 | 5 | 0 |
| r4 iamport-python | 0 | 0 | 0 |
| r5 AXSnapshot (Swift) | 0 | 0 | 0 |
| r6 reactive-crypto (Kotlin) | 0 | 0 | 0 |
| r7 pybithumb (Python) | 0 | 0 | 0 |
| r8 iamport-java | 0 | 0 | 0 |
| r9 upbitBar (Swift) | 0 | 0 | 0 |
| **합계** | **46** | **48** | **+2** |

새로 검출된 2건은 전부 `cors-wildcard-credentials` 정탐이다.

- `strategy_builder/backend/main.py:25` — `allow_origins=["*"]` + `allow_credentials=True`. 같은 앱이 `/api/orders/execute`·`/api/orders/cancel`·`/api/account` 를 노출한다.
- `MCP/KIS Code Assistant MCP/server.py:825` — 동일 조합.

대조군인 `backtester/backend/main.py:82`(오리진 화이트리스트 상수)는 **검출되지 않았다**. 같은 레포 안에서 정탐 2 / 오탐 0 이 실증된다. WARNING 룰(`cors-wildcard-origin`)은 코퍼스에서 발화 0건이라 노이즈 증가가 없다.

## 변이 시험

| 변이 | 기대 | 결과 |
| :--- | :--- | :--- |
| `python_cors.py` 첫 블록의 EXPECT 마커 제거 | 오탐 회귀로 실패 | `오탐 회귀 — 마커가 없는데 검출됐다: python_cors.py:13 finguard.python.cors-wildcard-credentials` → FAIL |
| `safe_python_cors.py` 의 화이트리스트 블록에 마커 추가 | 미탐 회귀 + 대조군 위반으로 실패 | `미탐 회귀 — 마커가 있는데 검출되지 않았다: safe_python_cors.py:25 ...` + `TestSafeFixturesHaveNoExpectations` FAIL |

두 변이 모두 원복 후 전체 통과를 재확인했다.

## 일부러 넣지 않은 패턴과 이유

- **`allow_origin_regex=".*"`** — 정규식 와일드카드 판정은 `.*`·`.+`·`^.*$` 등 변형이 많고 부분 매칭 정규식(예: `https://.*\.example\.com`)과 구분이 필요해, 근거가 되는 실코드 사례가 확보되기 전에는 넣지 않았다.
- **`allow_methods=["*"]` / `allow_headers=["*"]` 단독** — 오리진이 통제되면 메서드·헤더 와일드카드만으로는 교차출처 위협이 성립하지 않는다. 대조군 픽스처에 이 형태를 넣어 검출되지 않음을 고정했다.
- **`Access-Control-Allow-Origin: *` 를 응답 헤더에 직접 넣는 형태** — 미들웨어 설정과 달리 프레임워크·헬퍼가 제각각이라 이번 스코프에서 분리했다.
- **다른 언어(Java·Kotlin·TS)의 동등 설정** — 이번 PR 은 `rules/python.yaml` 단일 파일 스코프로 제한한다.

## 검증 결과

- `semgrep --validate --config rules/` → `Configuration is valid - found 0 configuration error(s), and 94 rule(s).`
- `go build -mod=vendor ./... && go vet -mod=vendor ./...` → 통과
- `go test -race -mod=vendor ./...` → 전 패키지 ok
- `go test -race -mod=vendor -tags semgrep_integration ./internal/scanner/` → ok
