### PR TITLE
fix(#24): 설정파일 시크릿 룰 스코프 확장 + plist·CI 전용 룰 분리

### DIFF
--- a/mapping/rules.yaml
+++ b/mapping/rules.yaml
@@ -1513,4 +1513,35 @@
         allow_origins=["https://desk.example.com"],   # 와일드카드 금지
         allow_methods=["GET"],
     )
+
+- rule_id: finguard.config.plist-secret
+  code: FIN-KEY-009
+  cwe: CWE-798
+  title: plist 평문 시크릿
+  severity: ERROR
+  basis: 개발보안가이드 「보안기능 - 하드코드된 중요정보」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 43 (앱 소스코드 내 운영정보 노출 방지)"
+  explain: plist 에 API 키·토큰·비밀번호가 평문으로 들어 있습니다. plist 는 배포 번들에 그대로 포함되어 단말에서 추출할 수 있으므로, 저장소 커밋 여부와 무관하게 노출됩니다. 빌드 시 주입하거나 Keychain 등 보호 저장소를 사용해야 합니다.
+  fix_example: |
+    ```xml
+    <!-- 평문 값 대신 빌드 설정에서 주입 -->
+    <key>API_KEY</key>
+    <string>${API_KEY}</string>
+    ```
+
+- rule_id: finguard.ci.plaintext-secret
+  code: FIN-KEY-010
+  cwe: CWE-798
+  title: CI 설정 평문 시크릿
+  severity: WARNING
+  basis: 개발보안가이드 「보안기능 - 하드코드된 중요정보」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 43 (앱 소스코드 내 운영정보 노출 방지)"
+  explain: CI 파이프라인 설정에 배포 토큰·비밀번호가 평문으로 들어 있습니다. 파이프라인 정의는 저장소에 커밋되므로 이력에 영구히 남고, 로그로도 흘러나갈 수 있습니다. 파이프라인 시크릿 저장소(GitHub Actions secrets / GitLab CI variables)로 옮겨 참조해야 합니다.
+  fix_example: |
+    ```yaml
+    deploy:
+      script:
+        - ./scripts/publish.sh
+      variables:
+        ARTIFACT_API_KEY: $ARTIFACT_API_KEY   # 평문 값 대신 CI 변수 참조
     ```

--- a/rules/config.yaml
+++ b/rules/config.yaml
@@ -1,11 +1,128 @@
 rules:
+  # 설정파일 평문 시크릿 (#24).
+  #
+  # 스코프가 application*.yml / *.properties 3종뿐이라 Spring 관례를 따르지 않는 레포에서는
+  # 룰이 파일을 열지도 못했다. 커밋된 .env·config.json·*.xcconfig·*.tfvars 는 금융권 레포의
+  # 대표적 유출 경로이므로 include 를 확장한다.
+  #
+  # 키 이름 앞뒤의 따옴표를 선택적으로 허용해 JSON·tfvars 형태("password": "...")도 매칭한다.
+  # 확장 전 정규식은 라인 선두 직후 식별자를 [\w.-]* 로만 허용해 JSON 에서 0건이었다.
+  #
+  # CI 파이프라인 설정은 제외하지 않는다 — 배포 토큰·DB 비밀번호 유출의 대표 경로다. 다만
+  # 서비스 컨테이너 부트스트랩 변수 노이즈가 있어 severity 를 낮춘 별도 룰(finguard.ci.plaintext-secret)로
+  # 분리했고, 중복 코멘트를 막기 위해 이 룰에서는 CI 경로를 뺀다.
   - id: finguard.config.plaintext-secret
     languages: [regex]
     severity: ERROR
     message: 설정파일에 시크릿이 평문으로 들어 있습니다. 환경변수 치환(${VAR}) 또는 시크릿 저장소를 사용해야 합니다.
     paths:
