### PR TITLE
feat(#33): Apple 플랫폼 전송보안 룰 보강 — ATS 부분완화·표기변형·라이브러리 검증 무력화

### DIFF
--- a/mapping/rules.yaml
+++ b/mapping/rules.yaml
@@ -1545,3 +1545,41 @@
       variables:
         ARTIFACT_API_KEY: $ARTIFACT_API_KEY   # 평문 값 대신 CI 변수 참조
     ```
+
+# ── Apple 플랫폼 전송보안 보강 (#33) ──────────────────────────────────────
+
+- rule_id: finguard.plist.ats-partial-exception
+  code: FIN-TLS-025
+  cwe: CWE-319
+  title: ATS 부분 완화(도메인 예외·취약 TLS 허용)
+  severity: WARNING
+  basis: 개발보안가이드 「보안기능 - 중요정보 평문 전송」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 65 (통신구간 암호화 적용)"
+  explain: ATS 예외 설정으로 특정 도메인·구간의 평문 HTTP 또는 폐기된 TLS 1.0/1.1 이 허용되어 Apple 플랫폼(iOS/macOS/watchOS/tvOS)의 전송보안이 부분적으로 무력화됩니다. 예외 범위가 좁다는 것과 그 구간이 평문이라는 것은 별개이며, 예외 도메인이 결제·인증 구간이면 전역 해제와 위험이 같습니다.
+  fix_example: |
+    ```xml
+    <key>NSExceptionDomains</key>
+    <dict>
+      <key>api.example-bank.co.kr</key>
+      <dict>
+        <key>NSExceptionAllowsInsecureHTTPLoads</key>
+        <false/>
+        <key>NSExceptionMinimumTLSVersion</key>
+        <string>TLSv1.2</string>
+      </dict>
+    </dict>
+    ```
+
+- rule_id: finguard.swift.insecure-trust-vendor
+  code: FIN-TLS-026
+  cwe: CWE-295
+  title: 서버 인증서 검증 우회(서드파티 라이브러리 소스)
+  severity: WARNING
+  basis: 개발보안가이드 「보안기능 - 부적절한 인증서 유효성 검증」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 47 (서버 인증서 무결성 검증)"
+  explain: 저장소에 반입한 서드파티 라이브러리(Pods/Carthage/xcframework) 소스가 서버 인증서 검증을 무력화하고 있습니다. 벤더 코드라도 최종 바이너리에서 그대로 실행되므로 점검 범위에서 제외하지 않습니다. 다만 개발팀이 해당 코드를 직접 수정할 수 없으므로 라이브러리 교체·버전 고정 등 의존성 감사 단계에서 해소해야 하며, 그 사이 머지를 막지 않도록 경고로 분류합니다.
+  fix_example: |
+    ```text
+    - 검증을 무력화하지 않는 상위 버전으로 교체하거나 대체 라이브러리를 선정
+    - 불가피하면 반입 심사 기록에 수용 위험(accepted risk)으로 등록하고 사용 범위를 제한
+    ```

--- a/rules/swift.yaml
+++ b/rules/swift.yaml
@@ -1,3 +1,14 @@
+# Swift / Apple 플랫폼(iOS·macOS·watchOS·tvOS) 룰셋.
+#
+# paths.exclude 정책 (#33):
+#   - 빌드 산출물(**/build/**, **/DerivedData/**, **/*.xcframework/**)은 전 룰에서 제외한다.
+#     DerivedData 는 앱 소스·plist 의 사본이라 같은 결함에 중복 코멘트만 만들고,
+#     xcframework 는 배포용 바이너리 번들이라 MR diff 에 소스로 등장하지 않는다.
+#   - Pods/Carthage 는 **plist ATS 룰에만** 제외한다. ATS 는 앱 타깃의 Info.plist 가 지배하므로
+#     팟 자신의 Info.plist 는 런타임에 효력이 없다 — 점검 범위 축소가 아니라 오탐 제거다.
+#     반대로 벤더 *Swift 코드* 의 인증서 검증 무력화는 최종 바이너리에 그대로 실려 나가므로
+#     범위에서 빼지 않는다. insecure-trust(ERROR) 에서 제외된 벤더 경로는
+#     insecure-trust-vendor(WARNING) 가 이어받아 코멘트는 남기되 게이트는 걸지 않는다.
 rules:
   - id: finguard.swift.hardcoded-secret
     languages: [regex]
@@ -5,6 +16,7 @@ rules:
     message: 소스코드에 비밀정보(비밀번호·API 키·토큰)가 하드코드되어 있습니다.
     paths:
       include: ["*.swift"]
+      exclude: ["**/build/**", "**/DerivedData/**", "**/*.xcframework/**"]
     patterns:
       - pattern-regex: '(?i)(let|var)\s+\w*(password|passwd|secret|api_?key|token|credential)\w*\s*=\s*"(?!(?-i:[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)")(?!(?-i:[a-z]+(?:_[a-z]+)+)")[^"]{4,}"'
       # 마스킹 플레이스홀더는 시크릿이 아니다 — 오히려 가리는 코드다
@@ -16,6 +28,7 @@ rules:
     message: 평문 HTTP URL 이 사용되고 있습니다. TLS(https) 로 전환해야 합니다.
     paths:
       include: ["*.swift"]
+      exclude: ["**/build/**", "**/DerivedData/**", "**/*.xcframework/**"]
     pattern-regex: '(?im)^(?![ \t]*(?://|\*|/\*)).*"http://(?!localhost|127\.0\.0\.1|0\.0\.0\.0|schemas\.|xmlns|(?:www\.)?w3\.org|(?:[\w.]+\.)?apache\.org|[\w.]*xml\.org|java\.sun\.com|(?:www\.)?example\.(?:com|org)|(?:www\.)?unicode\.org|(?:www\.)?jflex\.de|purl\.org|iana\.org|ietf\.org|slf4j\.org|json-schema\.org)[^"]+"'
 
   # 금융 실시간 채널(시세·체결통보)은 대부분 웹소켓이고 접속키가 함께 흐른다 (#30).
@@ -27,6 +40,7 @@ rules:
     message: 평문 WebSocket(ws://) 으로 통신하고 있습니다. 실시간 시세·체결통보 채널에는 접속키와 거래내역이 흐르므로 wss:// 로 전환해야 합니다.
     paths:
       include: ["*.swift"]
+      exclude: ["**/build/**", "**/DerivedData/**", "**/*.xcframework/**"]
     pattern-regex: '(?im)^(?![ \t]*(?://|\*|/\*)).*"ws://(?!localhost|127\.0\.0\.1|0\.0\.0\.0|schemas\.|xmlns|(?:www\.)?w3\.org|(?:[\w.]+\.)?apache\.org|[\w.]*xml\.org|java\.sun\.com|(?:www\.)?example\.(?:com|org)|(?:www\.)?unicode\.org|(?:www\.)?jflex\.de|purl\.org|iana\.org|ietf\.org|slf4j\.org|json-schema\.org)[^"]+"'
 
   - id: finguard.swift.userdefaults-sensitive
@@ -35,6 +49,7 @@ rules:
     message: UserDefaults 에 중요정보를 평문 저장하고 있습니다. Keychain 을 사용해야 합니다.
     paths:
       include: ["*.swift"]
+      exclude: ["**/build/**", "**/DerivedData/**", "**/*.xcframework/**"]
     pattern-regex: '(?i)UserDefaults[^\n]*\.set\([^\n]*(password|passwd|token|secret|pin|cardno|card_no|accountno)'
 
   - id: finguard.swift.uiwebview
@@ -43,6 +58,7 @@ rules:
     message: 폐기된 UIWebView 를 사용하고 있습니다. WKWebView 로 교체해야 합니다.
     paths:
       include: ["*.swift"]
+      exclude: ["**/build/**", "**/DerivedData/**", "**/*.xcframework/**"]
     pattern-regex: '\bUIWebView\b'
 
   - id: finguard.swift.weak-hash
@@ -51,6 +67,7 @@ rules:
     message: 취약한 해시 알고리즘(MD5/SHA-1)을 사용하고 있습니다.
     paths:
       include: ["*.swift"]
+      exclude: ["**/build/**", "**/DerivedData/**", "**/*.xcframework/**"]
     pattern-regex: '\b(CC_MD5|CC_SHA1|Insecure\.MD5|Insecure\.SHA1)\b'
 
   - id: finguard.swift.print-sensitive
@@ -59,6 +76,7 @@ rules:
     message: 로그/콘솔에 중요정보가 출력될 수 있습니다.
     paths:
       include: ["*.swift"]
+      exclude: ["**/build/**", "**/DerivedData/**", "**/*.xcframework/**"]
     pattern-regex: '(?im)^(?![ \t]*(?://|\*|/\*)).*?\b(?:print|NSLog|os_log)\((?:(?:"(?:\\.|[^"\\\n])*"|[^"\n])*?(?:\b(?:password|passwd|token|secret|pin|cardno|card_no)\b|주민)|[^\n]*?\\\([^)\n]*(?:\b(?:password|passwd|token|secret|pin|cardno|card_no)\b|주민))'
 
   - id: finguard.swift.sql-interpolation
@@ -67,15 +85,55 @@ rules:
     message: SQL 문자열에 변수를 직접 보간(interpolation)하고 있습니다. 바인딩 파라미터를 사용해야 합니다.
     paths:
       include: ["*.swift"]
+      exclude: ["**/build/**", "**/DerivedData/**", "**/*.xcframework/**"]
     pattern-regex: '"(?i)(SELECT|INSERT|UPDATE|DELETE)\b[^"]*\\\('
 
+  # ATS 전역 해제 (#33).
+  # 기존 정규식은 '<true/>' 한 가지 표기만 봤다. plist 는 <true/> 와 <true></true> 가 모두
+  # 유효하고, Xcode 가 아닌 편집기·스크립트가 만든 파일에서는 후자가 흔하다 — 회피 시도가
+  # 아니라 우연으로도 미탐이 나던 자리라 표기 변형을 함께 본다.
   - id: finguard.plist.ats-arbitrary-loads
     languages: [regex]
     severity: ERROR
     message: ATS 전역 해제(NSAllowsArbitraryLoads=true)로 평문 통신이 허용됩니다.
     paths:
       include: ["*.plist"]
-    pattern-regex: 'NSAllowsArbitraryLoads</key>\s*<true\s*/>'
+      exclude:
+        - "**/build/**"
+        - "**/DerivedData/**"
+        - "**/*.xcframework/**"
+        - "Pods/**"
+        - "**/Pods/**"
+        - "Carthage/**"
+        - "**/Carthage/**"
+    pattern-regex: 'NSAllowsArbitraryLoads</key>\s*<true\s*(?:/>|>\s*</true>)'
+
+  # ATS 부분 완화 (#33).
+  # 전역 해제(NSAllowsArbitraryLoads)만 잡으면 '도메인 단위로 좁혔으니 안전' 이라며 결제·인증
+  # 도메인을 NSExceptionDomains 예외에 넣고 종결하는 실제 다수 형태를 통째로 놓친다.
+  # 예외 대상이 좁다는 것과 그 구간이 평문이라는 것은 별개 사실이다.
+  # 전역 해제(ERROR)와 달리 영향 범위가 한정되므로 WARNING 으로 분리해 게이트를 막지 않는다.
+  - id: finguard.plist.ats-partial-exception
+    languages: [regex]
+    severity: WARNING
+    message: ATS 예외 설정으로 특정 도메인·구간의 평문 HTTP 또는 취약 TLS(1.0/1.1)가 허용됩니다. 예외 도메인이 결제·인증 구간이면 전역 해제와 위험이 같습니다.
+    paths:
+      include: ["*.plist"]
+      exclude:
+        - "**/build/**"
+        - "**/DerivedData/**"
+        - "**/*.xcframework/**"
+        - "Pods/**"
+        - "**/Pods/**"
+        - "Carthage/**"
+        - "**/Carthage/**"
+    # NSAllowsLocalNetworking 은 의도적으로 넣지 않았다 — Bonjour·로컬 기기 탐색에서
+    # 정상적으로 켜는 값이라 금융 앱에서도 오탐이 대부분이고, 사설망 구간이라 위험도가 다르다.
+    pattern-either:
+      # 도메인·용도별 평문 허용
+      - pattern-regex: '(?:NSAllowsArbitraryLoadsInWebContent|NSAllowsArbitraryLoadsForMedia|NSExceptionAllowsInsecureHTTPLoads|NSThirdPartyExceptionAllowsInsecureHTTPLoads)</key>\s*<true\s*(?:/>|>\s*</true>)'
+      # 예외 도메인의 최소 TLS 버전을 폐기된 1.0/1.1 로 내리는 형태
+      - pattern-regex: '(?:NSExceptionMinimumTLSVersion|NSThirdPartyExceptionMinimumTLSVersion)</key>\s*<string>\s*TLSv1\.[01]\s*</string>'
 
   - id: finguard.swift.webview-file-access
     languages: [regex]
@@ -83,13 +141,49 @@ rules:
     message: WebView 의 파일 접근 설정이 로컬 파일 탈취에 악용될 수 있습니다.
     paths:
       include: ["*.swift"]
+      exclude: ["**/build/**", "**/DerivedData/**", "**/*.xcframework/**"]
     pattern-regex: '\b(allowFileAccessFromFileURLs|allowUniversalAccessFromFileURLs)\b'
 
+  # 인증서 검증 무력화 (#33).
+  # 표준 API(SecTrustSetExceptions/URLCredential(trust:))만 보면 국내 금융 iOS 의 사실상
+  # 표준 네트워킹 스택인 Alamofire·Starscream 의 우회 관용구가 전부 통과한다.
+  # 라이브러리 API 이름은 각각 Alamofire 4(ServerTrustPolicy.disableEvaluation),
+  # Alamofire 5(DisabledTrustEvaluator), Starscream 3(disableSSLCertValidation),
+  # Starscream 4(allowSelfSigned) 의 실제 심볼이다.
   - id: finguard.swift.insecure-trust
     languages: [regex]
     severity: ERROR
-    message: 서버 인증서를 검증 없이 신뢰하고 있습니다(SecTrustSetExceptions/URLCredential(trust:)). 중간자 공격(MITM)에 노출됩니다.
+    message: 서버 인증서를 검증 없이 신뢰하고 있습니다(SecTrustSetExceptions/URLCredential(trust:)/Alamofire·Starscream 검증 무력화). 중간자 공격(MITM)에 노출됩니다.
     paths:
       include: ["*.swift"]
-      exclude: ["Pods/**", "**/Pods/**", "Carthage/**", "**/Carthage/**", "Vendor/**/*Pods*"]
-    pattern-regex: '(?im)^(?![ \t]*(?://|\*)).*(?:SecTrustSetExceptions|URLCredential\(trust:)'
+      exclude:
+        - "**/build/**"
+        - "**/DerivedData/**"
+        - "**/*.xcframework/**"
+        - "Pods/**"
+        - "**/Pods/**"
+        - "Carthage/**"
+        - "**/Carthage/**"
+        - "Vendor/**/*Pods*"
+    pattern-regex: '(?im)^(?![ \t]*(?://|\*)).*(?:SecTrustSetExceptions|URLCredential\(trust:|DisabledTrustEvaluator\(|ServerTrustPolicy\.disableEvaluation|allHostsMustBeEvaluated\s*:\s*false|allowSelfSigned\s*:\s*true|disableSSLCertValidation\s*=\s*true)'
+
+  # 벤더 소스의 인증서 검증 무력화 (#33).
+  # 위 insecure-trust 가 제외하는 Pods/Carthage 경로를 이 룰이 이어받는다. 벤더 코드라도
+  # 검증 무력화는 최종 바이너리에서 실제로 실행되므로 점검 범위에서 빼지 않는다("개발팀이
+  # 못 고친다" 는 보안 논거가 아니라 워크플로 논거다). 다만 그 자리에서 코드로 고칠 수 없고
+  # 라이브러리 교체·버전 고정으로 해소할 항목이라 게이트를 막지 않도록 WARNING 으로 낮춘다.
+  # reviewdog -filter-mode=added 특성상 코멘트는 그 SDK blob 을 커밋·갱신하는 시점,
+  # 즉 반입 여부를 결정하는 바로 그 시점에만 달린다.
+  - id: finguard.swift.insecure-trust-vendor
+    languages: [regex]
+    severity: WARNING
+    message: 반입한 서드파티 라이브러리 소스가 서버 인증서 검증을 무력화하고 있습니다. 개발팀이 직접 수정할 수 없는 코드이므로 라이브러리 교체·버전 고정 등 의존성 감사 단계에서 처리해야 합니다.
+    paths:
+      include:
+        - "Pods/**/*.swift"
+        - "**/Pods/**/*.swift"
+        - "Carthage/**/*.swift"
+        - "**/Carthage/**/*.swift"
+        - "**/*.xcframework/**/*.swift"
+      exclude: ["**/build/**", "**/DerivedData/**"]
+    pattern-regex: '(?im)^(?![ \t]*(?://|\*)).*(?:SecTrustSetExceptions|URLCredential\(trust:|DisabledTrustEvaluator\(|ServerTrustPolicy\.disableEvaluation|allHostsMustBeEvaluated\s*:\s*false|allowSelfSigned\s*:\s*true|disableSSLCertValidation\s*=\s*true)'

--- a/testdata/rule-fixtures/Ats-Info.plist
+++ b/testdata/rule-fixtures/Ats-Info.plist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- 룰 회귀 픽스처 — finguard.plist.ats-arbitrary-loads / finguard.plist.ats-partial-exception (#33)
+     semgrep 은 매치 시작 줄(<key> 가 있는 줄)을 보고하므로 마커는 그 줄 바로 위에 둔다.
+     plist 는 주석 문법이 XML 이라 마커를 <!-- --> 안에 넣는다 (Secrets-Info.plist 선례). -->
+<plist version="1.0">
+<dict>
+	<key>CFBundleIdentifier</key>
+	<string>com.example.trading</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<!-- <true></true> 표기형 — 기존 정규식('<true\s*/>')이 놓치던 자리다
+		# EXPECT: finguard.plist.ats-arbitrary-loads
+		--><key>NSAllowsArbitraryLoads</key>
+		<true></true>
+		<!--
+		# EXPECT: finguard.plist.ats-partial-exception
+		--><key>NSAllowsArbitraryLoadsInWebContent</key>
+		<true/>
+		<!--
+		# EXPECT: finguard.plist.ats-partial-exception
+		--><key>NSAllowsArbitraryLoadsForMedia</key>
+		<true></true>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>pay.example-bank.co.kr</key>
+			<dict>
+				<!-- 결제 도메인을 예외에 넣고 '좁혔으니 안전' 이라 종결하는 실제 다수 형태
+				# EXPECT: finguard.plist.ats-partial-exception
+				--><key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+				<!--
+				# EXPECT: finguard.plist.ats-partial-exception
+				--><key>NSExceptionMinimumTLSVersion</key>
+				<string>TLSv1.0</string>
+			</dict>
+			<key>cdn.example-vendor.com</key>
+			<dict>
+				<!--
+				# EXPECT: finguard.plist.ats-partial-exception
+				--><key>NSThirdPartyExceptionMinimumTLSVersion</key>
+				<string>TLSv1.1</string>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/testdata/rule-fixtures/safe_ats_Info.plist
+++ b/testdata/rule-fixtures/safe_ats_Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- 대조군 — 어떤 룰에도 걸리면 안 된다 (#33).
+     ATS 를 끄지 않고, 예외 도메인도 평문 허용 없이 최소 TLS 버전만 1.2 로 올린 정상 설정. -->
+<plist version="1.0">
+<dict>
+	<key>CFBundleIdentifier</key>
+	<string>com.example.trading</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<false/>
+		<key>NSAllowsArbitraryLoadsInWebContent</key>
+		<false/>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>api.example-bank.co.kr</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<false/>
+				<key>NSExceptionMinimumTLSVersion</key>
+				<string>TLSv1.2</string>
+				<key>NSExceptionRequiresForwardSecrecy</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/testdata/rule-fixtures/safe_swift_trust.swift
+++ b/testdata/rule-fixtures/safe_swift_trust.swift
@@ -1,0 +1,29 @@
+//
+//  대조군 — 어떤 룰에도 걸리면 안 된다 (#33).
+//
+//  기본 신뢰 평가를 그대로 쓰고, 자가서명 허용·평가 비활성화 플래그를 전부 끈 정상 구현.
+//
+
+import Foundation
+
+final class TrustSafeSamples {
+
+    func alamofire5Session() -> Any {
+        // 기본 평가기 — 인증서 체인과 호스트명을 모두 검증한다
+        let evaluators = ["api.example-bank.co.kr": DefaultTrustEvaluator()]
+        return ServerTrustManager(allHostsMustBeEvaluated: true, evaluators: evaluators)
+    }
+
+    func starscream4Security() -> Any {
+        return FoundationSecurity(allowSelfSigned: false)
+    }
+
+    func starscream3Socket(_ socket: WebSocketLike) {
+        socket.disableSSLCertValidation = false
+    }
+
+    func challengeHandler(_ challenge: URLAuthenticationChallenge) -> URLSession.AuthChallengeDisposition {
+        // 기본 처리에 위임 — 시스템 신뢰 평가를 우회하지 않는다
+        return .performDefaultHandling
+    }
+}

--- a/testdata/rule-fixtures/swift_insecure_trust.swift
+++ b/testdata/rule-fixtures/swift_insecure_trust.swift
@@ -1,0 +1,61 @@
+//
+//  룰 회귀 픽스처 — finguard.swift.insecure-trust (#33)
+//
+//  표준 API 두 개(SecTrustSetExceptions / URLCredential(trust:)) 외에 국내 금융 iOS 의
+//  사실상 표준 스택인 Alamofire·Starscream 의 검증 무력화 관용구를 함께 본다.
+//  합성 코드이며 실제 앱 코드가 아니다.
+//
+
+import Foundation
+
+final class TrustBypassSamples {
+
+    // MARK: - 표준 API (기존 커버리지 회귀 방어)
+
+    func acceptAnyCertificate(_ trust: SecTrust, blob: CFData) {
+        // EXPECT: finguard.swift.insecure-trust
+        SecTrustSetExceptions(trust, blob)
+    }
+
+    func credentialFromTrust(_ trust: SecTrust) -> URLCredential {
+        // EXPECT: finguard.swift.insecure-trust
+        return URLCredential(trust: trust)
+    }
+
+    // MARK: - Alamofire 5 — 평가기 자체를 비활성화
+
+    func alamofire5Session() -> Any {
+        // EXPECT: finguard.swift.insecure-trust
+        let evaluators = ["api.example-bank.co.kr": DisabledTrustEvaluator()]
+        return evaluators
+    }
+
+    // MARK: - Alamofire 5 — 모든 호스트 평가 강제 해제
+
+    func alamofire5Manager() -> Any {
+        // EXPECT: finguard.swift.insecure-trust
+        return ServerTrustManager(allHostsMustBeEvaluated: false, evaluators: [:])
+    }
+
+    // MARK: - Alamofire 4 — 정책을 disableEvaluation 으로 지정
+
+    func alamofire4Policies() -> Any {
+        // EXPECT: finguard.swift.insecure-trust
+        let policies = ["api.example-bank.co.kr": ServerTrustPolicy.disableEvaluation]
+        return policies
+    }
+
+    // MARK: - Starscream 4 — 자가서명 인증서 허용
+
+    func starscream4Security() -> Any {
+        // EXPECT: finguard.swift.insecure-trust
+        return FoundationSecurity(allowSelfSigned: true)
+    }
+
+    // MARK: - Starscream 3 — 인증서 검증 플래그를 끔
+
+    func starscream3Socket(_ socket: WebSocketLike) {
+        // EXPECT: finguard.swift.insecure-trust
+        socket.disableSSLCertValidation = true
+    }
+}


### PR DESCRIPTION
Closes #33

## 요약

Apple 플랫폼(iOS/macOS/watchOS/tvOS) 전송보안 룰의 커버리지 구멍 3종을 메운다.

| 룰 ID | 상태 | severity | 매핑 |
| :--- | :--- | :--- | :--- |
| `finguard.plist.ats-arbitrary-loads` | 확장 (표기 변형) | ERROR | FIN-TLS-002 (기존) |
| `finguard.plist.ats-partial-exception` | **신설** | WARNING | FIN-TLS-025 |
| `finguard.swift.insecure-trust` | 확장 (라이브러리 관용구) | ERROR | FIN-TLS-011 (기존) |
| `finguard.swift.insecure-trust-vendor` | **신설** | WARNING | FIN-TLS-026 |

## 검증에서 나온 반박 반영 내역

### (1) ATS 부분 완화 키 · 표기 변형 — 3개 렌즈 전원 원안 채택

원안대로 구현했다. `<true/>` 와 `<true></true>` 를 함께 인식하고, 부분 완화 키
4종 + `NS(ThirdParty)ExceptionMinimumTLSVersion=TLSv1.0/1.1` 을 별도 WARNING 룰로
분리했다. 전역 해제는 ERROR 유지.

### (2) Alamofire·Starscream 관용구 — 3개 렌즈 전원 원안 채택

재현율 렌즈가 확인해 준 실제 심볼 이름을 그대로 썼다: Alamofire 4
`ServerTrustPolicy.disableEvaluation`, Alamofire 5 `DisabledTrustEvaluator` ·
`allHostsMustBeEvaluated: false`, Starscream 3 `disableSSLCertValidation = true`,
Starscream 4 `allowSelfSigned: true`.

### (3) exclude 일괄 적용 — **원안을 채택하지 않고 재구성**

이슈 원안은 "swift.yaml 의 모든 룰에 Pods/Carthage 포함 exclude 일괄 적용"이었으나
재현율 렌즈와 규제 렌즈가 **둘 다 반대**했다. 반대 논거를 그대로 수용해 범위를 나눴다.

- **빌드 산출물**(`**/build/**`, `**/DerivedData/**`, `**/*.xcframework/**`)만 전 룰 exclude.
  DerivedData 는 앱 plist 의 사본이라 중복 코멘트만 만들고, 손실되는 정탐이 없다는 점은
  두 렌즈가 동의했다.
- **Pods/Carthage 는 plist ATS 룰에만 exclude.** ATS 는 앱 타깃의 Info.plist 가 지배하므로
  팟 자신의 Info.plist 는 런타임에 효력이 없다 — 점검 범위 축소가 아니라 오탐 제거다.
- **벤더 Swift 코드는 범위에서 빼지 않았다.** 두 렌즈의 처방이 갈렸던 지점이다.
  재현율 렌즈는 "exclude 대신 severity 강등", 규제 렌즈는 "기존 exclude 유지 + 수용위험
  명시 기록"을 제시했는데, semgrep 은 한 룰 안에서 경로별 severity 를 나눌 수 없다.
  그래서 `finguard.swift.insecure-trust-vendor`(WARNING) 를 신설해
  `insecure-trust`(ERROR) 가 제외하는 벤더 경로를 그대로 이어받게 했다. 결과적으로
  두 처방을 모두 충족한다 — 코멘트는 남고(범위에서 임의 제외 아님), 게이트는 안 걸리며
  (개발팀이 그 자리에서 고칠 수 없음), 제외 사유와 "의존성 감사 단계에서 처리"는
  룰 주석과 매핑 `explain` 에 수용위험으로 명시했다.

### (4) 매핑 basis·kisa_item

지어내지 않고 같은 CWE 의 기존 엔트리 값을 문자열 그대로 승계했다 —
FIN-TLS-025 ← FIN-TLS-002(CWE-319), FIN-TLS-026 ← FIN-TLS-011(CWE-295).
`#38` 에서 정정된 "Apple 플랫폼(iOS/macOS/watchOS/tvOS)" 표현도 신규 explain 에 반영했다.

## 실코드 전/후 검출 비교

코퍼스 10개 레포(`r0`~`r9`) 전체 재스캔.

| 레포 | 스택 | before | after | delta |
| :--- | :--- | ---: | ---: | ---: |
| r0 한국투자증권 OpenAPI | Python | 42 | 42 | 0 |
| r1 samchon/payments | TS | 8 | 8 | 0 |
| r2 CoinNow | Swift | 1 | 1 | 0 |
| r3 DuDoong-Backend | Kotlin | 11 | 11 | 0 |
| r4 iamport-python | Python | 0 | 0 | 0 |
| r5 AXSnapshot | Swift | 0 | 0 | 0 |
| r6 reactive-crypto | Kotlin | 2 | 2 | 0 |
| r7 pybithumb | Python | 0 | 0 | 0 |
| r8 iamport-java | Java | 0 | 0 | 0 |
| r9 upbitBar | Swift | 0 | 0 | 0 |
| **합계** | | **64** | **64** | **0** |

- **재현율 회귀 없음**: r2 `CoinNow/Info.plist:31`
  (`finguard.plist.ats-arbitrary-loads`)이 전/후 동일하게 검출된다. 코퍼스 유일 정탐이
  유지됐다.
- **신규 검출 0건**: 세 Swift 레포(r2/r5/r9)를 전수 grep 한 결과 부분 완화 키
  (`NSExceptionAllowsInsecureHTTPLoads` 등)와 Alamofire/Starscream 검증 무력화
  관용구가 **하나도 없었다**. 커밋된 `Pods/`·`Carthage/`·`*.xcframework` 도 없다.
  즉 이번 확장은 코퍼스에서 증분 정탐을 만들지 못하지만, **오탐도 0건**이다.
  코퍼스가 소규모 오픈소스라 벤더 디렉터리를 커밋하지 않는 것이 원인으로,
  룰의 가치는 폐쇄망 은행 레포(CocoaPods 커밋이 표준)에서 나타난다.

### 벤더 룰 동작 실증

코퍼스에 벤더 디렉터리가 없어 합성 트리로 확인했다.
`Pods/Alamofire/Trust.swift`(검증 무력화 7종)와 `Pods/Alamofire/Info.plist`(ATS 완화 6종)를
두고 스캔한 결과:

```
[('swift.insecure-trust-vendor', 'Pods/Alamofire/Trust.swift')]
```

의도대로 벤더 Swift 는 WARNING 룰만 발화하고(ERROR 룰은 제외), 벤더 plist 의 ATS 는
전부 억제됐다.

## 변이 시험

픽스처를 일부러 깨뜨려 통합 테스트가 실제로 실패하는지 확인했다(확인 후 원복).

| 변이 | 기대 | 결과 |
| :--- | :--- | :--- |
| `Ats-Info.plist` 의 `NSAllowsArbitraryLoadsForMedia` 마커 제거 | 오탐 회귀 검출 | ✅ `오탐 회귀 — 마커가 없는데 검출됐다: Ats-Info.plist:21 finguard.plist.ats-partial-exception` |
| 검출되지 않는 줄(`CFBundleIdentifier`)에 마커 추가 | 미탐 회귀 검출 | ✅ `미탐 회귀 — 마커가 있는데 검출되지 않았다: Ats-Info.plist:10 finguard.plist.ats-partial-exception` |
| `swift_insecure_trust.swift` 의 Starscream 4 마커 제거 | 오탐 회귀 검출 | ✅ `오탐 회귀 — 마커가 없는데 검출됐다: swift_insecure_trust.swift:51 finguard.swift.insecure-trust` |

원복 후 `기대 80건 · 검출 80건 · 전부 일치`.

## 일부러 넣지 않은 패턴

- **`NSAllowsLocalNetworking`** — 초안에 넣었다가 뺐다. Bonjour·로컬 기기 탐색에서
  정상적으로 켜는 값이고 사설망 구간이라 위험도가 다르다. 이슈에도 없던 항목이라
  오탐 표면만 넓힌다. 룰 주석에 제외 사유를 남겼다.
- **`NSExceptionRequiresForwardSecrecy=false`** — PFS 미지원 구형 서버 대응으로 켜는
  경우가 있고 평문 전송이 아니다. 별도 판단이 필요해 이번 범위에서 제외했다.
- **`SecTrustEvaluate` 결과 무시 패턴** — 반환값을 검사하지 않는 형태는 정규식으로는
  판별할 수 없고(호출 자체는 정상 코드), 데이터플로우가 필요하다.
- **벤더 룰 회귀 픽스처** — 현재 픽스처 하니스는 `testdata/rule-fixtures/` **평면 구조**만
  지원한다(`parseExpectations` 가 하위 디렉터리를 건너뛰므로, `Pods/` 하위에 픽스처를 두면
  검출은 되는데 기대값이 안 읽혀 오탐 회귀로 잡힌다). 그래서
  `finguard.swift.insecure-trust-vendor` 는 픽스처 대신 위 합성 트리 실증으로 확인했다.
  하니스를 재귀 순회로 바꾸는 것은 `integration_test.go` 변경이 필요해 별건으로 남긴다.

## 검증 결과

```
semgrep --validate --config rules/   → Configuration is valid, 109 rule(s)  (107 → +2)
룰 109 = 매핑 109, 누락 0 · 고아 0
go build -mod=vendor ./...           → OK
go vet -mod=vendor ./...             → OK
go test -race -mod=vendor ./...      → 전부 ok
go test -race -tags semgrep_integration ./internal/scanner/ -v → 기대 80건 · 검출 80건 · 전부 일치
```
