### PR TITLE
feat(#27): TypeScript 룰셋 언어 패리티 보강 — SQLi·암호재료·취약알고리즘·난수·TLS 5종 신설

### DIFF
--- a/mapping/rules.yaml
+++ b/mapping/rules.yaml
@@ -1391,4 +1391,77 @@
         else -> "/home"
     }
     response.sendRedirect(dest)
+
+- rule_id: finguard.ts.sql-injection
+  code: FIN-SQLI-008
+  cwe: CWE-89
+  title: SQL 삽입(TypeScript/JavaScript)
+  severity: ERROR
+  basis: 개발보안가이드 「입력데이터 검증 및 표현 - SQL 삽입」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 19 (SQL Injection)"
+  explain: 템플릿 보간·문자열 연결로 조립한 SQL 을 실행하거나, 파라미터화를 우회하는 raw 실행 API($queryRawUnsafe·$executeRawUnsafe·Prisma.raw)에 동적 문자열을 넘기고 있습니다. 조립에 쓰인 값이 외부 입력에서 유래하면 문장 구조가 바뀔 수 있습니다.
+  fix_example: |
+    ```ts
+    // 태그드 템플릿(파라미터 바인딩)
+    const rows = await prisma.$queryRaw`SELECT * FROM users WHERE id = ${userId}`;
+
+    // 드라이버 직접 사용 시 바인딩 파라미터
+    await pool.query("SELECT * FROM users WHERE id = $1", [userId]);
+    ```
+
+- rule_id: finguard.ts.hardcoded-crypto-material
+  code: FIN-CRY-012
+  cwe: CWE-321
+  title: 하드코드된 암호화 키/솔트/IV(TypeScript)
+  severity: ERROR
+  basis: 개발보안가이드 「보안기능 - 하드코드된 암호화 키 사용」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 43 (앱 소스코드 내 운영정보 노출 방지)"
+  explain: 암호화 키·IV·솔트가 소스코드에 하드코드되어 있거나, IV 없는 deprecated 암호 API(createCipher)를 사용하고 있습니다. 소스 유출 시 암호화가 그대로 무력화됩니다. 이 점검은 리터럴 값만 확인하므로, 고정 상수에서 파생하거나 전역 단일 값으로 재사용하는 IV 는 별도 수동 확인이 필요합니다.
+  fix_example: |
+    ```ts
+    const key = await loadKeyFromSecretStore();          // 보호 저장소에서 로드
+    const iv = crypto.randomBytes(12);                   // 매 암호화마다 새 난수 IV
+    const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+    ```
+
+- rule_id: finguard.ts.weak-crypto
+  code: FIN-CRY-013
+  cwe: CWE-327
+  title: 취약한 암호 알고리즘(TypeScript)
+  severity: WARNING
+  basis: 개발보안가이드 「보안기능 - 취약한 암호화 알고리즘 사용」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 52 (취약한 HTTPS 암호 알고리즘 이용)"
+  explain: MD5/SHA-1/DES/RC4/ECB 는 충돌·해독이 실증된 알고리즘·운영모드입니다. SHA-256 이상, AES-GCM 등으로 교체해야 합니다.
+  fix_example: |
+    ```ts
+    const digest = crypto.createHash("sha256").update(data).digest("hex");
+    const cipher = crypto.createCipheriv("aes-256-gcm", key, crypto.randomBytes(12));
+    ```
+
+- rule_id: finguard.ts.insecure-random
+  code: FIN-CRY-014
+  cwe: CWE-338
+  title: 예측 가능한 난수로 보안값 생성(TypeScript)
+  severity: ERROR
+  basis: 개발보안가이드 「보안기능 - 적절하지 않은 난수 값 사용」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 30 (유추 가능한 세션ID)"
+  explain: Math.random 계열은 암호학적으로 안전하지 않아 출력값을 예측할 수 있습니다. 키·토큰·OTP·솔트·세션ID 등 보안값 생성에는 crypto.randomBytes/randomUUID/getRandomValues 를 사용해야 합니다.
+  fix_example: |
+    ```ts
+    const token = crypto.randomBytes(32).toString("hex");
+    const otp = String(crypto.randomInt(0, 1000000)).padStart(6, "0");
+    ```
+
+- rule_id: finguard.ts.tls-verify-disabled
+  code: FIN-TLS-024
+  cwe: CWE-295
+  title: TLS 인증서 검증 비활성화(Node.js)
+  severity: ERROR
+  basis: 개발보안가이드 「보안기능 - 부적절한 인증서 유효성 검증」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 47 (서버 인증서 무결성 검증)"
+  explain: rejectUnauthorized:false · NODE_TLS_REJECT_UNAUTHORIZED=0 · checkServerIdentity 무력화는 서버 인증서 검증을 건너뛰어 중간자 공격(MITM)에 그대로 노출됩니다.
+  fix_example: |
+    ```ts
+    // 사설 CA 는 검증을 끄는 대신 CA 인증서를 신뢰 목록에 추가한다
+    const agent = new https.Agent({ ca: fs.readFileSync("/etc/ssl/internal-ca.pem") });
     ```