-      include: ["application*.yml", "application*.yaml", "*.properties"]
+      include:
+        - "application*.yml"
+        - "application*.yaml"
+        - "*.properties"
+        - "*.yml"
+        - "*.yaml"
+        - ".env"
+        - ".env.*"
+        - "*.env"
+        - "config*.json"
+        - "appsettings*.json"
+        - "*.tfvars"
+        - "*.xcconfig"
+      exclude:
+        # 서드파티 산출물 — 점검 대상 팀의 코드가 아니다
+        - "**/node_modules/**"
+        - "**/vendor/**"
+        - "Pods/**"
+        - "**/*.lock"
+        - "**/package-lock.json"
+        # 플레이스홀더의 표준 서식지 — 값이 시크릿이 아니라 예시다
+        - "*.example"
+        - "*.sample"
+        - "*.template"
+        - "*.dist"
+        - ".env.example"
+        - ".env.sample"
+        - ".env.template"
+        # CI 설정은 finguard.ci.plaintext-secret(WARNING) 담당
+        - ".github/workflows/**"
+        - "**/.github/workflows/**"
+        - ".gitlab-ci*.yml"
+        - "**/.gitlab-ci*.yml"
+        - "*gitlab-ci*.yml"
+        - ".circleci/**"
+        - "**/.circleci/**"
     patterns:
-      - pattern-regex: '(?i)^\s*[\w.-]*(password|passwd|secret|token|api[_-]?key)[\w.-]*\s*[:=]\s*(?!\s*$)(?!\$\{)(?!ENC\()["'']?[^\s"''#][^#\n]{3,}'
+      # 구분자 뒤 공백을 [ \t]* 로 제한한다 — \s* 는 개행을 넘어가 "값이 비어 있는 키"
+      # (예: openapi 의 `ApiKeyAuth:`) 가 다음 줄을 값으로 삼는 오탐을 만든다.
+      - pattern-either:
+          - pattern-regex: '(?i)^[ \t]*["'']?[\w.-]*(password|passwd|secret|token|api[_-]?key)[\w.-]*["'']?[ \t]*[:=][ \t]*(?![ \t]*$)(?!\$\{)(?!ENC\()["'']?[^\s"''#][^#\n]{3,}'
+          # 고신뢰 프리픽스 — 키 이름과 무관하게 값 자체가 Google API 키다
+          - pattern-regex: '\bAIza[0-9A-Za-z_-]{35}\b'
       # 마스킹 플레이스홀더는 시크릿이 아니다 — 오히려 가리는 코드다
       - pattern-not-regex: '(?i)["''`](\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|<[^>]*redact[^>]*>|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]|[:=]\s*(\*{3,}|•{3,}|#{3,})(?![\w-])'
