### PR TITLE
feat(#37): 자격증명 검증 없는 개발용 토큰 발급 엔드포인트 룰 신설(Java)

### DIFF
--- a/mapping/rules.yaml
+++ b/mapping/rules.yaml
@@ -1599,4 +1599,30 @@
     with open(token_path, "w", encoding="utf-8") as f:
         f.write(token)
     os.chmod(token_path, 0o600)   # 소유자만 읽기·쓰기
+
+# ── 개발용 인증 우회 엔드포인트 — Java (#37) ─────────────────────────────────
+# basis·kisa_item 은 지어내지 않는다. kisa_item 은 docs/평가기준_웹모바일HTS_66항목.md:46
+# 의 항목 37 표기를 그대로 쓴다.
+
+- rule_id: finguard.java.dev-auth-endpoint
+  code: FIN-DBG-002
+  cwe: CWE-306
+  title: 자격증명 검증 없는 개발용 토큰 발급 엔드포인트(Java)
+  severity: WARNING
+  basis: 개발보안가이드 「보안기능 - 적절한 인증 없이 중요기능 허용」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 37 (불충분한 이용자 인증)"
+  explain: 개발·로컬 전용으로 보이는 경로에서 자격증명 검증 없이 정식 access/refresh 토큰을 발급하고 있습니다. 프로파일 조건만으로는 외부망에 노출된 검증계/개발계를 막지 못합니다. 운영 빌드에서 엔드포인트를 제거하거나(빌드 프로파일 분리), 실제 자격증명 검증을 추가하거나, 네트워크 계층에서 접근을 차단해야 합니다.
+  fix_example: |
+    ```java
+    // 개발 전용 컨트롤러는 프로파일로 격리해 운영 컨텍스트에 등록되지 않게 하고,
+    // 노출되는 경로에는 실제 자격증명 검증을 둔다.
+    @Profile({"local", "dev"})
+    @RestController
+    class LocalLoginController {
+        @PostMapping("/dev/login")
+        public TokenResponse login(@RequestBody LoginRequest request) {
+            authService.verifyCredential(request.getEmail(), request.getRawPassword());
+            return jwtTokenProvider.generateAccessToken(request.getEmail());
+        }
+    }
     ```

--- a/rules/java.yaml
+++ b/rules/java.yaml
@@ -430,3 +430,68 @@ rules:
               - pattern: $E.evaluate($CTX, $W, $TAG, $X)
               - pattern: $E.evaluateExpression($X, ...)
           - focus-metavariable: $X
+
+  # ------------------------------------------------------------------
+  # 10. 개발용 인증 우회 엔드포인트 — 자격증명 검증 없이 토큰 발급 (CWE-489) (#37)
+  # ------------------------------------------------------------------
+  # 여러 줄에 걸친 AND 조건(매핑 애노테이션 경로 어휘 + 같은 메서드 본문의 토큰 발급 호출)이라
+  # 정규식으로는 표현할 수 없어 semantic 모드로 구성했다. Kotlin 문법(fun ...)을 같은 룰에
+  # 섞으면 Java 파서가 파싱 에러를 내므로 languages 는 [java] 단일로 둔다 — Kotlin 대응은
+  # finguard.kotlin.dev-backdoor-endpoint(#28)가 이미 담당한다.
+  #
+  # 억제 사유로 인정하지 않는 것: @Profile("!prod") · 런타임 isProdProfile() 게이트.
+  # 그 게이트는 인터넷에 공개된 staging/검증계에서는 무효라 실제 사고의 유일한(그리고
+  # 뚫린) 방어선이었다.
+  #
+  # 경로 어휘는 "세그먼트" 단위로만 인정한다(/dev/, /local-login/). 부분문자열 매칭이면
+  # /api/v1/devices 같은 정상 경로가 걸린다.
+  - id: finguard.java.dev-auth-endpoint
+    languages: [java]
+    severity: WARNING
+    message: |
+      개발·로컬 전용으로 보이는 경로에서 자격증명 검증 없이 토큰을 발급하고 있습니다. 프로파일 조건(@Profile("!prod")·isProdProfile())만으로는 외부망에 노출된 검증계/개발계를 막지 못합니다. 운영 빌드에서 엔드포인트를 제거하거나(빌드·프로파일 분리), 실제 자격증명 검증을 추가하거나, 네트워크 계층에서 접근을 차단해야 합니다. 이미 그런 완화를 적용했다면 대상 레포의 .finguard.yml `ignore` 에 해당 파일을 명시해 승인 사실을 남기십시오.
+    paths:
+      exclude: ["*Test.java"]
+    patterns:
+      # (A) 개발·로컬 어휘가 경로 세그먼트로 들어간 매핑 애노테이션이 붙은 메서드 안일 것
+      - pattern-either:
+          # @PostMapping("/dev/login") — 인자 하나짜리 축약형
+          - patterns:
+              - pattern-inside: |
+                  @$ANN($PATH)
+                  $RT $M(...) { ... }
+              - metavariable-regex:
+                  metavariable: $ANN
+                  regex: '^(?:Get|Post|Put|Patch|Delete|Request)Mapping$'
+              - metavariable-regex:
+                  metavariable: $PATH
+                  regex: '(?i)^"(?:[^"]*/)?(?:dev|develop|local|test|debug|stub|mock|impersonate|switch-?user|su)(?:[-_]\w+)*(?:/[^"]*)?"$'
+          # @RequestMapping(value = "/debug/switch-user", method = ...) — 명시 인자형
+          - patterns:
+              - pattern-inside: |
+                  @$ANN(value = $PATH, ...)
+                  $RT $M(...) { ... }
+              - metavariable-regex:
+                  metavariable: $ANN
+                  regex: '^(?:Get|Post|Put|Patch|Delete|Request)Mapping$'
+              - metavariable-regex:
+                  metavariable: $PATH
+                  regex: '(?i)^"(?:[^"]*/)?(?:dev|develop|local|test|debug|stub|mock|impersonate|switch-?user|su)(?:[-_]\w+)*(?:/[^"]*)?"$'
+      # (B) 같은 메서드 본문에 토큰 발급 호출이 있을 것 — 코멘트는 이 줄에 달린다
+      - pattern-either:
+          - pattern: $X.generateAccessToken(...)
+          - pattern: $X.createAccessToken(...)
+          - pattern: $X.generateRefreshToken(...)
+          - pattern: $X.createRefreshToken(...)
+          - pattern: $X.generateToken(...)
+          - pattern: $X.createToken(...)
+          - pattern: $X.issueToken(...)
+          # 제공자 객체 이름에 Jwt/Token 이 들어간 경우의 일반 발급 메서드
+          - patterns:
+              - pattern-either:
+                  - pattern: $P.generate(...)
+                  - pattern: $P.create(...)
+                  - pattern: $P.issue(...)
+              - metavariable-regex:
+                  metavariable: $P
+                  regex: '(?i)\w*(?:jwt|token)\w*'

--- a/testdata/rule-fixtures/java_dev_auth.java
+++ b/testdata/rule-fixtures/java_dev_auth.java
@@ -1,0 +1,51 @@
+// finguard.java.dev-auth-endpoint (#37) 정탐 픽스처.
+//
+// 자격증명 검증 없이 요청 본문만으로 정식 토큰을 발급하는 개발/로컬 전용 엔드포인트.
+// 매핑 애노테이션의 경로 세그먼트 어휘(dev/local/debug/impersonate/...) 와 같은 메서드
+// 본문의 토큰 발급 호출이 동시에 성립할 때만 검출된다.
+package fixtures;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+public class DevAuthController {
+
+    private JwtTokenProvider jwtTokenProvider;
+    private TokenService tokenService;
+    private UserRepository userRepository;
+
+    // 요청 본문의 email 만으로 사용자를 upsert 하고 정식 access 토큰을 발급한다.
+    @PostMapping("/oauth/local/login")
+    public TokenResponse localLogin(@RequestBody RegisterRequest request) {
+        User user = userRepository.findOrCreate(request.getEmail());
+        // EXPECT: finguard.java.dev-auth-endpoint
+        return jwtTokenProvider.generateAccessToken(user.getId());
+    }
+
+    // 명시 인자형 애노테이션 + 계정 전환(임의 계정 사칭) 경로.
+    @RequestMapping(value = "/debug/switch-user", method = RequestMethod.POST)
+    public TokenResponse switchUser(@RequestBody RegisterRequest request) {
+        User user = userRepository.findByEmail(request.getEmail());
+        // EXPECT: finguard.java.dev-auth-endpoint
+        return tokenService.createToken(user);
+    }
+
+    // 제공자 이름에 Jwt 가 들어간 일반 발급 메서드도 토큰 발급으로 본다.
+    @PostMapping("/dev-login")
+    public TokenResponse devLogin(@RequestBody RegisterRequest request) {
+        // EXPECT: finguard.java.dev-auth-endpoint
+        return jwtProvider.generate(request.getEmail());
+    }
+
+    // 개발 전용 경로지만 토큰을 발급하지 않으므로 검출 대상이 아니다.
+    @GetMapping("/dev/health")
+    public String devHealth() {
+        return "ok";
+    }
+}

--- a/testdata/rule-fixtures/safe_java_dev_auth.java
+++ b/testdata/rule-fixtures/safe_java_dev_auth.java
@@ -1,0 +1,44 @@
+// finguard.java.dev-auth-endpoint (#37) 대조군 — 어떤 룰에도 걸리면 안 된다.
+//
+// 검증 항목
+//   - 정상 로그인: 자격증명 검증 후 토큰 발급. 경로에 개발 어휘가 없다.
+//   - /api/v1/devices: "dev" 를 부분문자열로 포함하지만 경로 세그먼트가 아니다.
+//   - /local/config: 개발 경로지만 토큰 발급 호출이 없다.
+//   - testReport: 메서드명에 test 가 들어간 정상 업무 엔드포인트.
+package fixtures;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+public class SafeAuthController {
+
+    private JwtTokenProvider jwtTokenProvider;
+    private AuthService authService;
+    private DeviceService deviceService;
+
+    @PostMapping("/auth/login")
+    public TokenResponse login(@RequestBody LoginRequest request) {
+        authService.verifyCredential(request.getEmail(), request.getRawPassword());
+        return jwtTokenProvider.generateAccessToken(request.getEmail());
+    }
+
+    @GetMapping("/devices/list")
+    public DeviceList devices() {
+        return deviceService.list();
+    }
+
+    @GetMapping("/local/config")
+    public ConfigView localConfig() {
+        return ConfigView.current();
+    }
+
+    @PostMapping("/settlement/test-report")
+    public ReportView testReport(@RequestBody ReportRequest request) {
+        return deviceService.report(request);
+    }
+}


### PR DESCRIPTION
Closes #37

매핑 애노테이션의 경로 세그먼트에 개발·로컬 어휘가 있고 같은 메서드 본문에서 정식 토큰을 발급하는 Java Spring MVC 엔드포인트를 검출하는 `finguard.java.dev-auth-endpoint`(WARNING)를 신설했다.

## 신설 룰

| 룰 ID | severity | 매핑 | CWE |
| :--- | :--- | :--- | :--- |
| `finguard.java.dev-auth-endpoint` | WARNING | `FIN-DBG-002` | CWE-306 |

semantic 모드(`languages: [java]`)로 구성했다. 판정 조건은 AND 두 개다.

1. `@(Get|Post|Put|Patch|Delete|Request)Mapping` 의 경로에 개발 어휘가 **세그먼트로** 등장 (`/dev/`, `/local/`, `/debug/`, `/dev-login`, `impersonate`, `switch-user` 등)
2. 같은 메서드 본문에 토큰 발급 호출 (`generateAccessToken` / `createAccessToken` / `createToken` / `issueToken` / 이름에 `Jwt`·`Token` 이 든 제공자의 `generate`·`create`·`issue`)

코멘트는 (2)의 줄에 달린다 — 리뷰어가 "무엇이 문제인지"를 바로 보게 하기 위함이다.

## ① 반박 반영 내역

**semgrep 구현가능성 렌즈 — `languages: [java, kotlin]` 은 파서 에러**

반영. `languages: [java]` 단일로 한정했다. 검증자는 "증거가 전부 Kotlin이니 `[kotlin]` 단일로 하라"고 했지만, **Kotlin 쪽은 이슈 #28(PR #48)에서 `finguard.kotlin.dev-backdoor-endpoint`(FIN-DBG-001, ERROR)로 이미 머지됐다.** 남은 공백은 Java Spring MVC 쪽이므로, 검증자가 같은 문단에서 제시한 대안("Java 버전이 필요하면 Java 리턴타입-우선 시그니처로 별도 룰")을 그대로 따랐다. `@$ANN(...)` + `$RT $M(...) { ... }` 형태로 semgrep 1.169.0 에서 실제 매칭을 확인했다.

**재현율 수호자 — "유령 룰(발화하지 않는 무음 룰)이 룰 없는 것보다 나쁘다"**

반영. 픽스처(`testdata/rule-fixtures/java_dev_auth.java`)로 실제 발화를 3건 확인했고, 통합 테스트 `TestFixtureExpectationsMatchScan` 이 미탐/오탐 양방향으로 이를 고정한다. 발화 증거는 아래 변이 시험 절에 있다.

**재현율 수호자 — "정당한 완화를 적용해도 계속 발화 → 리뷰어의 학습적 무시 → 2차 재현율 손실"**

반영. 룰 message 와 매핑 `explain` 에 종결 경로를 명시했다.
- 운영 빌드에서 엔드포인트 제거(빌드·프로파일 분리)
- 실제 자격증명 검증 추가
- 네트워크 계층 차단
- 이미 완화했다면 대상 레포 `.finguard.yml` 의 `ignore` 에 파일을 명시해 **승인 사실을 남기는** 경로

**재현율 수호자 + 규제 렌즈 — `@Profile("!prod")` · `isProdProfile()` 을 억제 사유로 인정하지 말 것**

반영. 억제 패턴을 넣지 않았다. 룰 주석에 "그 게이트는 외부망에 노출된 staging/검증계에서 무효라 실제 사고의 유일한(그리고 뚫린) 방어선이었다"를 근거로 남겼다.

**규제 렌즈 — basis / kisa_item 지정**

반영, 문자열 그대로.
- `basis: 개발보안가이드 「보안기능 - 적절한 인증 없이 중요기능 허용」`
- `kisa_item: 전자금융기반시설 평가기준(2026) 웹·모바일·HTS 37 (불충분한 이용자 인증)` — `docs/평가기준_웹모바일HTS_66항목.md:46` 에서 항목 존재를 확인하고 표기를 옮겼다.

**규제 렌즈 — "이름에 test 가 든 정상 엔드포인트" 오탐**

반영. severity 를 WARNING 으로 두었고(ERROR 승격은 실코드 검증 후 별도 판단 — 아래 ②에 따라 이번에는 보류), 경로 어휘를 **부분문자열이 아니라 세그먼트**로 한정했다. 대조군 픽스처에 `/api/v1/devices/list`(부분문자열 `dev`)와 `/settlement/test-report`(어휘는 걸리지만 토큰 발급 없음)를 넣어 고정했다.

## ② 실코드 전/후 검출 비교

코퍼스 10개 레포 전수 재스캔. 접두 `campaign/rN/src`.

| 레포 | 스택 | before | after | delta |
| :--- | :--- | ---: | ---: | ---: |
| r0 한국투자증권 | Python | 42 | 42 | +0 |
| r1 samchon/payments | TS | 8 | 8 | +0 |
| r2 CoinNow | Swift | 1 | 1 | +0 |
| r3 DuDoong-Backend | Kotlin | 11 | 11 | +0 |
| r4 iamport-python | Python | 0 | 0 | +0 |
| r5 AXSnapshot | Swift | 0 | 0 | +0 |
| r6 reactive-crypto | Kotlin | 2 | 2 | +0 |
| r7 pybithumb | Python | 0 | 0 | +0 |
| r8 iamport-rest-client-java | Java | 0 | 0 | +0 |
| r9 upbitBar | Swift | 0 | 0 | +0 |

**신규 검출 0건. 오탐 0건.**

Java 코퍼스는 r8 하나뿐이고(`*.java` 81개), 결제 PG REST **클라이언트 라이브러리**라 Spring MVC 컨트롤러가 존재하지 않는다 — 매핑 애노테이션이 한 건도 없다. 따라서 이 룰이 볼 대상 자체가 코퍼스에 없다. **"코퍼스에 해당 패턴 없음"이 사실이며, 억지 검출을 만들지 않았다.** 이슈의 원 증거(DuDoong `AuthController.kt`)는 Kotlin 이고 그쪽은 #28 이 이미 잡고 있다(r3 의 `finguard.kotlin.dev-backdoor-endpoint` 1건이 before/after 모두에 포함).

실증이 코퍼스로 되지 않으므로 **ERROR 승격은 하지 않는다**(규제 렌즈의 "실코드 검증 후 판단" 조건을 충족하지 못했다). 발화 자체는 픽스처로 검증했다.

## ③ 변이 시험

픽스처를 일부러 깨뜨려 테스트가 실제로 실패하는지 확인했다(확인 후 원복).

| 변이 | 기대 | 실제 |
| :--- | :--- | :--- |
| 정탐 줄(`tokenService.createToken`)의 `// EXPECT:` 마커 제거 | 오탐 회귀로 FAIL | `FAIL … 오탐 회귀 — 마커가 없는데 검출됐다: java_dev_auth.java:35 finguard.java.dev-auth-endpoint` |
| 검출되지 않는 줄(`/dev/health` 의 `return "ok";`)에 마커 추가 | 미탐 회귀로 FAIL | `FAIL … 미탐 회귀 — 마커가 있는데 검출되지 않았다: java_dev_auth.java:50 finguard.java.dev-auth-endpoint` |
| 원복 후 | PASS | `ok github.com/leeyudok/finguard/internal/scanner` |

## ④ 일부러 넣지 않은 패턴과 이유

- **`languages: [java, kotlin]` 혼합** — Java 파서가 Kotlin 문법 패턴에서 파싱 에러를 낸다(검증자 실측). Kotlin 은 `finguard.kotlin.dev-backdoor-endpoint`(#28) 담당이라 넣으면 같은 줄에 코멘트가 두 번 달린다.
- **`@Profile` · `isProdProfile()` 억제** — 반박이 명시적으로 금지. 그게 뚫린 방어선이다.
- **클래스 레벨 `@RequestMapping` 접두 결합** — 메서드 애노테이션 경로만 본다. 클래스 접두에만 `dev` 가 있고 메서드에는 없는 형태는 놓친다. semgrep 단일 패턴으로 두 애노테이션을 결합하려면 클래스 전체를 `pattern-inside` 로 잡아야 하는데, 그러면 같은 클래스의 모든 메서드가 후보가 되어 정밀도가 급락한다. 알려진 한계로 남긴다.
- **배열 경로 형태 `@PostMapping({"/dev/login", "/x"})`** — 실사용 빈도가 낮고 메타변수 바인딩이 배열 리터럴로 잡혀 경로 정규식이 닿지 않는다. 필요해지면 별도 대안으로 추가한다.
- **`@Secured`·`permitAll` 결합 판정** — 시큐리티 설정은 다른 파일에 있어 semgrep 의 파일 단위 스코프를 벗어난다. 추측으로 단정하지 않는다.
- **ERROR 승격** — 위 ② 사유.

## 검증

| 명령 | 결과 |
| :--- | :--- |
| `semgrep --validate --config rules/` | `Configuration is valid - found 0 configuration error(s), and 108 rule(s).` (107 → 108) |
| `go build -mod=vendor ./...` | 통과 |
| `go vet -mod=vendor ./...` | 통과 |
| `go test -race -mod=vendor ./...` | 전 패키지 `ok` |
| `go test -race -mod=vendor -tags semgrep_integration ./internal/scanner/` | `ok` |
| 룰 수 = 매핑 수 대조 | 룰 108 / 매핑 108, 매핑 없는 룰 0, 고아 매핑 0 |