--- a/rules/typescript.yaml
+++ b/rules/typescript.yaml
@@ -210,3 +210,125 @@ rules:
               - pattern: createWriteStream($P, ...)
               - pattern: mkdirSync($P, ...)
           - focus-metavariable: $P
+
+  # ── 언어 패리티 보강 (#27) ─────────────────────────────────────────────
+  # java/python/go/kotlin 이 모두 갖고 있던 SQL 조립·암호재료·난수·TLS 룰의 TS 대응.
+  # 국내 결제·핀테크 백엔드의 Node/NestJS 비중이 높아 이 결손은 스택 하나가
+  # 통째로 미점검되는 문제였다.
+
+  # SQL 삽입 (CWE-89).
+  # taint 모드가 아니라 java.sql-string-build 와 같은 직접 patterns 구조다 — 증거 코드는
+  # 환경변수·process.argv 값이 템플릿 리터럴에 직접 들어가고 $REQ.* 를 거치지 않아
+  # taint 소스로는 잡히지 않는다.
+  #
+  # 두 갈래로 나눈다.
+  #  (A) 이름 자체가 unsafe 를 선언하는 raw 실행 API($queryRawUnsafe·$executeRawUnsafe·
+  #      Prisma.raw). 오탐 위험이 낮으므로 인자가 "상수 문자열 리터럴이 아니기만" 하면 잡는다.
+  #      변수 하나만 넘기는 형태(script 를 split 해서 넘기는 증거 코드)도 여기서 걸린다.
+  #      이 갈래만 정규식이다 — semgrep 1.169.0 은 `export namespace X { ... }` 본문 안의
+  #      호출을 AST 패턴으로 매칭하지 못한다(같은 코드를 `namespace X` 로 바꾸면 매칭된다).
+  #      실증거인 PaymentSetupWizard.ts 의 $executeRawUnsafe 가 정확히 그 형태라 AST 로는
+  #      영영 미탐이 된다.
+  #  (B) 범용 실행 싱크(.query/.execute/.raw). 이름만으로는 SQL 인지 알 수 없으므로
+  #      인자에 템플릿 보간(${) 또는 문자열 연결(+)이 있고 SQL 키워드가 보일 때만 발화한다.
+  #
+  # 인자 개수(arity)로 안전을 판정하지 않는다 — 보간과 바인딩을 섞은
+  # `pool.query(`... id = ${req.query.id} AND status = $1`, ["A"])` 가 정확히 취약하기 때문이다.
+  # 태그드 템플릿($queryRaw`...`)은 진짜 파라미터화라 제외되지만, 그 안의 Prisma.raw() 는
+  # 주입 재개통 경로라 (A) 에서 다시 잡는다.
+  - id: finguard.ts.sql-injection
+    languages: [ts, js]
+    severity: ERROR
+    message: SQL 문을 문자열 조립(템플릿 보간·연결)으로 만들어 실행하거나, 파라미터화를 우회하는 raw 실행 API 에 동적 문자열을 넘기고 있습니다. 조립에 쓰인 값이 외부 입력에서 유래하면 SQL 삽입이 가능합니다. 파라미터 바인딩($1 · ? · 태그드 템플릿)을 사용해야 합니다.
+    metadata:
+      cwe: "CWE-89"
+      category: security
+    patterns:
+      - pattern-either:
+          # (A) unsafe 를 이름으로 선언한 raw 실행 API — 인자가 상수 문자열 리터럴이 아니면 발화.
+          #     첫 인자가 변수·호출·보간 템플릿·문자열 연결일 때만 매칭하므로
+          #     $queryRawUnsafe("SELECT 1") 같은 상수 실행은 걸리지 않는다.
+          - pattern-regex: '\$(?:query|execute)RawUnsafe\s*\(\s*(?:[A-Za-z_$][\w$]*(?:\.[\w$]+)*\s*[,)(]|`[^`]*\$\{|["''][^"'']*["'']\s*\+)'
+          - pattern-regex: '\bPrisma\.(?:raw|sql)\s*\(\s*(?:[A-Za-z_$][\w$]*(?:\.[\w$]+)*\s*[,)(]|`[^`]*\$\{|["''][^"'']*["'']\s*\+)'
+          # (B) 범용 싱크 — 보간·연결 + SQL 키워드가 함께 보일 때만
+          - patterns:
+              - pattern-either:
+                  - pattern: $DB.query($Q, ...)
+                  - pattern: $DB.execute($Q, ...)
+                  - pattern: $DB.raw($Q, ...)
+              # (A) 와 이중 검출되지 않도록 raw 실행 API 는 여기서 제외한다.
+              - pattern-not: Prisma.raw(...)
+              - pattern-not: Prisma.sql(...)
+              - focus-metavariable: $Q
+              # 조립 흔적(보간·연결)과 SQL 키워드를 한 정규식 안에서 함께 요구한다.
+              # 두 조건을 pattern-either + pattern-regex 로 나누면 semgrep 이 두 매치의
+              # 범위 교집합을 요구해, 조립 흔적과 키워드가 떨어져 있는 문자열이 누락된다.
+              - metavariable-pattern:
+                  metavariable: $Q
+                  pattern-regex: '(?is)^(?=[\s\S]*(?:`[^`]*\$\{|["''][^"'']*["'']\s*\+|\+\s*["'']))[\s\S]*\b(?:select\s|insert\s+into\b|update\b[\s\S]*\bset\b|delete\s+from\b|merge\s+into\b|create\s+(?:table|schema|database|user)\b|drop\s+(?:table|schema|database)\b|alter\s+table\b|truncate\s+table\b|grant\s|from\s|where\s)'
+
+  # 하드코드된 암호화 키·IV·salt, IV 없는 deprecated 암호 API (CWE-321).
+  #
+  # 한계(의도적): IV 가 "문자열 리터럴"이거나 아예 없는 경우만 본다. 테이블명 같은
+  # 고정 상수에서 결정론적으로 파생한 IV(예: 이름을 16자로 자르거나 패딩)나 전역 단일 IV
+  # 재사용은 이 룰로 잡히지 않는다 — 값 흐름 추적이 필요해 정적 정규식 범위를 벗어난다.
+  # 그 경우는 별도 IV 재사용 룰이 필요하며 이 룰의 근거로 삼지 않는다.
+  - id: finguard.ts.hardcoded-crypto-material
+    languages: [regex]
+    severity: ERROR
+    message: 암호화 키·IV·salt 가 소스에 하드코드되어 있거나, IV 없는 deprecated 암호 API(createCipher)를 사용하고 있습니다. 소스 유출 시 암호화가 그대로 무력화됩니다. 키는 보호 저장소에서 로드하고 IV·salt 는 매번 안전한 난수로 생성해야 합니다.
+    metadata:
+      cwe: "CWE-321"
+      category: security
+    paths:
+      include: ["*.ts", "*.tsx", "*.js", "*.jsx"]
+      exclude: ["*.test.ts", "*.spec.ts", "*.test.js", "*.spec.js"]
+    pattern-regex: '(?im)^(?![ \t]*(?://|\*|/\*))(?:\s*(?:export\s+)?(?:const|let|var|readonly|static|private|public|protected)\s+(?:\w*(?:crypto|aes|enc|encrypt|cipher|hmac|sign)_?(?:key|iv|salt)\w*|iv|salt|nonce|initvector|init_vector)\s*(?::\s*[\w<>?.\[\]|]+)?\s*=\s*["''`][A-Za-z0-9+/=_-]{7,}["''`]|.*\bcreateCipher\s*\(|.*\bcreate(?:Cipher|Decipher)iv\s*\([^)]*,\s*["''`][^"''`]{4,}["''`]\s*\))'
+
+  # 취약한 암호 알고리즘 (CWE-327) — go.weak-crypto / python.weak-hash 의 TS 대응.
+  - id: finguard.ts.weak-crypto
+    languages: [regex]
+    severity: WARNING
+    message: MD5/SHA-1/DES/RC4/ECB 등 취약한 암호·해시 알고리즘을 사용하고 있습니다. SHA-256 이상, AES-GCM 등으로 교체해야 합니다.
+    metadata:
+      cwe: "CWE-327"
+      category: security
+    paths:
+      include: ["*.ts", "*.tsx", "*.js", "*.jsx"]
+    pattern-regex: '(?im)^(?![ \t]*(?://|\*|/\*)).*(?:create(?:Hash|Hmac)\s*\(\s*["''`](?:md5|md4|sha1|sha-1)["''`]|create(?:Cipher|Decipher)iv\s*\(\s*["''`][^"''`]*(?:ecb|-des|des-|rc4|rc2)[^"''`]*["''`]|["''`](?:aes-\d+-ecb|des-ede3|des3|rc4)["''`])'
+
+  # 예측 가능한 난수로 보안값 생성 (CWE-338).
+  # 이름 조건 필수 — 화면용 ID·애니메이션 지연 등 비보안 용도의 Math.random 오탐을 막는다.
+  # crypto.randomBytes/randomUUID/getRandomValues 는 애초에 매칭되지 않는다.
+  #
+  # 한계(의도적): 식별자에 보안 어휘가 전혀 없는 자격증명 생성기
+  # (예: `const alphaNumeric = (n) => ... randint(...)` 를 비밀번호 생성에 쓰는 코드)는
+  # 잡지 못한다. 이름 조건을 풀면 화면용 난수 전부가 오탐이 되어 도구를 못 쓰게 된다.
+  - id: finguard.ts.insecure-random
+    languages: [regex]
+    severity: ERROR
+    message: 보안값(키·토큰·OTP·salt·IV·세션ID 등)을 예측 가능한 난수로 생성하고 있습니다. Math.random 계열은 암호학적으로 안전하지 않습니다. crypto.randomBytes/randomUUID/getRandomValues 를 사용해야 합니다.
+    metadata:
+      cwe: "CWE-338"
+      category: security
+    paths:
+      include: ["*.ts", "*.tsx", "*.js", "*.jsx"]
+      exclude: ["*.test.ts", "*.spec.ts", "*.test.js", "*.spec.js"]
+    # iv·seed·salt·nonce 는 부분문자열로 쓰면 drive·receive·assert 같은 흔한 식별자를
+    # 통째로 먹으므로 완전 단어로만 본다. 나머지 어휘는 합성 식별자(otpCode·apiToken)를
+    # 잡아야 해 부분문자열 매칭을 유지한다.
+    pattern-regex: '(?im)^(?![ \t]*(?://|\*|/\*)).*(?:\b(?:iv|seed|salt|nonce)\b|\b\w*(?:token|password|passwd|secret|apikey|api_key|privatekey|secretkey|seckey|sessionkey|cryptokey|encryptkey|otp)\w*\b)[^\n]*?\b(?:Math\.random\s*\(|randint\s*\(|_\.random\s*\(|lodash\.random\s*\()'
+
+  # TLS 인증서 검증 비활성화 (CWE-295) — python.tls-verify-disabled / go.tls-skip-verify 의 TS 대응.
+  # https.createServer 의 mTLS-optional 구성에서는 rejectUnauthorized:false 의 의미가 다르지만,
+  # 미탐 비용이 더 커 감수한다(수동 확인 대상).
+  - id: finguard.ts.tls-verify-disabled
+    languages: [regex]
+    severity: ERROR
+    message: TLS 서버 인증서 검증을 비활성화하고 있습니다. 중간자 공격(MITM)에 그대로 노출됩니다. 사설 CA 는 검증을 끄는 대신 CA 인증서를 신뢰 목록에 추가해야 합니다.
+    metadata:
+      cwe: "CWE-295"
+      category: security
+    paths:
+      include: ["*.ts", "*.tsx", "*.js", "*.jsx"]
+    pattern-regex: '(?im)^(?![ \t]*(?://|\*|/\*)).*(?:rejectUnauthorized\s*:\s*false|strictSSL\s*:\s*false|insecureSkipTLSVerify\s*:\s*true|NODE_TLS_REJECT_UNAUTHORIZED["'']?\]?\s*=\s*["'']?0|checkServerIdentity\s*:\s*(?:\([^)]*\)|\w+)\s*=>\s*(?:undefined|null|\{\s*\}))'