+      # pattern-not-regex 는 검출 범위를 "포함"할 때만 억제된다(semgrep 1.169.0 실측).
+      # 값 부분만 매칭하는 정규식은 필터로 동작하지 않으므로 아래 억제 패턴은 줄 전체를 잡는다.
+      #
+      # 값이 시크릿이 아닌 스키마/플래그 — 스코프 확장으로 유입되는 대표 노이즈
+      - pattern-not-regex: '(?im)^\s*["'']?[\w.-]+["'']?\s*[:=]\s*["'']?(true|false|null|none|nil|yes|no|on|off|required|optional|string|integer|boolean|object|array|number)["'']?\s*(#.*)?$'
+      # 다른 키·환경변수·시크릿 저장소를 가리키는 참조는 값이 아니다
+      - pattern-not-regex: '(?im)^\s*["'']?[\w.-]+["'']?\s*[:=]\s*["'']?(\$|\{\{|<%|%\(|env:|secretKeyRef|valueFrom|vault:|aws:|arn:).*$'
+      # 앞자리만 남기고 잘라 둔 자리표시자 (예: APP_SECRET: "UH...") — 값이 아니라 서식 안내다
+      - pattern-not-regex: '(?im)^\s*["'']?[\w.-]+["'']?\s*[:=]\s*["'']?[\w-]{0,6}\.{2,}["'']?\s*$'
+      # YAML 안에 삽입된 코드 예시(문서·매핑 테이블의 fix_example 등)는 설정값이 아니다.
+      # Go 단축 선언(:=) 과 함수 호출·첨자 접근으로 값을 받아오는 형태를 제외한다.
+      - pattern-not-regex: '(?im)^\s*[\w.-]+\s*:=.*$'
+      - pattern-not-regex: '(?im)^\s*["'']?[\w.-]+["'']?\s*[:=]\s*[\w.]+[(\[].*$'
+
+  # plist 는 key 와 값이 두 줄로 나뉘어 key=value 정규식이 닿지 않는다 (#24).
+  # iOS 앱의 GoogleService-Info.plist·Secrets.plist 는 커밋 시 그대로 배포 번들에 실린다.
+  - id: finguard.config.plist-secret
+    languages: [regex]
+    severity: ERROR
+    message: plist 에 시크릿이 평문으로 들어 있습니다. 배포 번들에 그대로 포함되어 추출 가능하므로, 빌드 시 주입하거나 보호 저장소(Keychain)를 사용해야 합니다.
+    paths:
+      include: ["*.plist"]
+      exclude:
+        - "**/node_modules/**"
+        - "**/vendor/**"
+        - "Pods/**"
+        - "*.example"
+        - "*.sample"
+        - "*.template"
+    patterns:
+      - pattern-regex: '(?is)<key>[^<]*(api[_-]?key|secret|token|password|client[_-]?secret)[^<]*</key>\s*<string>(?!\s*[$\{])[^<]{8,}</string>'
+      - pattern-not-regex: '(?i)<string>\s*(\*{3,}|x{3,}|redacted|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme|none|null|false|true)\s*</string>'
+
+  # CI 파이프라인 설정의 평문 시크릿 (#24).
+  #
+  # 워크플로 env: 에 박힌 PAT·배포키는 즉시 악용 가능한 정탐이라 스코프에서 빼지 않는다.
+  # 다만 서비스 컨테이너 부트스트랩 변수(POSTGRES_PASSWORD 등)는 일회성 로컬 값이라 노이즈가
+  # 크므로 그 변수명에 한해 억제하고, severity 는 WARNING 으로 두어 기본 게이트를 막지 않는다.
+  - id: finguard.ci.plaintext-secret
+    languages: [regex]
+    severity: WARNING
+    message: CI 파이프라인 설정에 시크릿이 평문으로 들어 있습니다. 파이프라인 시크릿 저장소(GitHub Actions secrets / GitLab CI variables)를 사용해야 합니다.
+    paths:
+      include:
+        - ".github/workflows/**"
+        - "**/.github/workflows/**"
+        - ".gitlab-ci*.yml"
+        - "**/.gitlab-ci*.yml"
+        - "*gitlab-ci*.yml"
+        - ".circleci/**"
+        - "**/.circleci/**"
+    patterns:
+      # `- KEY=값` 형태의 script 스텝도 CI 에서 흔한 유출 지점이라 목록 항목 접두를 허용한다.
+      - pattern-regex: '(?i)^[ \t]*(-[ \t]+)?["'']?[\w.-]*(password|passwd|secret|token|api[_-]?key)[\w.-]*["'']?[ \t]*[:=][ \t]*(?![ \t]*$)(?!\$\{)(?!ENC\()["'']?[^\s"''#][^#\n]{3,}'
+      # 억제 패턴은 줄 전체를 잡아야 필터로 동작한다(위 룰의 주석 참조).
+      #
+      # 컨테이너 부트스트랩 변수 — services:/image: 로 띄우는 일회성 로컬 자격증명
+      - pattern-not-regex: '(?im)^\s*["'']?(POSTGRES|POSTGRESQL|MYSQL|MARIADB|MONGO|MONGODB|REDIS|RABBITMQ|ELASTIC|MSSQL|SA)_[\w]*(PASSWORD|PASS)["'']?\s*[:=].*$'
+      - pattern-not-regex: '(?im)^\s*["'']?(MYSQL_ROOT_PASSWORD|MONGO_INITDB_ROOT_PASSWORD|SA_PASSWORD)["'']?\s*[:=].*$'
+      # 마스킹 플레이스홀더
+      - pattern-not-regex: '(?i)["''`](\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|<[^>]*redact[^>]*>|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]|[:=]\s*(\*{3,}|•{3,}|#{3,})(?![\w-])'
+      - pattern-not-regex: '(?im)^\s*["'']?[\w.-]+["'']?\s*[:=]\s*["'']?(true|false|null|none|nil|yes|no|on|off|required|optional|string|integer|boolean|object|array|number)["'']?\s*(#.*)?$'
+      # 시크릿 저장소 참조는 시크릿이 아니라 올바른 사용법이다
+      - pattern-not-regex: '(?im)^\s*["'']?[\w.-]+["'']?\s*[:=]\s*["'']?(\$|\{\{|<%|%\(|env:|secretKeyRef|valueFrom|vault:|aws:|arn:).*$'
+      - pattern-not-regex: '(?im)^\s*["'']?[\w.-]+["'']?\s*[:=]\s*["'']?[\w-]{0,6}\.{2,}["'']?\s*$'

