### PR TITLE
feat(#28): Kotlin 서버(Spring Boot) 룰 보강 — Android 전용 룰셋의 사각지대 해소

### DIFF
--- a/mapping/rules.yaml
+++ b/mapping/rules.yaml
@@ -1291,3 +1291,104 @@
     # 올바른 예 — TLS 적용
     url = "wss://ops.example.com:21000"
     ```
+
+# ── Kotlin 서버(Spring Boot) 룰 (#28) ────────────────────────────────────────
+# basis·kisa_item 은 같은 CWE 의 기존 엔트리 값을 그대로 승계한다. 승계할 기존
+# 엔트리가 없는 항목(CWE-489·CWE-209)의 kisa_item 은 FIN-AND-001 과 같이 비워 둔다 —
+# 감사 대응 자료이므로 근거를 지어내지 않는다.
+
+- rule_id: finguard.kotlin.feign-full-logging
+  code: FIN-LOG-004
+  cwe: CWE-532
+  title: 로그 중요정보 노출(Feign 전체 로깅)
+  severity: WARNING
+  basis: 개발보안가이드 「에러처리 - 오류 메시지 정보노출」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 59 (디버그 로그 내 중요정보 노출 방지)"
+  explain: Feign 로깅 레벨이 FULL(또는 HEADERS)이면 요청·응답의 헤더와 본문이 통째로 로그에 남습니다. PG·오픈뱅킹 연동 클라이언트에서는 Authorization 헤더와 결제 응답 본문이 그대로 흘러 들어갑니다.
+  fix_example: |
+    ```kotlin
+    // 운영 프로파일은 BASIC 이하로. 본문·헤더는 남기지 않는다.
+    @Bean
+    fun feignLoggerLevel(): Logger.Level = Logger.Level.BASIC
+    ```
+
+- rule_id: finguard.kotlin.dev-backdoor-endpoint
+  code: FIN-DBG-001
+  cwe: CWE-489
+  title: 개발용 인증 우회 엔드포인트 잔존(Kotlin)
+  severity: ERROR
+  basis: 개발보안가이드 「캡슐화 - 제거되지 않고 남은 디버그 코드」
+  kisa_item: ""
+  explain: 개발·로컬 전용 로그인/토큰 발급 엔드포인트가 소스에 남아 있습니다. 운영 배포본에 함께 나가면 정상 인증 절차를 우회해 임의 계정의 토큰을 발급받을 수 있습니다.
+  fix_example: |
+    ```kotlin
+    // 개발 전용 컨트롤러는 프로파일로 격리해 운영 컨텍스트에 등록되지 않게 한다
+    @Profile("local", "dev")
+    @RestController
+    class LocalLoginController { /* ... */ }
+    ```
+
+- rule_id: finguard.kotlin.stacktrace-exposure
+  code: FIN-LOG-005
+  cwe: CWE-209
+  title: 스택트레이스 노출(Kotlin)
+  severity: WARNING
+  basis: 개발보안가이드 「에러처리 - 오류 메시지 정보노출」
+  kisa_item: ""
+  explain: printStackTrace 는 예외 내부 구조(쿼리문·파일 경로·라이브러리 버전)를 표준에러로 직접 출력해 로깅 파이프라인의 마스킹·보존 정책을 우회합니다. 로거로 보내고 사용자 응답에는 내부 정보를 포함하지 않아야 합니다.
+  fix_example: |
+    ```kotlin
+    } catch (e: MessagingException) {
+        log.warn("메일 발송 실패: {}", e.javaClass.simpleName)  // 스택은 로거에만
+        throw MailSendFailedException()
+    }
+    ```
+
+- rule_id: finguard.kotlin.path-traversal
+  code: FIN-PATH-006
+  cwe: CWE-22
+  title: 경로 조작 및 자원 삽입(Kotlin)
+  severity: ERROR
+  basis: 개발보안가이드 「입력데이터 검증 및 표현 - 경로 조작 및 자원 삽입」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 28 (파일 다운로드)"
+  explain: 외부 입력이 검증 없이 파일 경로로 사용되어 기준 디렉터리 밖의 파일에 접근할 수 있습니다.
+  fix_example: |
+    ```kotlin
+    val safeName = File(requested).name              // basename 만 취한다
+    val base = File("/data/statements").canonicalFile
+    val target = File(base, safeName).canonicalFile
+    require(target.toPath().startsWith(base.toPath())) { "경로 이탈" }
+    ```
+
+- rule_id: finguard.kotlin.ssrf
+  code: FIN-SSRF-004
+  cwe: CWE-918
+  title: 서버측 요청 위조(Kotlin)
+  severity: WARNING
+  basis: 개발보안가이드 「입력데이터 검증 및 표현 - 서버사이드 요청 위조」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 61 (서버 사이드 요청 위조 (SSRF))"
+  explain: 외부 입력이 서버가 호출할 URL 로 사용되어 내부망 자원에 접근될 수 있습니다.
+  fix_example: |
+    ```kotlin
+    val u = URL(target)
+    require(u.host in ALLOWED_HOSTS) { "허용되지 않은 호스트" }
+    u.readText()
+    ```
+
+- rule_id: finguard.kotlin.open-redirect
+  code: FIN-REDIR-004
+  cwe: CWE-601
+  title: 검증되지 않은 리다이렉트(Kotlin)
+  severity: WARNING
+  basis: 개발보안가이드 「입력데이터 검증 및 표현 - 신뢰되지 않는 URL 주소로 자동접속 연결」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 34 (리다이렉트 기능을 이용한 피싱 공격)"
+  explain: 외부 입력이 리다이렉트 대상 URL 로 사용되어 피싱 사이트로 유도될 수 있습니다.
+  fix_example: |
+    ```kotlin
+    val dest = when (next) {
+        "home" -> "/home"
+        "mypage" -> "/mypage"
+        else -> "/home"
+    }
+    response.sendRedirect(dest)
+    ```

--- a/rules/kotlin.yaml
+++ b/rules/kotlin.yaml
@@ -16,14 +16,18 @@ rules:
       - pattern-not-regex: '(?i)["''`](\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|<[^>]*redact[^>]*>|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]|[:=]\s*(\*{3,}|•{3,}|#{3,})(?![\w-])'
 
   # 2. 취약 해시 (CWE-328)
+  #   - MessageDigest/Mac 직접 호출 외에, 알고리즘명을 문자열로 받는 사내 래퍼
+  #     (CryptUtil.encrypt("MD5", ...) 류)와 DigestUtils.md5Hex 계열까지 본다 (#28).
+  #     거래소 서명 유틸이 이 형태로 MD5 를 쓰고 있었는데 기존 패턴은 전혀 보지 못했다.
+  #   - \s 는 개행을 포함하므로 인자가 다음 줄로 넘어가도 매칭된다.
   - id: finguard.kotlin.weak-hash
     languages: [regex]
     severity: WARNING
-    message: 취약한 해시 알고리즘(MD5/SHA-1)을 사용하고 있습니다. SHA-256 이상을 사용해야 합니다.
+    message: 취약한 해시 알고리즘(MD5/SHA-1)을 사용하고 있습니다. SHA-256 이상(서명은 HMAC-SHA256)을 사용해야 합니다.
     paths:
       include: ["*.kt", "*.kts"]
       exclude: ["*Test.kt", "*Test.kts"]
-    pattern-regex: 'MessageDigest\.getInstance\(\s*"(?i:MD5|SHA-?1)"'
+    pattern-regex: '(?:MessageDigest|Mac)\.getInstance\(\s*"(?i:MD5|SHA-?1|HmacMD5|HmacSHA-?1)"|\b(?:DigestUtils|Hashing)\.(?:md5|sha1)\w*\s*\(|\b\w*(?i:digest|hash|encrypt|sign|hmac)\w*\s*\(\s*"(?i:MD5|SHA-?1|HmacMD5|HmacSHA-?1)"'
 
   # 3. 취약 암호 알고리즘/운영모드 (CWE-327)
   #   - DES/RC4/Blowfish, 블록암호 ECB. RSA/ECB(JCA 표기 관행)는 제외.
@@ -51,6 +55,15 @@ rules:
     pattern-regex: '(?im)^(?![ \t]*(?://|\*))(?:.*\b)?(?:\b(?:iv|key|seed)\b|\w*(?:securekey|secretkey|seckey|sessionkey|privatekey|cryptokey|token|salt|nonce|otp|passwd|password|secret)\w*)\s*(?:\[[^\]]*\])?\s*[-+]?=\s*[^=][^;\n]*\b(?:Math\.random\s*\(|java\.util\.Random\s*\(|kotlin\.random\.Random\b|(?<!Secure)Random\s*\()'
 
   # 5. 민감정보 로깅 (CWE-532)
+  #   - 싱크를 Android Log.* 에서 서버측 로깅(slf4j log/logger.*, println, System.out.print*)
+  #     까지 넓혔다 (#28). Kotlin Spring Boot 백엔드는 Log.d 를 쓰지 않아 종전 패턴이
+  #     한 건도 발화하지 않았다.
+  #   - 오탐 억제는 "라인 단위 mask/redact 어휘 제외" 를 쓰지 않는다. 검증에서
+  #     log.debug("card=${mask(cardNo)}, password=$password") 처럼 한 필드만 마스킹하고
+  #     다른 필드를 흘리는 라인을 통째로 지운다는 반박이 나왔다 — 마스킹 누락은 보통
+  #     이 부분 마스킹 형태로 나타난다.
+  #   - availableTokens/tokenBucket 등 레이트리밋 식별자는 어휘 조건이 \btoken\b 경계라
+  #     애초에 매칭되지 않는다(제외 목록 불필요). 회귀는 safe_kotlin_server.kt 로 고정.
   - id: finguard.kotlin.log-sensitive
     languages: [regex]
     severity: WARNING
@@ -58,19 +71,21 @@ rules:
     paths:
       include: ["*.kt", "*.kts"]
       exclude: ["*Test.kt", "*Test.kts"]
-    pattern-regex: '(?im)^(?![ \t]*(?://|\*)).*\bLog\.[dviwe]\s*\((?:(?:"(?:\\.|[^"\\\n])*"|[^"\n])*?\b(?:password|passwd|secret|token|pin|ssn|dataBody|responseBody)\b|[^\n]*?\$\{?[\w.]*\b(?:password|passwd|secret|token|pin|ssn|dataBody|responseBody)\b)'
+    pattern-regex: '(?im)^(?![ \t]*(?://|\*)).*\b(?:Log\.[dviwe]|log(?:ger)?\.(?:trace|debug|info|warn|error)|println|System\.out\.print(?:ln)?)\s*\((?:(?:"(?:\\.|[^"\\\n])*"|[^"\n])*?\b(?:password|passwd|secret|token|pin|ssn|dataBody|responseBody)\b|[^\n]*?\$\{?[\w.]*\b(?:password|passwd|secret|token|pin|ssn|dataBody|responseBody)\b)'
 
   # 6. SQL 문자열 조립 (CWE-89)
-  #   - rawQuery/execSQL 에 문자열 템플릿($var) 또는 + 연결.
+  #   - rawQuery/execSQL(Android) 에 더해 서버측 싱크(JPA createQuery/createNativeQuery,
+  #     Hibernate createSQLQuery, Spring jdbcTemplate.*)를 추가했다 (#28).
+  #   - 문자열 템플릿($var) 또는 + 연결이 싱크 인자에 직접 붙은 경우만.
   #   - ? 바인딩(PreparedStatement 대응)은 제외. 주석(//) 제외.
   - id: finguard.kotlin.sql-raw
     languages: [regex]
     severity: ERROR
-    message: SQL 문을 문자열 조립(템플릿·연결)으로 만들고 있습니다. 파라미터 바인딩(?, selectionArgs)을 사용해야 합니다.
+    message: SQL 문을 문자열 조립(템플릿·연결)으로 만들고 있습니다. 파라미터 바인딩(?, selectionArgs, setParameter)을 사용해야 합니다.
     paths:
       include: ["*.kt", "*.kts"]
       exclude: ["*Test.kt", "*Test.kts"]
-    pattern-regex: '(?im)^(?![ \t]*(?://|\*)).*\b(?:rawQuery|execSQL)\s*\(\s*(?:"[^"]*\$\{?[A-Za-z_][^"]*"|"[^"]*"\s*\+|[^,()]*\+\s*"[^"]*")'
+    pattern-regex: '(?im)^(?![ \t]*(?://|\*)).*\b(?:rawQuery|execSQL|createQuery|createNativeQuery|createSQLQuery|jdbcTemplate\.(?:query|update|execute|queryForObject|queryForList|queryForMap|batchUpdate))\s*\(\s*(?:"[^"]*\$\{?[A-Za-z_][^"]*"|"[^"]*"\s*\+|[^,()]*\+\s*"[^"]*")'
 
   # 7. WebView JavaScript 활성화 (CWE-749)
   - id: finguard.kotlin.webview-js-enabled
@@ -162,3 +177,163 @@ rules:
     paths:
       include: ["*.kt", "*.java"]
     pattern-regex: 'PendingIntent\.(?:getActivity|getService|getBroadcast|getForegroundService)\([^;]*FLAG_MUTABLE'
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # Kotlin 서버(Spring Boot) 룰 (#28)
+  #
+  # 위 14개 룰은 전부 Android 관용구라 Kotlin 백엔드에서 한 건도 발화하지 않았다.
+  # 아래는 서버측 전용이며, taint 룰은 languages:[kotlin] 로 Kotlin 문법 그대로 작성한다.
+  # java.yaml 의 taint 룰에 `kotlin` 을 얹는 방식은 쓰지 않았다 — 그 패턴들이
+  # `new File(...)` 처럼 Kotlin 에 없는 `new` 생성자 문법에 의존해 Kotlin 파일에서는
+  # 0 findings 이고, Java 검출까지 흔들 위험만 있다(이슈 #28 검증 절).
+  # ──────────────────────────────────────────────────────────────────────────
+
+  # 15. Feign/HTTP 클라이언트 전체 로깅 (CWE-532)
+  #   - feign Logger.Level.FULL 은 요청·응답의 헤더와 본문을 통째로 로그에 남긴다.
+  #     PG·오픈뱅킹 연동 클라이언트에서는 Authorization 헤더와 결제 응답이 그대로 흐른다.
+  - id: finguard.kotlin.feign-full-logging
+    languages: [regex]
+    severity: WARNING
+    message: Feign 로깅 레벨이 FULL 입니다. 요청·응답 헤더와 본문이 통째로 로그에 남아 연동 시크릿(Authorization)·결제 응답이 노출됩니다. BASIC 이하로 낮추거나 민감 헤더를 마스킹해야 합니다.
+    paths:
+      include: ["*.kt", "*.kts"]
+      exclude: ["*Test.kt", "*Test.kts"]
+    pattern-regex: '(?m)^(?![ \t]*(?://|\*)).*\bLogger\.Level\.(?:FULL|HEADERS)\b'
+
+  # 16. 배포본에 남은 개발용 인증 우회 엔드포인트 (CWE-489)
+  #   - 매핑 경로에 dev/local/test/debug 세그먼트가 있고 인증 관련 어휘가 함께 오는 경우.
+  #   - 일반 업무 API(/api/v1/events 등)는 dev 세그먼트가 없어 걸리지 않는다.
+  - id: finguard.kotlin.dev-backdoor-endpoint
+    languages: [regex]
+    severity: ERROR
+    message: 개발·로컬 전용 인증 우회 엔드포인트가 소스에 남아 있습니다. 프로파일 분리로 운영 배포본에서 제거하거나 별도 인증을 걸어야 합니다.
+    paths:
+      include: ["*.kt", "*.kts"]
+      exclude: ["*Test.kt", "*Test.kts"]
+    pattern-regex: '(?im)^(?![ \t]*(?://|\*)).*@(?:Get|Post|Put|Patch|Delete|Request)Mapping\s*\(\s*(?:value\s*=\s*)?"[^"]*/(?:dev|develop|local|test|debug|stub|mock)[\w-]*/[^"]*(?:login|signin|token|auth|admin|impersonat|su)[^"]*"'
+
+  # 17. 스택트레이스 노출 (CWE-209)
+  #   - printStackTrace 는 예외 내부 구조(쿼리·경로·라이브러리 버전)를 표준에러로 흘리고
+  #     로깅 파이프라인을 우회해 마스킹도 적용되지 않는다.
+  - id: finguard.kotlin.stacktrace-exposure
+    languages: [regex]
+    severity: WARNING
+    message: printStackTrace 로 예외 스택트레이스를 그대로 출력하고 있습니다. 로거로 보내고 사용자 응답에는 내부 정보를 포함하지 않아야 합니다.
+    paths:
+      include: ["*.kt", "*.kts"]
+      exclude: ["*Test.kt", "*Test.kts"]
+    pattern-regex: '(?m)^(?![ \t]*(?://|\*)).*\.printStackTrace\s*\('
+
+  # 18. 경로 조작 및 자원 삽입 (CWE-22) — Kotlin taint
+  #   - OS 명령 삽입은 별도 taint 룰을 두지 않는다. 위 finguard.kotlin.os-command 가
+  #     이미 모든 Runtime.exec/ProcessBuilder 를 ERROR 로 잡고 있어 같은 줄에 코멘트만
+  #     두 번 달린다.
+  - id: finguard.kotlin.path-traversal
+    languages: [kotlin]
+    severity: ERROR
+    message: 외부 입력이 검증 없이 파일 경로로 사용되고 있습니다. 파일명만 취해(basename) 기준 디렉터리 하위인지 정규화 후 확인해야 합니다.
+    paths:
+      include: ["*.kt", "*.kts"]
+      exclude: ["*Test.kt", "*Test.kts"]
+    mode: taint
+    pattern-sources:
+      - pattern: $REQ.getParameter(...)
+      - pattern: $REQ.getHeader(...)
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  fun $F(..., @$ANN $X : $T, ...) { ... }
+              - pattern-inside: |
+                  fun $F(..., @$ANN $X : $T, ...) = ...
+              - pattern-inside: |
+                  fun $F(..., @$ANN(...) $X : $T, ...) { ... }
+              - pattern-inside: |
+                  fun $F(..., @$ANN(...) $X : $T, ...) = ...
+          - metavariable-regex:
+              metavariable: $ANN
+              regex: ^(RequestParam|PathVariable|RequestHeader|CookieValue|ModelAttribute|RequestPart)$
+          - pattern: $X
+    pattern-sanitizers:
+      # basename 만 취한 값은 상위 경로(..)를 벗어날 수 없다.
+      - pattern: FilenameUtils.getName(...)
+      - pattern: File(...).name
+      - pattern: $P.fileName
+    pattern-sinks:
+      # File(x).name 처럼 basename 추출 목적의 생성은 싱크가 아니다.
+      - patterns:
+          - pattern-either:
+              - pattern: File(...)
+              - pattern: FileInputStream(...)
+              - pattern: FileOutputStream(...)
+              - pattern: Paths.get(...)
+          - pattern-not-inside: File(...).name
+          - pattern-not-inside: FilenameUtils.getName(...)
+
+  # 19. 서버측 요청 위조 (CWE-918) — Kotlin taint
+  - id: finguard.kotlin.ssrf
+    languages: [kotlin]
+    severity: WARNING
+    message: 외부 입력이 서버가 호출할 URL 로 사용되고 있습니다. 호스트 허용목록으로 제한해야 합니다.
+    paths:
+      include: ["*.kt", "*.kts"]
+      exclude: ["*Test.kt", "*Test.kts"]
+    mode: taint
+    pattern-sources:
+      - pattern: $REQ.getParameter(...)
+      - pattern: $REQ.getHeader(...)
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  fun $F(..., @$ANN $X : $T, ...) { ... }
+              - pattern-inside: |
+                  fun $F(..., @$ANN $X : $T, ...) = ...
+              - pattern-inside: |
+                  fun $F(..., @$ANN(...) $X : $T, ...) { ... }
+              - pattern-inside: |
+                  fun $F(..., @$ANN(...) $X : $T, ...) = ...
+          - metavariable-regex:
+              metavariable: $ANN
+              regex: ^(RequestParam|PathVariable|RequestHeader|CookieValue|ModelAttribute|RequestPart)$
+          - pattern: $X
+    # 싱크는 "URL 생성" 이 아니라 "실제 호출" 이다. URL(target) 만 만들고 호스트
+    # 허용목록을 검사하는 정상 코드가 흔해서, 생성 자체를 싱크로 두면 오탐이 된다.
+    pattern-sinks:
+      - pattern: URL(...).readText(...)
+      - pattern: URL(...).readBytes(...)
+      - pattern: $U.openConnection(...)
+      - pattern: $U.openStream(...)
+      - pattern: $RT.getForObject(...)
+      - pattern: $RT.getForEntity(...)
+      - pattern: $RT.postForObject(...)
+      - pattern: $RT.postForEntity(...)
+      - pattern: $RT.exchange(...)
+
+  # 20. 검증되지 않은 리다이렉트 (CWE-601) — Kotlin taint
+  - id: finguard.kotlin.open-redirect
+    languages: [kotlin]
+    severity: WARNING
+    message: 외부 입력이 리다이렉트 대상 URL 로 사용되고 있습니다. 상대경로 허용목록으로 제한해야 합니다.
+    paths:
+      include: ["*.kt", "*.kts"]
+      exclude: ["*Test.kt", "*Test.kts"]
+    mode: taint
+    pattern-sources:
+      - pattern: $REQ.getParameter(...)
+      - pattern: $REQ.getHeader(...)
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  fun $F(..., @$ANN $X : $T, ...) { ... }
+              - pattern-inside: |
+                  fun $F(..., @$ANN $X : $T, ...) = ...
+              - pattern-inside: |
+                  fun $F(..., @$ANN(...) $X : $T, ...) { ... }
+              - pattern-inside: |
+                  fun $F(..., @$ANN(...) $X : $T, ...) = ...
+          - metavariable-regex:
+              metavariable: $ANN
+              regex: ^(RequestParam|PathVariable|RequestHeader|CookieValue|ModelAttribute|RequestPart)$
+          - pattern: $X
+    pattern-sinks:
+      - pattern: $RESP.sendRedirect(...)
+      - pattern: RedirectView(...)

--- a/testdata/rule-fixtures/kotlin_server_vulns.kt
+++ b/testdata/rule-fixtures/kotlin_server_vulns.kt
@@ -1,0 +1,182 @@
+// Kotlin Spring Boot 백엔드 취약 패턴 픽스처 (#28).
+// 기존 kotlin 룰은 전부 Android 관용구라 이런 서버 코드에서 한 건도 발화하지 않았다.
+// 기대값은 검출 줄 바로 위의 EXPECT 마커에 적는다.
+
+package fixtures.kotlin.server
+
+import feign.Logger
+import java.io.File
+import java.io.FileInputStream
+import java.net.URL
+import java.security.MessageDigest
+import javax.crypto.Mac
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+private val log = LoggerFactory.getLogger("fixture")
+
+// ── 서버측 민감정보 로깅 (log-sensitive 싱크 확장) ───────────────────────────
+
+class LoggingSamples {
+
+    fun issueToken(token: String, password: String, secret: String) {
+        // EXPECT: finguard.kotlin.log-sensitive
+        log.info("issued: $token")
+        // EXPECT: finguard.kotlin.log-sensitive
+        log.debug("login password=$password")
+        // EXPECT: finguard.kotlin.log-sensitive
+        println("client secret=$secret")
+        // EXPECT: finguard.kotlin.log-sensitive
+        System.out.println("pin=$password")
+    }
+
+    // 부분 마스킹 — 카드번호는 가렸지만 password 는 그대로 흐른다.
+    // 라인에 mask 어휘가 있다는 이유로 통째로 억제하면 이 실취약이 사라진다(#28 검증 반박).
+    fun partiallyMasked(cardNo: String, password: String) {
+        // EXPECT: finguard.kotlin.log-sensitive
+        log.debug("card=${mask(cardNo)}, password=$password")
+    }
+
+    private fun mask(v: String): String = v.takeLast(4).padStart(v.length, '*')
+}
+
+// ── 서버측 SQL 조립 (sql-raw 싱크 확장) ─────────────────────────────────────
+
+class OrderQueryRepository(private val entityManager: FakeEntityManager, private val jdbcTemplate: FakeJdbcTemplate) {
+
+    fun findByStatus(status: String): List<String> {
+        // EXPECT: finguard.kotlin.sql-raw
+        return entityManager.createQuery("SELECT o FROM Orders o WHERE o.status = '$status'")
+    }
+
+    fun findNative(userId: String): List<String> {
+        // EXPECT: finguard.kotlin.sql-raw
+        return entityManager.createNativeQuery("SELECT * FROM ORDERS WHERE USER_ID = '" + userId + "'")
+    }
+
+    fun countByBranch(branch: String): List<String> {
+        // EXPECT: finguard.kotlin.sql-raw
+        return jdbcTemplate.queryForObject("SELECT COUNT(*) FROM ACCT WHERE BRANCH = '$branch'")
+    }
+}
+
+class FakeEntityManager {
+    fun createQuery(sql: String): List<String> = listOf(sql)
+    fun createNativeQuery(sql: String): List<String> = listOf(sql)
+}
+
+class FakeJdbcTemplate {
+    fun queryForObject(sql: String): List<String> = listOf(sql)
+    fun query(sql: String): List<String> = listOf(sql)
+}
+
+// ── 취약 해시 (weak-hash 확장: 알고리즘명을 문자열로 받는 래퍼) ──────────────
+
+object ExchangeSignUtil {
+
+    fun legacyDigest(payload: ByteArray): ByteArray {
+        // EXPECT: finguard.kotlin.weak-hash
+        return MessageDigest.getInstance("MD5").digest(payload)
+    }
+
+    fun legacyMac(): Mac {
+        // EXPECT: finguard.kotlin.weak-hash
+        return Mac.getInstance("HmacSHA1")
+    }
+
+    // 거래소 서명 유틸이 실제로 쓰던 형태 — 알고리즘명이 사내 래퍼의 문자열 인자로 온다.
+    // 인자가 다음 줄로 넘어가도 잡혀야 한다.
+    fun sign(plain: String, secret: String): String {
+        // EXPECT: finguard.kotlin.weak-hash
+        return CryptUtil.encrypt(
+            "MD5",
+            (plain + secret).toByteArray(Charsets.UTF_8)
+        ).toString()
+    }
+}
+
+object CryptUtil {
+    fun encrypt(algorithm: String, data: ByteArray): ByteArray =
+        MessageDigest.getInstance(algorithm).digest(data)
+}
+
+// ── Feign 전체 로깅 ─────────────────────────────────────────────────────────
+
+class PaymentFeignConfig {
+    // EXPECT: finguard.kotlin.feign-full-logging
+    fun feignLoggerLevel(): Logger.Level = Logger.Level.FULL
+}
+
+// ── 개발용 인증 우회 엔드포인트 ─────────────────────────────────────────────
+
+@RestController
+class DevAuthController {
+
+    // EXPECT: finguard.kotlin.dev-backdoor-endpoint
+    @PostMapping("/oauth/local/login")
+    fun localDevLogin(): String = "issued"
+}
+
+// ── 스택트레이스 노출 ───────────────────────────────────────────────────────
+
+class MailSender {
+    fun send() {
+        try {
+            error("boom")
+        } catch (e: IllegalStateException) {
+            // EXPECT: finguard.kotlin.stacktrace-exposure
+            e.printStackTrace()
+        }
+    }
+}
+
+// ── taint 룰 (Kotlin 문법 sink) ─────────────────────────────────────────────
+
+@RestController
+class TaintController {
+
+    @GetMapping("/ops/ping")
+    fun ping(@RequestParam host: String): String {
+        // 외부 입력이 명령 문자열에 섞인다. OS 명령 삽입 전용 taint 룰은 두지 않았고,
+        // 기존 finguard.kotlin.os-command 가 모든 exec 호출을 ERROR 로 잡는다.
+        // EXPECT: finguard.kotlin.os-command
+        val p = Runtime.getRuntime().exec("ping -c 1 $host")
+        return p.toString()
+    }
+
+    @GetMapping("/statement/{name}")
+    fun statement(@PathVariable name: String): String {
+        // EXPECT: finguard.kotlin.path-traversal
+        val f = File("/data/statements/$name")
+        return f.readText()
+    }
+
+    @GetMapping("/statement/stream")
+    fun stream(@RequestParam("file") fileName: String): Int {
+        // EXPECT: finguard.kotlin.path-traversal
+        return FileInputStream("/data/statements/$fileName").read()
+    }
+
+    @GetMapping("/proxy")
+    fun proxy(@RequestParam target: String): String =
+        // EXPECT: finguard.kotlin.ssrf
+        URL(target).readText()
+
+    fun legacyProxy(request: HttpServletRequest): String {
+        val target = request.getParameter("url")
+        // EXPECT: finguard.kotlin.ssrf
+        return URL(target).readText()
+    }
+
+    @GetMapping("/go")
+    fun go(@RequestParam next: String, response: HttpServletResponse) {
+        // EXPECT: finguard.kotlin.open-redirect
+        response.sendRedirect(next)
+    }
+}

--- a/testdata/rule-fixtures/safe_kotlin_server.kt
+++ b/testdata/rule-fixtures/safe_kotlin_server.kt
@@ -1,0 +1,134 @@
+// Kotlin 서버 대조군 (#28) — 어떤 룰에도 걸리면 안 되는 정상 코드.
+// 룰 확장이 정상 서버 코드에 오탐을 쏟지 않는지 고정한다.
+
+package fixtures.kotlin.server
+
+import java.io.File
+import java.net.URL
+import java.security.MessageDigest
+import java.security.SecureRandom
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+private val log = LoggerFactory.getLogger("safe-fixture")
+
+// 레이트리밋 인터셉터 — availableTokens/tokenBucket 은 민감정보가 아니다.
+// log-sensitive 의 민감어휘 조건이 \btoken\b 경계라 여기에 걸리지 않아야 한다.
+class ThrottlingInterceptor(private val buckets: FakeBucketRegistry) {
+
+    fun preHandle(request: HttpServletRequest): Boolean {
+        val remoteAddr = request.remoteAddr
+        log.info("remoteAddr : $remoteAddr")
+
+        val bucket = buckets.resolveBucket(remoteAddr)
+        val availableTokens = bucket.availableTokens
+        log.info("$remoteAddr : $availableTokens")
+        log.debug("tokenBucket refillTokens=${bucket.refillTokens} tokenCount=${bucket.tokenCount}")
+
+        return bucket.tryConsume(1)
+    }
+}
+
+class FakeBucket(val availableTokens: Long, val refillTokens: Long, val tokenCount: Long) {
+    fun tryConsume(n: Int): Boolean = availableTokens >= n
+}
+
+class FakeBucketRegistry {
+    fun resolveBucket(key: String): FakeBucket = FakeBucket(10, 10, 10)
+}
+
+// 정상 로깅 — 값 자체를 남기지 않는다.
+class AuthService {
+    fun issue(accessToken: String) {
+        log.info("access token issued (length={})", accessToken.length)
+        log.info("login succeeded for user")
+    }
+}
+
+// 바인딩 파라미터를 쓰는 정상 쿼리.
+class SafeRepository(private val entityManager: SafeEntityManager, private val jdbcTemplate: SafeJdbcTemplate) {
+
+    fun findByStatus(status: String): List<String> =
+        entityManager.createQuery("SELECT o FROM Orders o WHERE o.status = :status", status)
+
+    fun countByBranch(branch: String): Int =
+        jdbcTemplate.queryForObject("SELECT COUNT(*) FROM ACCT WHERE BRANCH = ?", branch)
+}
+
+class SafeEntityManager {
+    fun createQuery(jpql: String, param: String): List<String> = listOf(jpql, param)
+}
+
+class SafeJdbcTemplate {
+    fun queryForObject(sql: String, param: String): Int = sql.length + param.length
+}
+
+// 강한 해시 · 안전한 난수.
+object SafeCrypto {
+    fun digest(payload: ByteArray): ByteArray = MessageDigest.getInstance("SHA-256").digest(payload)
+
+    fun nonce(): ByteArray {
+        val out = ByteArray(16)
+        SecureRandom().nextBytes(out)
+        return out
+    }
+}
+
+// CORS 는 와일드카드가 아니라 명시 오리진 목록 — 걸리면 안 된다.
+class CorsConfig {
+    val allowedOriginPatterns = listOf(
+        "https://bank.example.com",
+        "https://admin.example.com"
+    )
+}
+
+// 검증을 거친 파일 접근 · 리다이렉트 · 외부 호출.
+@RestController
+class SafeController {
+
+    private val allowedHosts = setOf("api.example.com")
+
+    @GetMapping("/statement")
+    fun statement(@RequestParam name: String): String {
+        val safeName = File(name).name
+        return File("/data/statements", safeName).readText()
+    }
+
+    @GetMapping("/proxy")
+    fun proxy(@RequestParam target: String): String {
+        val u = URL(target)
+        require(u.host in allowedHosts) { "blocked host" }
+        return "ok"
+    }
+
+    @GetMapping("/go")
+    fun go(@RequestParam next: String, response: HttpServletResponse) {
+        // 외부 입력은 분기 키로만 쓰고, 리다이렉트 대상은 상수 리터럴에서 나온다.
+        val dest = when (next) {
+            "home" -> "/home"
+            "mypage" -> "/mypage"
+            else -> "/home"
+        }
+        response.sendRedirect(dest)
+    }
+
+    // 운영 API 는 dev/local 세그먼트가 없어 backdoor 룰에 걸리지 않는다.
+    @PostMapping("/api/v1/auth/token/refresh")
+    fun refresh(): String = "refreshed"
+}
+
+// 예외는 로거로 보낸다 — printStackTrace 를 쓰지 않는다.
+class SafeMailSender {
+    fun send() {
+        try {
+            error("boom")
+        } catch (e: IllegalStateException) {
+            log.warn("메일 발송 실패: {}", e.javaClass.simpleName)
+        }
+    }
+}


### PR DESCRIPTION
Closes #28

Kotlin 룰셋 14개가 전부 Android 관용구라 Spring Boot Kotlin 백엔드에서 한 건도 발화하지 않던 사각지대를 해소한다. 기존 룰 3개의 스코프를 서버로 넓히고, Kotlin 서버 전용 룰 6개를 신설했다.

## 1. 검증 반박을 어떻게 반영했는가

| 반박 (렌즈) | 원안 | 반영 |
| :--- | :--- | :--- |
| **재현율 수호자** — java taint 룰에 `kotlin` 을 얹으면 `new File(...)` 등 Java 전용 생성자 문법 때문에 Kotlin 은 0 findings 이고 Java 검출만 흔들린다 | (B) java.yaml 8종을 `languages: [java, kotlin]` 로 확장 | **원안 폐기.** `java.yaml` 은 한 줄도 건드리지 않았다. `languages: [kotlin]` 전용 taint 룰을 Kotlin 문법(`File(...)`, `URL(...)`, `@RequestParam` 파라미터 소스)으로 새로 작성했다. |
| **재현율 수호자** — "라인에 mask\|redact 어휘가 있으면 제외" 하는 negative 는 부분 마스킹 실취약을 통째로 지운다 | (A) mask/redact 라인 negative 추가 | **negative 미채택.** semgrep regex 모드의 `pattern-not-regex` 는 매치 범위(=라인) 단위로만 억제되어 "민감 토큰 자체가 mask() 로 감싸인 경우만 제외"를 표현할 수 없다. 대신 `log.debug("card=${mask(cardNo)}, password=$password")` 를 **정탐 픽스처**로 박아 회귀를 막았다. |
| **재현율 수호자** — `availableTokens`/`tokenBucket` 제외 목록은 불필요하다(`\btoken\b` 경계라 애초에 매칭 안 됨) | (A) 레이트리밋 식별자 negative 추가 | **negative 미채택**, 대신 `safe_kotlin_server.kt` 에 `availableTokens`·`tokenBucket`·`refillTokens`·`tokenCount` 로깅을 대조군으로 고정. 실코드 `ThrottlingInterceptor.kt:54` 도 확장 후 스캔에서 검출 0건으로 실측 확인. |
| **금융 규제 심사관** — `ThrottlingInterceptor.kt:54` 를 negative 픽스처로 고정해 회귀를 막을 것 | 픽스처 고정 | **채택** (위와 동일한 대조군 파일). 단 위치는 `rules/testdata` 가 아니라 2026-08-21 도입된 `testdata/rule-fixtures/` 규약을 따랐다. |
| **금융 규제 심사관** — sql-raw 서버측 싱크는 기존 FIN-SQLI 매핑을 그대로 쓰므로 매핑 신규 작성 불필요 | — | **채택.** `sql-raw` 는 룰 ID 가 그대로라 매핑 변경 없음. |
| **semgrep 구현자** — `new` 생성자 계열 sink 는 Kotlin 문법으로 별도 작성해야 한다. 단순 메서드 호출 소스는 언어 확장만으로 동작 | — | **채택.** sink 를 Kotlin 생성자 호출로 작성. 소스는 `request.getParameter(...)` 와 `@RequestParam/@PathVariable/...` 파라미터 두 계열 모두 픽스처로 발화 확인(무음 룰 금지 — 커버된다는 착각이 무룰보다 나쁘다). |

추가로 `@RequestParam("file") fileName: String` 처럼 **인자 있는 애노테이션**과 **표현식 본문 함수**(`fun f(...) = ...`)가 semgrep 1.169.0 에서 `pattern-inside` 로 잡히지 않는 것을 실측하고, 네 가지 형태를 `pattern-either` 로 모두 커버했다.

## 2. 실코드 검출 전/후 (수정 전 = main, 수정 후 = 이 브랜치)

| 레포 | 전체 전 | 전체 후 | kotlin 룰 기여 전 | kotlin 룰 기여 후 | 신규 검출 |
| :--- | ---: | ---: | ---: | ---: | :--- |
| Gosrock/DuDoong-Backend (r3) | 5 | 9 | **0** | **4** | feign-full-logging 1, dev-backdoor-endpoint 1, stacktrace-exposure 2 |
| namjug-kim/reactive-crypto (r6) | 0 | 1 | **0** | **1** | weak-hash 1 |

수정 전 r3 의 5건은 전부 `finguard.config.plaintext-secret` 이었고 kotlin 룰 기여가 0이었다.

### 이슈가 지목한 미탐이 실제로 잡히는가

| 이슈 근거 | 결과 |
| :--- | :--- |
| `DuDoong-Infrastructure/.../feign/FeignCommonConfig.kt:31` (Feign FULL 로깅 → PG 시크릿 유출) | ✅ `finguard.kotlin.feign-full-logging` 이 **31행** 검출 |
| `DuDoong-Api/.../auth/controller/AuthController.kt:187` (개발용 즉시 로그인 엔드포인트) | ✅ `finguard.kotlin.dev-backdoor-endpoint` 가 **187행** 검출 |
| `reactive-crypto-coineal/.../CoinealSignUtil.kt:37` (MD5 서명) | ✅ `finguard.kotlin.weak-hash` 가 **36행**(`.encrypt(` 호출 시작 줄) 검출 |
| `DuDoong-Api/.../ThrottlingInterceptor.kt:54` (레이트리밋 토큰 오탐 후보) | ✅ **검출 0건** — 오탐 없음 |

### 오탐 점검

새로 터진 5건을 전부 열어 확인했다.

- `FeignCommonConfig.kt:31` — `Logger.Level.FULL`. 토스페이먼츠 연동 Feign 클라이언트의 요청·응답 헤더/본문 전체 로깅. **정탐.**
- `AuthController.kt:187` — `@PostMapping("/oauth/local/login")` + `localDevLogin`. 카카오 인증 없이 토큰을 발급하는 개발용 경로가 소스에 잔존. **정탐.**
- `AwsSesUtils.kt:70,104` — `catch (ex: Exception) { log.info(ex.toString()); ex.printStackTrace() }`. 예외를 삼키고 스택트레이스를 표준에러로 흘림. **정탐.**
- `CoinealSignUtil.kt:36` — 거래소 서명에 MD5. **정탐.**

**오탐 0건.** 특히 log-sensitive 싱크를 `log/logger.*`·`println`·`System.out.print*` 로 넓혔음에도 두 레포에서 신규 검출이 0인데, 민감어휘 AND 조건이 그대로 살아 있기 때문이다(규제 렌즈의 예측과 일치). 코퍼스 나머지 8개 레포에는 `.kt` 파일이 없어(`find` 실측) 영향 범위 밖이다.

## 3. 변이 시험

`TestFixtureExpectationsMatchScan` 이 실제로 회귀를 잡는지 양방향으로 확인했다.

- **마커 제거** — `feign-full-logging` 마커를 떼자 `오탐 회귀 — 마커가 없는데 검출됐다: kotlin_server_vulns.kt:112 finguard.kotlin.feign-full-logging` 으로 FAIL.
- **검출 없는 줄에 마커 추가** — `fun notASink(): String = "harmless"` 위에 `EXPECT: finguard.kotlin.ssrf` 를 달자 `미탐 회귀 — 마커가 있는데 검출되지 않았다: kotlin_server_vulns.kt:114 finguard.kotlin.ssrf` 로 FAIL.
- 원복 후 `기대 40건 · 검출 40건 · 전부 일치` PASS.

## 4. 일부러 넣지 않은 패턴과 이유

| 패턴 | 제외 이유 |
| :--- | :--- |
| `finguard.kotlin.os-command-injection` (taint) | 기존 `finguard.kotlin.os-command` 가 이미 **모든** `Runtime.exec`/`ProcessBuilder` 를 ERROR 로 잡는다. taint 판을 더하면 같은 줄에 코멘트가 두 번 달릴 뿐 새로 잡히는 건 없다. |
| CSRF 비활성화 (`csrf { it.disable() }`) | r3 `SecurityConfig.kt:31` 에 실재하지만, **stateless JWT API 에서는 정상 설정**이라 오탐률이 높다. 또한 CWE-352 는 `mapping/rules.yaml` 에 선례 엔트리가 없어 `basis`/`kisa_item` 을 지어내야 한다. |
| CORS 와일드카드 (CWE-942), 광역 `permitAll()` (CWE-306) | 코퍼스에 실사례가 없어 발화를 검증할 수 없고(무음 룰 금지), 동일하게 승계할 매핑 선례가 없다. |
| XXE / zip-slip / LDAP 삽입 Kotlin 판 | 코퍼스에 사례가 없어 "실제로 발화하는가"를 확인할 수 없다. Kotlin 실사례가 확보되면 별도 이슈로. |
| SQL 삽입 taint 룰 | 확장한 `sql-raw` 정규식과 싱크가 겹쳐 같은 줄 중복 코멘트를 만든다. 크로스라인 조립까지 잡으려면 별도 설계가 필요해 이 PR 범위에서 제외. |
| `log-sensitive` 민감어휘에 `accessToken`/`refreshToken` 추가 | `\btoken\b` 경계 때문에 `$accessToken` 은 현재 미탐이다. 다만 어휘를 넓히면 `log.info("... length={}", accessToken.length)` 같은 **안전한 로깅**이 오탐이 된다(같은 경계가 `availableTokens` 오탐도 막고 있다). 대칭 문제라 이 PR 에서 임의 결정하지 않고 남긴다. |
| `Logger.Level.BASIC` | 헤더·본문을 남기지 않아 취약이 아니다. `FULL`/`HEADERS` 만 대상. |

## 5. 매핑

신규 룰 6건의 엔트리를 추가했다(`FIN-LOG-004`, `FIN-DBG-001`, `FIN-LOG-005`, `FIN-PATH-006`, `FIN-SSRF-004`, `FIN-REDIR-004`). `basis`·`kisa_item` 은 같은 CWE 의 기존 엔트리에서 **문자열 그대로** 승계했다. 승계할 선례가 없는 CWE-489·CWE-209 의 `kisa_item` 은 `FIN-AND-001` 과 같이 빈 문자열로 두었다 — 감사 대응 자료이므로 근거를 지어내지 않는다. 기존 엔트리는 수정하지 않았다.

룰 98개 = 매핑 98개 (`TestMappingCoversAllRules` 통과).

## 6. 검증 결과

```
semgrep --validate --config rules/
  → Configuration is valid - found 0 configuration error(s), and 98 rule(s)   (before: 92)

go build -mod=vendor ./...     → OK
go vet -mod=vendor ./...       → OK
go test -race -mod=vendor ./...
  → ok  internal/gitlab, internal/mapping, internal/rdjson,
        internal/repoconfig, internal/scanner, internal/webhook

go test -race -mod=vendor -tags semgrep_integration ./internal/scanner/ -v
  → TestFixtureExpectationsMatchScan: 기대 40건 · 검출 40건 · 전부 일치 (PASS)
  → TestSafeFixturesHaveNoExpectations (PASS)
  → TestNoYAMLFixturesUnderRules (PASS)
```

## 7. 변경 파일

- `rules/kotlin.yaml` — 기존 룰 3개 확장, 신규 룰 6개
- `mapping/rules.yaml` — 신규 엔트리 6개 추가 (기존 엔트리 무변경)
- `testdata/rule-fixtures/kotlin_server_vulns.kt` — 정탐 픽스처 (EXPECT 마커 20개)
- `testdata/rule-fixtures/safe_kotlin_server.kt` — 대조군 (검출 0건)

`java.yaml` 을 포함한 다른 언어 룰 파일은 건드리지 않았다.