--- a/testdata/rule-fixtures/safe_ts_parity.ts
+++ b/testdata/rule-fixtures/safe_ts_parity.ts
@@ -1,0 +1,50 @@
+// 언어 패리티 보강 룰(#27) 대조군 — 어떤 룰에도 걸리면 안 된다.
+// safe_ 접두 파일은 EXPECT 마커를 가질 수 없다.
+import crypto from "crypto";
+import https from "https";
+
+declare const prisma: any;
+declare const pool: any;
+declare const gqlClient: any;
+declare const userId: string;
+declare const uid: string;
+declare const keyBuf: Buffer;
+declare const data: Buffer;
+
+export async function run(): Promise<void> {
+  // 상수 리터럴만 넘기는 raw 실행 — 조립 여지가 없다
+  await prisma.$queryRawUnsafe("SELECT 1");
+
+  // 태그드 템플릿은 진짜 파라미터화다
+  await prisma.$queryRaw`SELECT * FROM users WHERE id = ${userId}`;
+
+  // 완전 바인딩
+  await pool.query("SELECT * FROM users WHERE id = $1", [userId]);
+
+  // SQL 이 아닌 query 싱크 — 보간이 있어도 SQL 키워드가 없다
+  await gqlClient.query(`{ user(id: "${uid}") { name } }`);
+}
+
+// 비보안 용도 난수 — 이름에 보안 어휘가 없다
+const elementId = Math.random().toString(36).slice(2);
+
+// iv·seed 를 부분문자열로 보면 걸리는 흔한 식별자들 (drive·receive)
+const driveJitter = Math.random() * 100;
+const receiveDelay = Math.random() * 100;
+
+// 검증을 켜는 쪽 대입은 걸리지 않아야 한다
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = "1";
+
+// 안전한 난수원
+const nonce = crypto.randomBytes(12);
+
+// 난수 IV · AEAD 운영모드
+const cipher = crypto.createCipheriv("aes-256-gcm", keyBuf, crypto.randomBytes(12));
+
+// 안전한 해시
+const digest = crypto.createHash("sha256").update(data).digest("hex");
+
+// 인증서 검증 유지
+const agent = new https.Agent({ rejectUnauthorized: true });
+
+export { elementId, driveJitter, receiveDelay, nonce, cipher, digest, agent };