--- a/testdata/rule-fixtures/Secrets-Info.plist
+++ b/testdata/rule-fixtures/Secrets-Info.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- 룰 회귀 픽스처 — finguard.config.plist-secret (#24)
+     key 와 값이 두 줄로 나뉘어 key=value 정규식이 닿지 않는 형태다. 값은 합성 더미다.
+     semgrep 은 매치 시작 줄(<key> 가 있는 줄)을 보고하므로 마커는 그 줄 바로 위에 둔다. -->
+<plist version="1.0">
+<dict>
+	<key>BUNDLE_ID</key>
+	<string>com.example.trading</string>
+	<!--
+	# EXPECT: finguard.config.plist-secret
+	--><key>API_KEY</key>
+	<string>AIzaSyA1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q</string>
+	<!--
+	# EXPECT: finguard.config.plist-secret
+	--><key>CLIENT_SECRET</key>
+	<string>0d1f2a3b4c5d6e7f8091a2b3c4d5e6f7</string>
+	<key>IS_ADS_ENABLED</key>
+	<false/>
+	<key>API_KEY_SOURCE</key>
+	<string>${API_KEY}</string>
+</dict>
+</plist>

--- a/testdata/rule-fixtures/config_secrets.yml
+++ b/testdata/rule-fixtures/config_secrets.yml
@@ -1,0 +1,19 @@
+# 룰 회귀 픽스처 — finguard.config.plaintext-secret (#24)
+# Spring 관례를 따르지 않는 일반 YAML 설정도 스코프에 들어온다.
+
+datasource:
+  url: jdbc:postgresql://db.example.com:5432/core
+  username: core_app
+  # EXPECT: finguard.config.plaintext-secret
+  password: Tr4d1ng-Ops-2026!
+
+payments:
+  # EXPECT: finguard.config.plaintext-secret
+  api_key: sk_live_9f8e7d6c5b4a32100011
+  # EXPECT: finguard.config.plaintext-secret
+  client_secret: 0d1f2a3b4c5d6e7f8091a2b3
+
+google:
+  # 키 이름과 무관하게 값 자체가 Google API 키인 경우 (고신뢰 프리픽스)
+  # EXPECT: finguard.config.plaintext-secret
+  credential: AIzaSyA1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q

--- a/testdata/rule-fixtures/safe_config.yml
+++ b/testdata/rule-fixtures/safe_config.yml
@@ -1,0 +1,32 @@
+# 대조군 픽스처 — 어떤 룰에도 걸리면 안 된다 (#24).
+# 스코프 확장으로 새로 열리는 일반 YAML 에서 대표적으로 유입되는 비-시크릿 라인들이다.
+# safe_ 접두라 EXPECT 마커를 가질 수 없다.
+
+datasource:
+  url: jdbc:postgresql://db.example.com:5432/core
+  # 환경변수 치환 — 올바른 사용법
+  password: ${DB_PASSWORD}
+
+auth:
+  # 값이 플래그·스키마인 경우
+  token_required: true
+  api_key_rotation: false
+  client_secret_source: env:CLIENT_SECRET
+
+k8s:
+  env:
+    - name: DB_PASSWORD
+      valueFrom: secretKeyRef
+
+openapi:
+  components:
+    securitySchemes:
+      ApiKeyAuth:
+        type: apiKey
+        name: X-API-KEY
+
+masked:
+  # 마스킹 플레이스홀더는 시크릿이 아니라 가리는 코드다
+  password: "********"
+  api_key: "your-api-key"
+  client_secret: "CHANGE_ME"

--- a/testdata/rule-fixtures/sample.env
+++ b/testdata/rule-fixtures/sample.env
@@ -1,0 +1,12 @@
+# 룰 회귀 픽스처 — finguard.config.plaintext-secret (#24)
+# 커밋된 .env 는 금융권 레포의 대표적 유출 경로다. 값은 전부 합성 더미다.
+
+APP_ENV=production
+DB_HOST=db.example.com
+# EXPECT: finguard.config.plaintext-secret
+DB_PASSWORD=Ops-Db-2026-Xk91
+# EXPECT: finguard.config.plaintext-secret
+PG_API_KEY=live_11223344556677889900
+# 시크릿 저장소·환경변수 참조는 값이 아니다 (억제 대상)
+VAULT_TOKEN=${VAULT_TOKEN}
+FEATURE_TOKEN_ROTATION=true

--- a/testdata/rule-fixtures/sample.gitlab-ci.yml
+++ b/testdata/rule-fixtures/sample.gitlab-ci.yml
@@ -1,0 +1,24 @@
+# 룰 회귀 픽스처 — finguard.ci.plaintext-secret (#24)
+# CI 설정은 스코프에서 빼지 않고 WARNING 별도 룰로 분리한다. 값은 합성 더미다.
+
+stages: [build, deploy]
+
+services:
+  - name: postgres:16
+    alias: db
+
+variables:
+  # 컨테이너 부트스트랩 변수는 일회성 로컬 값이라 억제된다
+  POSTGRES_PASSWORD: ci_local_only
+  MYSQL_ROOT_PASSWORD: ci_local_only
+  # 시크릿 저장소 참조는 올바른 사용법이다
+  DEPLOY_TOKEN: $CI_DEPLOY_TOKEN
+
+deploy:
+  stage: deploy
+  script:
+    # EXPECT: finguard.ci.plaintext-secret
+    - REGISTRY_PASSWORD=Gl-Deploy-2026-Zq77 ./scripts/publish.sh
+  variables:
+    # EXPECT: finguard.ci.plaintext-secret
+    ARTIFACT_API_KEY: ci_11223344556677889900


### PR DESCRIPTION
Closes #24

설정파일 시크릿 룰이 Spring 관례(`application*.yml` / `*.properties`)에만 걸려 있어 코퍼스 10개 중 8개에서 파일을 열지도 못하던 문제를 고친다. 스코프를 넓히는 변경이라 오탐 억제를 함께 넣고 실코드로 측정했다.

## 룰 변경

| 룰 ID | 상태 | severity | 내용 |
| :--- | :--- | :--- | :--- |
| `finguard.config.plaintext-secret` | 수정 | ERROR | include 확장 + JSON/tfvars 대응(키 따옴표 허용) + AIza 프리픽스 |
| `finguard.config.plist-secret` | 신규 | ERROR | plist 전용 멀티라인 `<key>`/`<string>` 패턴 |
| `finguard.ci.plaintext-secret` | 신규 | WARNING | CI 파이프라인 설정 전용 |

include 추가: `*.yml`, `*.yaml`, `.env`, `.env.*`, `*.env`, `config*.json`, `appsettings*.json`, `*.tfvars`, `*.xcconfig`, (plist 룰) `*.plist`.
매핑에 `FIN-KEY-009` / `FIN-KEY-010` 을 등록해 **룰 94개 : 매핑 94개** 1:1 을 유지한다.

## 검증에서 나온 반박 반영 내역

1. **`.github/workflows/**` · `.gitlab-ci*.yml` 전면 제외 폐기** (재현율·규제 두 렌즈 공통 거부) — 워크플로 `env:` 의 PAT·배포키는 즉시 악용 가능한 1급 정탐이다. 원안의 exclude 를 버리고 **CI 설정을 include 하되 `finguard.ci.plaintext-secret`(WARNING) 별도 룰로 분리**했다. 게이트는 막지 않고 코멘트는 남는다. 노이즈 원인이 특정된 컨테이너 부트스트랩 변수(`POSTGRES_PASSWORD`·`MYSQL_ROOT_PASSWORD` 등)만 `pattern-not-regex` 로 좁혀 억제한다. `.circleci/**` 도 같은 성격이라 CI 룰로 함께 묶었다.
2. **`.env.example` / `.env.sample` / `.env.template` / `*.dist` 배제** (재현율 수호자 지적) — 플레이스홀더의 표준 서식지이므로 ERROR 룰 exclude 에 넣었다.
3. **`*.json` / `*.tfvars` 확장이 기존 정규식과 정렬되지 않는다** (semgrep 구현 렌즈 실측: `"password": "..."` 에서 0 findings) — 키 매칭부를 `["']?[\w.-]*(...)["']?` 로 고쳐 따옴표로 감싸인 키에서도 매치되게 했다. 픽스처에 JSON 유사 형태를 포함해 회귀로 고정한다.
4. **plist 멀티라인 패턴 + `AIza[0-9A-Za-z_-]{35}` 프리픽스** — 원안 그대로 채택. plist 는 별도 룰(`finguard.config.plist-secret`), AIza 는 키 이름과 무관한 고신뢰 값이라 메인 룰의 `pattern-either` 에 넣었다.
5. **신규 룰ID 는 매핑 필수** (매핑 없는 룰은 코멘트가 통째로 생략 = 검출 0) — 두 신규 룰 모두 매핑에 등록했다. `basis`·`kisa_item` 은 같은 CWE-798 의 기존 엔트리(`finguard.config.plaintext-secret`) 값을 그대로 승계했다(개발보안가이드 「보안기능 - 하드코드된 중요정보」 / 평가기준 43).
6. **`**/vendor/**` 는 exclude 유지** — 두 렌즈가 갈렸다(재현율=제거, 규제=수용). 점검 대상 팀이 소유·수정하지 않는 서드파티 산출물이고, 이 레포 자신도 폐쇄망 대응으로 `vendor/` 를 커밋한다. 판단이 뒤집히면 한 줄로 되돌릴 수 있게 exclude 목록에 사유 주석을 달았다.

## 구현 중 실측으로 드러난 semgrep 동작 2건

- **`pattern-not-regex` 는 검출 범위를 "포함" 할 때만 억제된다.** 값 부분만 매칭하는 억제 정규식(`[:=]\s*(true|false)...`)은 필터로 전혀 동작하지 않았다. 억제 패턴을 전부 줄 전체(`(?im)^...$`)를 잡도록 다시 썼다.
- **`\s*` 는 개행을 넘어간다.** 구분자 뒤를 `\s*` 로 두면 값이 비어 있는 키(openapi 의 `ApiKeyAuth:`)가 다음 줄을 값으로 삼아 오탐이 난다. `[ \t]*` 로 제한했다.

## 실코드 검증 — 코퍼스 10개 수정 전/후 검출 수

| 레포 | 수정 전 | 수정 후 | 증감 | 새로 터진 건의 성격 |
| :--- | ---: | ---: | ---: | :--- |
| r0 open-trading-api (Python) | 40 | 40 | 0 | `kis_devlp.yaml`·`legacy/rest/config.yaml` 은 스캔 대상이 됐으나 값이 잘라 둔 자리표시자(`"UH..."`)라 억제됨 |
| r1 samchon/payments (TS) | 0 | **4** | +4 | git 추적 중인 `packages/payment-backend/.env` 의 `*_PASSWORD` 2건 · `*_SECRET` 2건 — 전부 정탐 |
| r2 CoinNow (Swift) | 1 | 1 | 0 | — |
| r3 DuDoong-Backend (Kotlin) | 5 | **7** | +2 | `docker-compose.yml` 의 `MYSQL_ROOT_PASSWORD`·`MYSQL_PASSWORD` 평문 값 |
| r4 iamport-python | 0 | 0 | 0 | — |
| r5 AXSnapshot (Swift) | 0 | 0 | 0 | — |
| r6 reactive-crypto (Kotlin) | 0 | **1** | +1 | `.circleci/config.yml` 의 codecov 업로드 토큰 평문 — 정탐(WARNING) |
| r7 pybithumb (Python) | 0 | 0 | 0 | — |
| r8 iamport-java | 0 | 0 | 0 | — |
| r9 upbitBar (Swift) | 0 | 0 | 0 | — |
| **합계** | **46** | **53** | **+7** | 오탐 0 |

증가분 7건은 모두 커밋된 파일의 평문 자격증명이다. 억제 없이 돌렸을 때 나오던 오탐 후보 2종(자리표시자 `APP_SECRET: "UH..."`, CI 컨테이너 부트스트랩 변수)은 억제 패턴으로 제거했고, `docker-compose.yml` 의 DB 비밀번호는 실제 커밋된 평문 자격증명이라 정탐으로 남겼다(레포별 조정이 필요하면 `.finguard.yml` 의 `ignore`·`block_on` 으로 흡수 가능).

**자체 레포 스캔**(`semgrep --config rules/ --exclude testdata .`)도 함께 돌렸다. 확장 직후에는 `mapping/rules.yaml` 의 `fix_example` 코드블록(`apiKey := os.Getenv("API_KEY")` 등) 3건이 오탐으로 잡혔고, YAML 안에 삽입된 코드(Go 단축 선언 `:=`, 함수 호출·첨자 접근 값) 억제를 추가해 **0건**으로 정리했다.

## 변이 시험

| 변이 | 기대 | 결과 |
| :--- | :--- | :--- |
| `config_secrets.yml` 의 `api_key` 마커 제거 | 오탐 회귀로 실패 | `오탐 회귀 — 마커가 없는데 검출됐다: config_secrets.yml:11 finguard.config.plaintext-secret` → FAIL |
| `safe_config.yml` 의 `password: ${DB_PASSWORD}` 줄에 마커 추가 | 미탐 회귀 + 대조군 위반으로 실패 | `미탐 회귀 — 마커가 있는데 검출되지 않았다: safe_config.yml:8 ...` + `TestSafeFixturesHaveNoExpectations` FAIL |

두 변이 모두 원복 후 전체 통과를 재확인했다.

## 일부러 넣지 않은 패턴과 이유

- **`*.json` 전반(`*.json` 와일드카드)** — `config*.json`·`appsettings*.json` 으로 한정했다. 모든 JSON 을 열면 package.json·tsconfig·잠금 파일 계열·번들 산출물까지 들어와 스코프 대비 소득이 낮다.
- **엔트로피 기반 시크릿 탐지** — 키 이름과 무관하게 고엔트로피 문자열을 잡는 방식은 오탐률이 높아 이번 확장의 균형을 깨뜨린다. 키 이름 기반 + 고신뢰 프리픽스(AIza)만 사용했다.
- **`id_rsa`·PEM 개인키 블록** — 별개의 유출 경로이고 파일 스코프도 달라 이 이슈에서 분리했다.
- **`*.pbxproj`** — 이슈 근거의 CoinNow 사례는 pbxproj 자체가 아니라 그 프로젝트가 참조하는 `GoogleService-Info.plist` 가 대상이다. pbxproj 는 시크릿 서식이 아니라 빌드 그래프라 스코프에 넣지 않았다.
- **`.env.example` 계열의 WARNING 룰** — 이슈 논의의 nonprod(P3) 계열로, 이번 PR 은 ERROR 룰의 오탐 제거까지만 한다.

## 검증 결과

- `semgrep --validate --config rules/` → `Configuration is valid - found 0 configuration error(s), and 94 rule(s).`
- `go build -mod=vendor ./... && go vet -mod=vendor ./...` → 통과
- `go test -race -mod=vendor ./...` → 전 패키지 ok (매핑 1:1 테스트 포함)
- `go test -race -mod=vendor -tags semgrep_integration ./internal/scanner/` → ok
