### PR TITLE
fix(gitlab): 소스 확보 경로 하드닝 — checkout 인자 인젝션 차단 + clone https 강제

### DIFF
--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -8,8 +8,14 @@ import (
 	"fmt"
 	"net/url"
 	"os/exec"
+	"regexp"
 	"strings"
 )
+
+// shaPattern 은 git 커밋 해시(축약 포함, sha-1/sha-256) 형식이다.
+// checkout 인자로 넘기기 전 payload 의 sha 가 이 형식인지 검증해,
+// `-` 로 시작하는 값이 git 옵션으로 해석되는 인자 인젝션을 차단한다.
+var shaPattern = regexp.MustCompile(`^[0-9a-fA-F]{7,64}$`)
 
 // ValidateCloneHost 는 webhook payload 의 clone URL 이 신뢰 GitLab(apiV4URL 의
 // 호스트)을 가리키는지 검증한다. payload 는 위조 가능하므로, 검증 없이 clone 하면
@@ -23,8 +29,10 @@ func ValidateCloneHost(apiV4URL, cloneURL string) error {
 	if err != nil {
 		return fmt.Errorf("clone URL 파싱 실패: %w", err)
 	}
-	if cu.Scheme != "https" && cu.Scheme != "http" {
-		return fmt.Errorf("clone URL scheme 불허: %s", cu.Scheme)
+	// https 만 허용한다. http 를 허용하면 FetchSource 가 URL 에 심는 oauth2
+	// 토큰이 평문으로 전송될 수 있다(위조 payload 로 다운그레이드 가능).
+	if cu.Scheme != "https" {
+		return fmt.Errorf("clone URL scheme 불허(https 만 허용): %s", cu.Scheme)
 	}
 	if !strings.EqualFold(au.Hostname(), cu.Hostname()) {
 		return fmt.Errorf("clone URL 호스트 불일치: %s (신뢰 호스트 %s)", cu.Hostname(), au.Hostname())
@@ -52,11 +60,19 @@ func FetchSource(ctx context.Context, cloneURL, token string, mrIID int, sha, de
 		{"git", "-C", destDir, "fetch", "--quiet", "--depth", "50", "origin",
 			fmt.Sprintf("refs/merge-requests/%d/head", mrIID)},
 	}
+	// sha 는 payload 에서 온 위조 가능한 값이다. 형식이 커밋 해시가 아니면
+	// FETCH_HEAD 로 폴백하지 말고 거부한다 — 잘못된 커밋을 조용히 체크아웃하는
+	// 대신 명시적으로 실패하는 편이 안전하다.
 	co := "FETCH_HEAD"
 	if sha != "" {
+		if !shaPattern.MatchString(sha) {
+			return fmt.Errorf("checkout sha 형식 불허: %q", sha)
+		}
 		co = sha
 	}
-	steps = append(steps, []string{"git", "-C", destDir, "checkout", "--quiet", co})
+	// ref 뒤에 "--" 를 두어 pathspec 이 없음을 못박는다(뒤에 붙이는 이유: `--` 앞이
+	// pathspec 이 아니라 커밋으로 해석되어야 하므로). ref 는 위에서 형식 검증된 값이다.
+	steps = append(steps, []string{"git", "-C", destDir, "checkout", "--quiet", co, "--"})
 	for _, s := range steps {
 		cmd := exec.CommandContext(ctx, s[0], s[1:]...)
 		var stderr bytes.Buffer

--- a/internal/gitlab/gitlab_test.go
+++ b/internal/gitlab/gitlab_test.go
@@ -1,6 +1,9 @@
 package gitlab
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func TestValidateCloneHost(t *testing.T) {
 	api := "https://gitlab.example.com/api/v4"
@@ -13,6 +16,7 @@ func TestValidateCloneHost(t *testing.T) {
 		{"다른 호스트", "https://evil.example.com/dok123/app.git", false},
 		{"서브도메인 위장", "https://gitlab.example.com.evil.example.com/a.git", false},
 		{"ssh scheme", "ssh://git@gitlab.example.com/dok123/app.git", false},
+		{"http 다운그레이드", "http://gitlab.example.com/dok123/app.git", false},
 		{"빈 URL", "", false},
 	}
 	for _, tc := range cases {
@@ -22,6 +26,25 @@ func TestValidateCloneHost(t *testing.T) {
 		}
 		if !tc.ok && err == nil {
 			t.Errorf("%s: 거부돼야 하는데 허용됨", tc.name)
+		}
+	}
+}
+
+// FetchSource 는 sha 형식 검증을 git 명령 실행 전에 수행하므로,
+// 비정상 sha 는 네트워크·git 접근 없이 거부돼야 한다.
+func TestFetchSourceRejectsBadSHA(t *testing.T) {
+	bad := []string{
+		"--upload-pack=touch /tmp/pwned", // 옵션 인젝션 시도
+		"-x",
+		"deadbeef; rm -rf /",
+		"refs/heads/main",
+		"zzzz",
+	}
+	for _, sha := range bad {
+		err := FetchSource(context.Background(),
+			"https://gitlab.example.com/a/b.git", "", 1, sha, t.TempDir()+"/src")
+		if err == nil {
+			t.Errorf("비정상 sha %q: 거부돼야 하는데 통과", sha)
 		}
 	}
 }


### PR DESCRIPTION
## 요약

`serve` 모드가 webhook payload 값으로 소스를 확보하는 경로(`internal/gitlab/gitlab.go`)의 심층방어(defense-in-depth) 두 건. 둘 다 webhook secret 을 아는 경로에서만 도달하지만, secret 유출·넓은 신뢰경계를 대비한다.

## 변경

### 1. clone URL https 강제 (CWE-319)

`ValidateCloneHost` 가 `http` 도 통과시켜, 위조 payload 로 스킴을 다운그레이드하면 `FetchSource` 가 URL 에 심는 oauth2 토큰이 평문으로 전송될 수 있었다. `https` 만 허용하도록 한정.

### 2. `git checkout` 인자 인젝션 차단 (CWE-88)

`checkout --quiet <sha>` 의 `sha` 가 payload(`last_commit.id`)에서 온 위조 가능한 값인데, `--` 구분자와 형식 검증이 없어 `-` 로 시작하는 값이 git 옵션으로 해석될 여지가 있었다.

- `sha` 를 `^[0-9a-fA-F]{7,64}$` 로 검증(빈 값은 기존대로 `FETCH_HEAD` 폴백). 형식 검증은 **git 명령 실행 전**에 수행하여, 비정상 sha 는 네트워크·git 접근 없이 거부.
- ref 뒤에 `--` 를 추가해 pathspec 없음을 못박음(`git checkout <ref> --` 형식 — `--` 를 앞에 두면 ref 가 pathspec 으로 오인되므로 뒤에 둔다).

## 테스트

- `ValidateCloneHost`: http 다운그레이드 거부 케이스 추가.
- `FetchSource`: 옵션 인젝션·셸 메타문자·비-hex ref 등 비정상 sha 거부 케이스 추가.
- `go build -mod=vendor ./...` / `go test -mod=vendor ./...` 통과.

Closes #51