--- a/testdata/rule-fixtures/ts_parity_vulns.ts
+++ b/testdata/rule-fixtures/ts_parity_vulns.ts
@@ -1,0 +1,70 @@
+// 언어 패리티 보강 룰(#27) 정탐 픽스처 — SQL 조립 · 암호재료 · 난수 · TLS.
+// 대조군은 safe_ts_parity.ts.
+import crypto from "crypto";
+import https from "https";
+
+declare const prisma: any;
+declare const pool: any;
+declare const conn: any;
+declare const Prisma: any;
+declare const rawQuery: string;
+declare const schema: string;
+declare const reader: string;
+declare const tableName: string;
+declare const filter: string;
+declare const acct: string;
+declare const data: Buffer;
+declare const keyBuf: Buffer;
+declare const passphrase: string;
+
+export async function run(): Promise<void> {
+  // 변수 하나만 넘기는 raw 실행 — 조립 흔적이 호출부에 없어도 unsafe API 는 잡는다
+  // EXPECT: finguard.ts.sql-injection
+  await prisma.$queryRawUnsafe(rawQuery);
+
+  // 템플릿 보간 DDL
+  // EXPECT: finguard.ts.sql-injection
+  await prisma.$executeRawUnsafe(`GRANT SELECT ON SCHEMA ${schema} TO ${reader}`);
+
+  // 태그드 템플릿 안의 Prisma.raw — 파라미터화를 재개통하는 경로
+  // EXPECT: finguard.ts.sql-injection
+  await prisma.$queryRaw`SELECT * FROM ${Prisma.raw(tableName)}`;
+
+  // 보간과 바인딩을 섞은 형태 — 인자 개수로 안전을 판정하지 않는다
+  // EXPECT: finguard.ts.sql-injection
+  await pool.query(`SELECT * FROM users WHERE id = ${filter} AND status = $1`, ["A"]);
+
+  // 문자열 연결
+  // EXPECT: finguard.ts.sql-injection
+  await conn.query("SELECT * FROM ledger WHERE acct = '" + acct + "'");
+}
+
+// 하드코드된 암호화 키
+// EXPECT: finguard.ts.hardcoded-crypto-material
+const ENCRYPT_KEY = "A1b2C3d4E5f6G7h8";
+
+// IV 가 없는 deprecated 암호 API
+// EXPECT: finguard.ts.hardcoded-crypto-material
+const legacyCipher = crypto.createCipher("aes-256-cbc", passphrase);
+
+// IV 가 문자열 리터럴
+// EXPECT: finguard.ts.hardcoded-crypto-material
+const decipher = crypto.createDecipheriv("aes-256-cbc", keyBuf, "0123456789abcdef");
+
+// 취약한 해시
+// EXPECT: finguard.ts.weak-crypto
+const digest = crypto.createHash("md5").update(data).digest("hex");
+
+// ECB 운영모드
+// EXPECT: finguard.ts.weak-crypto
+const ecbCipher = crypto.createCipheriv("aes-256-ecb", keyBuf, null);
+
+// 예측 가능한 난수로 OTP 생성 — 이름 조건 충족
+// EXPECT: finguard.ts.insecure-random
+const otpCode = String(Math.floor(Math.random() * 1000000));
+
+// TLS 검증 비활성화
+// EXPECT: finguard.ts.tls-verify-disabled
+const agent = new https.Agent({ rejectUnauthorized: false });
+
+export { ENCRYPT_KEY, legacyCipher, decipher, digest, ecbCipher, otpCode, agent };


### PR DESCRIPTION
Closes #27

TypeScript 룰셋에 없던 SQL 조립·암호재료·취약 알고리즘·난수·TLS 점검을 신설해 java/python/go/kotlin 과의 언어 커버리지 불균형을 해소한다.

## 신설 룰

| 룰 ID | severity | CWE | 매핑 code |
| :--- | :--- | :--- | :--- |
| `finguard.ts.sql-injection` | ERROR | CWE-89 | FIN-SQLI-008 |
| `finguard.ts.hardcoded-crypto-material` | ERROR | CWE-321 | FIN-CRY-012 |
| `finguard.ts.weak-crypto` | WARNING | CWE-327 | FIN-CRY-013 |
| `finguard.ts.insecure-random` | ERROR | CWE-338 | FIN-CRY-014 |
| `finguard.ts.tls-verify-disabled` | ERROR | CWE-295 | FIN-TLS-024 |

룰 97개 = 매핑 97개(스크립트로 대조, 누락·고아 0). `basis`·`kisa_item` 은 전부 동일 CWE 의 기존 항목에서 승계했고 신규 문구를 만들지 않았다.

이슈 원안은 4룰이었으나 하드코드 암호재료(CWE-321, 「하드코드된 암호화 키 사용」)와 취약 알고리즘(CWE-327, 「취약한 암호화 알고리즘 사용」)은 근거 조항과 CWE 가 달라 한 매핑 항목에 담을 수 없다. 감사 대응상 근거가 섞이면 안 되므로 `finguard.ts.weak-crypto` 로 분리했다.

## 검증에서 나온 반박을 어떻게 반영했나

**재현율 수호자 — arity 기반 pattern-not 은 실취약을 지운다**
원안의 "2번째 인자로 파라미터 배열을 넘기면 제외"를 **넣지 않았다**. 제외 조건은 "인자가 상수 문자열 리터럴일 때"뿐이다. 반례로 제시된 `pool.query(\`... id = ${x} ... AND status = $1\`, ["A"])` 가 픽스처에 정탐으로 들어가 있고 실제로 검출된다.

**재현율 수호자 — 태그드 템플릿 안의 `Prisma.raw()`**
별도 싱크로 추가했다. `prisma.$queryRaw\`SELECT * FROM ${Prisma.raw(tableName)}\`` 가 검출된다(픽스처 정탐). 태그드 템플릿 자체는 진짜 파라미터화이므로 계속 제외된다.

**재현율 수호자 — 증거 3·4(파생 IV·전역 IV 재사용)와 룰이 어긋난다**
동의한다. `hardcoded-crypto-material` 은 리터럴 IV 와 IV 없는 deprecated API 만 본다는 한계를 룰 주석과 매핑 `explain` 에 명시했고, 증거 3·4 를 이 룰의 근거로 삼지 않았다. 다만 같은 파일(TokenManager.ts)의 **하드코드된 대칭키(`ENCRYPT_KEY`)** 는 이 룰이 실제로 잡는다. 파생 IV·IV 재사용은 값 흐름 추적이 필요해 별도 룰 대상이다.

**금융 규제·반입심사 — 매핑 미등록이면 코멘트가 생략된다**
같은 PR 에서 5개 항목을 `mapping/rules.yaml` 에 등록했다. `kisa_item` 은 SQLi→19, 암호재료→43, 취약 알고리즘→52, 난수→30(기존 `go.weak-rand-crypto`·`kotlin.insecure-random` 과 동일), TLS→47(기존 `python.tls-verify-disabled` 와 동일)로 승계했다. 난수 항목은 "확실하지 않으면 공란" 지침이 있었으나, 동일 CWE-338 기존 항목 두 건이 이미 30 을 쓰고 있어 승계 원칙을 따랐다.

**semgrep 구현자 — taint 가 아니라 직접 patterns 구조**
`mode: taint` 를 쓰지 않고 `java.sql-string-build` 와 같은 `patterns` + `focus-metavariable` + `metavariable-pattern` 구조로 작성했다. 실증거는 환경변수·`process.argv` 값이 템플릿에 직접 들어가 `$REQ.*` 소스를 거치지 않으므로 taint 로는 잡히지 않는다.

## 구현 중 발견한 semgrep 엔진 제약

`semgrep 1.169.0` 은 **`export namespace X { ... }` 본문 안의 호출을 AST 패턴으로 매칭하지 못한다**. 같은 코드를 `namespace X` 로 바꾸면 매칭된다(최소 재현으로 확인). 이슈 증거인 `PaymentSetupWizard.ts` 의 `$executeRawUnsafe` 가 정확히 그 형태여서 AST 갈래로는 영영 미탐이었다.

그래서 `ts.sql-injection` 의 (A) 갈래(이름이 unsafe 를 선언하는 raw 실행 API)는 정규식으로, (B) 갈래(범용 `.query`/`.execute`/`.raw` 싱크)는 AST 로 작성했다. 두 갈래가 같은 줄을 이중 검출하지 않도록 (B) 에 `pattern-not: Prisma.raw(...)`/`Prisma.sql(...)` 를 넣었다.

또 `metavariable-pattern` 안에서 "조립 흔적"과 "SQL 키워드"를 `pattern-either` + `pattern-regex` 두 조건으로 나누면 semgrep 이 두 매치의 **범위 교집합**을 요구해, 두 흔적이 떨어져 있는 문자열(`"... acct = '" + acct + "'"`)이 조용히 누락된다. 한 정규식 안에서 lookahead 로 함께 요구하도록 합쳤다.

## 실코드 검출 — 수정 전/후

코퍼스: `campaign/r0`(한국투자증권 OpenAPI) · `r1`(samchon/payments). r2~r9 는 TS/JS 파일이 0개라 이 룰의 대상이 아니다(전 코퍼스 TS/JS 파일 총 346개 = r0 106 + r1 240).

| 코퍼스 | 스캔 파일 | 전체 검출 전 | 전체 검출 후 | 신규 룰 검출 |
| :--- | ---: | ---: | ---: | ---: |
| r1 (samchon/payments) | 181 | 0 | 4 | 4 |
| r0 (한국투자증권 OpenAPI) | 1067 | 40 | 40 | 0 |

r0 의 40건은 전부 기존 python/shell 룰이며 이번 변경으로 늘거나 줄지 않았다(신규 룰 0건 = TS 파일에서 오탐 없음).

r1 신규 검출 4건 전수 확인 — 모두 정탐:

| 파일:라인 | 룰 | 판정 |
| :--- | :--- | :--- |
| `packages/payment-backend/src/executable/schema.ts:26` | ts.sql-injection | 정탐 — 이슈 증거 1. 환경변수·`process.argv` 로 만든 DDL 을 `$queryRawUnsafe()` 에 전달 |
| `packages/payment-backend/src/PaymentSetupWizard.ts:24` | ts.sql-injection | 정탐 — 이슈 증거 2. `$executeRawUnsafe(\`GRANT ... ${env}\`)` |
| `packages/payment-backend/src/utils/TokenManager.ts:79` | ts.hardcoded-crypto-material | 정탐 — 하드코드된 AES 대칭키 `ENCRYPT_KEY` |
| `packages/fake-iamport-server/src/controllers/FakeIamportCertificationsController.ts:95` | ts.insecure-random | 정탐 — `__otp: randint(0, 9999)` (비암호학적 난수로 OTP 생성) |

이슈 본문이 지목한 파일:라인 중 `schema.ts:26` 과 `PaymentSetupWizard.ts:23`(실제 호출 시작 줄 24)은 검출된다. 오탐 폭증은 없다 — TS/JS 346개 파일에서 신규 검출 4건, 전부 정탐.

## 변이 시험

픽스처를 일부러 깨뜨려 회귀 테스트가 실제로 실패하는지 확인했다(확인 후 원복, 최종 상태는 통과).

| 변이 | 기대 | 실제 |
| :--- | :--- | :--- |
| `tls-verify-disabled` 마커 1개 제거 | 오탐 회귀로 실패 | `오탐 회귀 — 마커가 없는데 검출됐다: ts_parity_vulns.ts:67 finguard.ts.tls-verify-disabled` → FAIL |
| 검출되지 않는 줄(`import https ...`)에 `sql-injection` 마커 추가 | 미탐 회귀로 실패 | `미탐 회귀 — 마커가 있는데 검출되지 않았다: ts_parity_vulns.ts:5 finguard.ts.sql-injection` → FAIL |

## 일부러 넣지 않은 패턴과 그 이유

- **인자 개수 기반 SQL 제외**: 보간과 바인딩을 섞은 코드가 정확히 취약하다(위 반박 반영).
- **`$DB.query()` 에 SQL 키워드 없이 발화**: GraphQL·Mongo·검색 클라이언트도 `.query()` 를 쓴다. 이름만으로는 SQL 인지 알 수 없어 보간·연결 + SQL 키워드를 동시에 요구했다. 대신 이름이 `Unsafe` 를 선언하는 API 는 키워드 조건 없이 잡는다.
- **이름 조건 없는 `Math.random`**: 화면용 ID·애니메이션 지연 난수가 전부 오탐이 되어 도구를 못 쓰게 된다. 대신 `iv`·`seed`·`salt`·`nonce` 는 완전 단어로만 본다(부분문자열로 두면 `drive`·`receive` 가 걸린다 — 대조군 픽스처에 넣었다).
- **이슈 증거 5(`test/manual/password.ts:8`)**: 식별자가 `CHARACTERS`·`LETTERS`·`alphaNumeric` 뿐이라 보안 어휘가 하나도 없다. 이름 조건을 만족하지 않아 **검출되지 않으며, 잡으려면 이름 조건을 없애야 해 넣지 않았다.** 이 한계를 룰 주석에 명시했다.
- **파생·재사용 IV 탐지**: 값 흐름 추적이 필요해 정적 정규식 범위를 벗어난다. 별도 룰 대상으로 남긴다.

## 검증 결과

| 명령 | 결과 |
| :--- | :--- |
| `semgrep --validate --config rules/` | 통과 — `Configuration is valid - found 0 configuration error(s), and 97 rule(s)` (92 → 97) |
| `go build -mod=vendor ./...` | 통과 |
| `go vet -mod=vendor ./...` | 통과 |
| `go test -race -mod=vendor ./...` | 통과 |
| `go test -race -mod=vendor -tags semgrep_integration ./internal/scanner/` | 통과 — `기대 32건 · 검출 32건 · 전부 일치` |

`internal/scanner/integration_test.go` 는 수정하지 않았다(마커가 곧 기대값). 다른 언어 룰 파일도 건드리지 않았다.
