### PR TITLE
feat(#32): 연동 클라이언트 전체 로깅 + 결제·인증 패키지 debug 로깅 룰 신설

### DIFF
--- a/mapping/rules.yaml
+++ b/mapping/rules.yaml
@@ -1626,3 +1626,59 @@
         }
     }
     ```
+
+# ── 연동 클라이언트 전체 로깅 · 결제/인증 패키지 debug 로깅 (#32) ─────────────
+# basis 는 같은 CWE(532) 의 기존 엔트리(FIN-LOG-002·FIN-LOG-004) 값을 그대로 승계한다.
+# kisa_item 은 FIN-LOG-004 의 항목 59 표기를 문자열 그대로 쓴다.
+
+- rule_id: finguard.java.http-client-full-logging
+  code: FIN-LOG-006
+  cwe: CWE-532
+  title: 로그 중요정보 노출(HTTP 클라이언트 전체 로깅, Java)
+  severity: WARNING
+  basis: 개발보안가이드 「에러처리 - 오류 메시지 정보노출」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 59 (디버그 로그 내 중요정보 노출 방지)"
+  explain: 외부 연동 HTTP 클라이언트가 요청·응답을 통째로 로깅하도록 설정돼 있습니다. 헤더와 본문이 그대로 로그에 남습니다. 동일 클라이언트에 인증 헤더 인터셉터(BasicAuth·Bearer)가 등록돼 있으면 연동 자격증명이 Authorization 헤더째로 기록되므로 즉시 조치해야 합니다. 로깅 레벨을 BASIC 이하로 낮추거나 민감 헤더·본문을 마스킹해야 합니다.
+  fix_example: |
+    ```java
+    // 요청 메서드·URL·상태코드·소요시간만 남긴다. 헤더·본문은 남기지 않는다.
+    @Bean
+    public Logger.Level feignLoggerLevel() {
+        return Logger.Level.BASIC;
+    }
+    ```
+
+- rule_id: finguard.config.prod-debug-logging
+  code: FIN-LOG-007
+  cwe: CWE-532
+  title: 운영 프로파일 설정의 결제·인증 패키지 debug 로깅
+  severity: ERROR
+  basis: 개발보안가이드 「에러처리 - 오류 메시지 정보노출」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 59 (디버그 로그 내 중요정보 노출 방지)"
+  explain: 파일명으로 운영 적용이 확인되는 설정 파일에서 결제·인증·연동 패키지의 로깅 레벨이 debug/trace 입니다. 연동 클라이언트의 요청·응답이 운영 로그에 상세히 기록되어 자격증명과 거래 정보가 평문으로 남습니다. info 이상으로 낮춰야 합니다.
+  fix_example: |
+    ```yaml
+    logging:
+      level:
+        com.example.outer.api.tossPayments: info   # 운영은 info 이상
+    ```
+
+- rule_id: finguard.config.debug-logging
+  code: FIN-LOG-008
+  cwe: CWE-532
+  title: 결제·인증 패키지 debug 로깅(운영 적용 여부 확인 필요)
+  severity: WARNING
+  basis: 개발보안가이드 「에러처리 - 오류 메시지 정보노출」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 59 (디버그 로그 내 중요정보 노출 방지)"
+  explain: 결제·인증·연동 패키지의 로깅 레벨이 debug/trace 로 설정돼 있습니다. 이 설정이 운영 프로파일에 적용되는지는 자동으로 판정할 수 없습니다 — YAML 멀티도큐먼트의 프로파일 경계(spring.config.activate.on-profile)를 정적 분석으로 확정할 수 없기 때문입니다. 해당 블록이 어느 프로파일에 속하는지 확인하고, 운영에 적용된다면 info 이상으로 낮춰야 합니다.
+  fix_example: |
+    ```yaml
+    # 개발 프로파일에만 debug 를 두고, 운영 문서에 그 경계를 명시한다.
+    spring:
+      config:
+        activate:
+          on-profile: local
+    logging:
+      level:
+        com.example.outer.api.tossPayments: debug
+    ```

--- a/rules/config.yaml
+++ b/rules/config.yaml
@@ -126,3 +126,64 @@ rules:
       # 시크릿 저장소 참조는 시크릿이 아니라 올바른 사용법이다
       - pattern-not-regex: '(?im)^\s*["'']?[\w.-]+["'']?\s*[:=]\s*["'']?(\$|\{\{|<%|%\(|env:|secretKeyRef|valueFrom|vault:|aws:|arn:).*$'
       - pattern-not-regex: '(?im)^\s*["'']?[\w.-]+["'']?\s*[:=]\s*["'']?[\w-]{0,6}\.{2,}["'']?\s*$'
+
+  # ── 결제·인증 패키지 debug/trace 로깅 (CWE-532) (#32) ────────────────────────
+  #
+  # 연동 클라이언트의 전체 로깅(finguard.java.http-client-full-logging ·
+  # finguard.kotlin.feign-full-logging)이 실제 유출로 완성되는 지점은 "그 패키지의 로깅
+  # 레벨이 debug/trace 로 켜져 있는가" 다. 설정 파일 쪽 절반을 여기서 본다.
+  #
+  # semgrep 은 YAML 멀티도큐먼트의 `spring.config.activate.on-profile: prod` 경계를 판정할 수
+  # 없다. 추측으로 prod 라고 단정하지 않고 **파일명으로 근사**해 두 룰로 분리한다.
+  #   - application*prod*  → ERROR (finguard.config.prod-debug-logging)
+  #   - 그 외 설정 파일    → WARNING (finguard.config.debug-logging), 프로파일 확인 필요 문구 병기
+  #
+  # 알려진 한계: 이슈의 대표 증거(DuDoong application-infrastructure.yml 의 prod 프로파일 블록
+  # 안 tossPayments debug)는 파일명에 prod 가 없어 WARNING 에 머문다. 자동 판정 불가 구간이므로
+  # WARNING 코멘트가 리뷰어에게 프로파일 경계를 직접 확인하도록 요구한다.
+  - id: finguard.config.prod-debug-logging
+    languages: [regex]
+    severity: ERROR
+    message: 운영 프로파일 설정 파일에서 결제·인증·연동 패키지의 로깅 레벨이 debug/trace 입니다. 해당 패키지의 요청·응답이 운영 로그에 상세히 기록되어 연동 자격증명·거래 정보가 평문으로 남습니다. info 이상으로 낮춰야 합니다.
+    paths:
+      include:
+        - "application*prod*.yml"
+        - "application*prod*.yaml"
+        - "application*prod*.properties"
+        - "logback*prod*.xml"
+      exclude:
+        - "**/node_modules/**"
+        - "**/vendor/**"
+        - "*.example"
+        - "*.sample"
+        - "*.template"
+    pattern-either:
+      # key: debug 형태 (yml/properties 공통). 값이 다음 줄로 넘어가지 않도록 [ \t]* 로 제한.
+      - pattern-regex: '(?im)^[ \t]*(?:logging\.level\.)?[\w.$*-]*(?:pay(?:ment)?|pg|toss|inicis|kcp|nice|kftc|openbanking|card|auth|security|jdbc|sql)[\w.$*-]*[ \t]*[:=][ \t]*["'']?(?i:debug|trace)["'']?[ \t]*$'
+      # logback <logger name="..." level="DEBUG"/>
+      - pattern-regex: '(?is)<logger[^>]*name\s*=\s*"[^"]*(?:pay(?:ment)?|pg|toss|inicis|kcp|nice|kftc|openbanking|card|auth|security|jdbc|sql)[^"]*"[^>]*level\s*=\s*"(?i:debug|trace)"'
+
+  - id: finguard.config.debug-logging
+    languages: [regex]
+    severity: WARNING
+    message: 결제·인증·연동 패키지의 로깅 레벨이 debug/trace 로 설정돼 있습니다. 이 설정이 운영 프로파일에 적용되는지 확인이 필요합니다 — YAML 멀티도큐먼트의 프로파일 경계는 자동 판정할 수 없습니다. 운영에 적용된다면 연동 자격증명·거래 정보가 로그에 평문으로 남으므로 info 이상으로 낮춰야 합니다.
+    paths:
+      include:
+        - "application*.yml"
+        - "application*.yaml"
+        - "*.properties"
+        - "logback*.xml"
+      exclude:
+        # 운영 파일명은 finguard.config.prod-debug-logging(ERROR) 담당 — 중복 코멘트 방지
+        - "application*prod*.yml"
+        - "application*prod*.yaml"
+        - "application*prod*.properties"
+        - "logback*prod*.xml"
+        - "**/node_modules/**"
+        - "**/vendor/**"
+        - "*.example"
+        - "*.sample"
+        - "*.template"
+    pattern-either:
+      - pattern-regex: '(?im)^[ \t]*(?:logging\.level\.)?[\w.$*-]*(?:pay(?:ment)?|pg|toss|inicis|kcp|nice|kftc|openbanking|card|auth|security|jdbc|sql)[\w.$*-]*[ \t]*[:=][ \t]*["'']?(?i:debug|trace)["'']?[ \t]*$'
+      - pattern-regex: '(?is)<logger[^>]*name\s*=\s*"[^"]*(?:pay(?:ment)?|pg|toss|inicis|kcp|nice|kftc|openbanking|card|auth|security|jdbc|sql)[^"]*"[^>]*level\s*=\s*"(?i:debug|trace)"'

--- a/rules/java.yaml
+++ b/rules/java.yaml
@@ -495,3 +495,32 @@ rules:
               - metavariable-regex:
                   metavariable: $P
                   regex: '(?i)\w*(?:jwt|token)\w*'
+
+  # ------------------------------------------------------------------
+  # 11. 외부 연동 HTTP 클라이언트 전체 로깅 (CWE-532) (#32)
+  # ------------------------------------------------------------------
+  # 기존 로그 룰(finguard.java.print-sensitive)은 호출부 인자의 어휘만 보므로, 설정 한 줄로
+  # 모든 요청·응답 헤더와 본문을 흘리는 구조를 원리적으로 볼 수 없다. Feign Logger.Level.FULL
+  # 이 BasicAuth/Bearer 인터셉터와 결합하면 연동 시크릿이 담긴 Authorization 헤더와 결제 승인
+  # 응답 본문이 그대로 로그에 남는다.
+  #
+  # severity 는 WARNING 이다. FULL/BODY 로깅은 `if (BuildConfig.DEBUG)`·@Profile("local") 로
+  # 감싸인 경우가 흔한데 정규식은 그 감쌈을 보지 못한다 — ERROR 로 두면 기본 게이트
+  # (FINGUARD_BLOCK_ON=ERROR)가 로컬 전용 설정에 걸려 머지를 막는다.
+  # "같은 설정 클래스에 인증 헤더 인터셉터가 등록된 경우만 ERROR 승격" 은 semgrep 단독으로
+  # 판정할 수 없어(등록이 다른 파일에 있을 수 있다) 룰이 아니라 매핑 explain 의 일반 지침으로 옮겼다.
+  #
+  # paths 는 *.java 만이다. Kotlin 은 finguard.kotlin.feign-full-logging(#28)이 이미 담당한다 —
+  # 여기에 *.kt 를 넣으면 같은 줄에 코멘트가 두 번 달린다.
+  - id: finguard.java.http-client-full-logging
+    languages: [regex]
+    severity: WARNING
+    message: 외부 연동 HTTP 클라이언트가 요청·응답을 통째로 로깅하도록 설정돼 있습니다. 헤더와 본문이 그대로 로그에 남아 연동 자격증명(Authorization)과 결제·계좌 응답이 노출됩니다. 로깅 레벨을 BASIC 이하로 낮추거나 민감 헤더·본문을 마스킹해야 합니다.
+    paths:
+      include: ["*.java"]
+      exclude: ["*Test.java"]
+    patterns:
+      - pattern-regex: '(?im)^(?![ \t]*(?://|\*|/\*)).*(?:\bLogger\.Level\.(?:FULL|HEADERS)\b|\bHttpLoggingInterceptor\.Level\.(?:BODY|HEADERS)\b|\bsetLevel\s*\(\s*(?:HttpLoggingInterceptor\.)?(?:Level\.)?(?:FULL|BODY)\s*\)|org\.apache\.http\.wire)'
+      # org.apache.http.wire 로거를 *끄는* 설정은 오히려 수정된 코드다.
+      # pattern-not-regex 는 검출 범위를 포함할 때만 억제되므로 줄 전체를 잡는다.
+      - pattern-not-regex: '(?im)^.*org\.apache\.http\.wire.*\b(?:OFF|ERROR|WARN|NONE|BASIC)\b.*$'

--- a/testdata/rule-fixtures/application-infrastructure.yml
+++ b/testdata/rule-fixtures/application-infrastructure.yml
@@ -1,0 +1,28 @@
+# finguard.config.debug-logging (#32) 정탐 픽스처.
+#
+# 파일명으로는 운영 적용 여부를 알 수 없는 설정 파일 — WARNING.
+# YAML 멀티도큐먼트의 on-profile 경계는 semgrep 이 판정할 수 없어 추측하지 않는다.
+# 마커 없는 줄은 오탐 방지 대조군이다.
+spring:
+  config:
+    activate:
+      on-profile: staging
+
+logging:
+  level:
+    # EXPECT: finguard.config.debug-logging
+    com.example.outer.api.tossPayments.*: debug
+    # 대조군 — warn 은 대상이 아니다
+    com.example.outer.api.inicis: warn
+---
+spring:
+  config:
+    activate:
+      on-profile: prod
+
+logging:
+  level:
+    # EXPECT: finguard.config.debug-logging
+    com.example.outer.api.card: debug
+    # 대조군 — 어휘 없는 패키지
+    com.example.common.mapper: debug

--- a/testdata/rule-fixtures/application-prod.yml
+++ b/testdata/rule-fixtures/application-prod.yml
@@ -1,0 +1,25 @@
+# finguard.config.prod-debug-logging (#32) 정탐 픽스처.
+#
+# 파일명에 prod 가 들어간 설정 파일 — 운영 적용이 파일명으로 확인되므로 ERROR.
+# 마커 없는 줄은 오탐 방지 대조군이다.
+spring:
+  config:
+    activate:
+      on-profile: prod
+
+logging:
+  level:
+    root: info
+    # EXPECT: finguard.config.prod-debug-logging
+    com.example.outer.api.tossPayments.*: debug
+    # EXPECT: finguard.config.prod-debug-logging
+    com.example.openbanking: trace
+    # 대조군 — info 는 대상이 아니다
+    com.example.outer.api.kftc: info
+    # 대조군 — 결제·인증 어휘가 없는 패키지
+    com.example.batch.scheduler: debug
+
+management:
+  endpoint:
+    health:
+      show-details: never

--- a/testdata/rule-fixtures/java_http_logging.java
+++ b/testdata/rule-fixtures/java_http_logging.java
@@ -1,0 +1,38 @@
+// finguard.java.http-client-full-logging (#32) 정탐 픽스처.
+//
+// 설정 한 줄로 요청·응답 전체를 로그에 흘리는 구조. 마커 없는 줄은 오탐 방지 대조군이다.
+package fixtures;
+
+import feign.Logger;
+import okhttp3.logging.HttpLoggingInterceptor;
+
+public class HttpClientLoggingConfig {
+
+    // Feign 전역 로깅 레벨 — 헤더와 본문이 통째로 남는다.
+    // EXPECT: finguard.java.http-client-full-logging
+    public Logger.Level feignLoggerLevel() { return Logger.Level.FULL; }
+
+    // HEADERS 도 Authorization 헤더를 그대로 남긴다.
+    // EXPECT: finguard.java.http-client-full-logging
+    public Logger.Level feignHeaderLevel() { return Logger.Level.HEADERS; }
+
+    // OkHttp 본문 로깅.
+    public HttpLoggingInterceptor okHttpInterceptor() {
+        HttpLoggingInterceptor interceptor = new HttpLoggingInterceptor();
+        // EXPECT: finguard.java.http-client-full-logging
+        interceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
+        return interceptor;
+    }
+
+    // 대조군 1 — BASIC 은 메서드·URL·상태코드만 남긴다.
+    public Logger.Level safeLoggerLevel() { return Logger.Level.BASIC; }
+
+    // 대조군 2 — wire 로거를 끄는 설정은 오히려 수정된 코드다.
+    public void disableWireLog() {
+        java.util.logging.Logger.getLogger("org.apache.http.wire").setLevel(java.util.logging.Level.OFF);
+    }
+
+    // 대조군 3 — 주석 안의 설정 예시는 실제 설정이 아니다.
+    // interceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
+    public void documented() { }
+}

--- a/testdata/rule-fixtures/logback-payment.xml
+++ b/testdata/rule-fixtures/logback-payment.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  finguard.config.debug-logging (#32) 정탐 픽스처 — logback 문법.
+
+  XML 에는 줄 주석이 없어 EXPECT 마커(`#|// EXPECT: <룰ID>` 로 줄이 끝나야 한다)를
+  한 줄짜리 <!-- ... --> 안에 넣을 수 없다. 주석을 다음 줄에서 닫고 대상 요소를 이어 쓴다.
+  마커 없는 줄은 오탐 방지 대조군이다.
+-->
+<configuration>
+  <!-- # EXPECT: finguard.config.debug-logging
+  --><logger name="com.example.outer.api.tossPayments" level="DEBUG"/>
+
+  <!-- 대조군 — INFO 는 대상이 아니다 -->
+  <logger name="com.example.outer.api.kftc" level="INFO"/>
+
+  <!-- 대조군 — wire 로거를 끄는 설정은 수정된 코드다 -->
+  <logger name="org.apache.http.wire" level="OFF"/>
+
+  <root level="info">
+    <appender-ref ref="STDOUT"/>
+  </root>
+</configuration>

--- a/testdata/rule-fixtures/safe_java_http_logging.java
+++ b/testdata/rule-fixtures/safe_java_http_logging.java
@@ -1,0 +1,23 @@
+// finguard.java.http-client-full-logging (#32) 대조군 — 어떤 룰에도 걸리면 안 된다.
+package fixtures;
+
+import feign.Logger;
+import okhttp3.logging.HttpLoggingInterceptor;
+
+public class SafeHttpClientLoggingConfig {
+
+    // 메서드·URL·상태코드·소요시간만 남는다.
+    public Logger.Level feignLoggerLevel() { return Logger.Level.BASIC; }
+
+    // NONE 은 아무것도 남기지 않는다.
+    public Logger.Level feignNoneLevel() { return Logger.Level.NONE; }
+
+    public HttpLoggingInterceptor okHttpInterceptor() {
+        HttpLoggingInterceptor interceptor = new HttpLoggingInterceptor();
+        interceptor.setLevel(HttpLoggingInterceptor.Level.NONE);
+        return interceptor;
+    }
+
+    // 레벨 상수를 참조만 하고 클라이언트에 적용하지 않는 헬퍼.
+    public String describeLevel() { return "BASIC"; }
+}


### PR DESCRIPTION
Closes #32

> **⚠️ 이 PR 은 #37 PR(#53, `feat/issue-37-dev-auth-endpoint`) 위에 쌓았다.** 세 이슈(#37 · #32 · #34)가 모두 `rules/java.yaml` 을 건드려 순차 스택으로 구성했고, 이 PR 의 base 는 `main` 이 아니라 `feat/issue-37-dev-auth-endpoint` 다(diff 에는 이 PR 의 변경만 보인다). **#53 을 먼저 머지한 뒤 이 PR 의 base 를 `main` 으로 바꿔 머지해야 한다.**

설정 한 줄로 요청·응답 전체를 로그에 흘리는 구조를 볼 수 있는 룰이 없었다. 기존 로그 룰(`finguard.java.print-sensitive` / `finguard.kotlin.log-sensitive`)은 호출부 인자의 어휘만 보므로 원리적으로 이 구조를 볼 수 없다.

## 신설 룰

| 룰 ID | severity | 스코프 | 매핑 | CWE |
| :--- | :--- | :--- | :--- | :--- |
| `finguard.java.http-client-full-logging` | WARNING | `*.java` | `FIN-LOG-006` | CWE-532 |
| `finguard.config.prod-debug-logging` | ERROR | `application*prod*.{yml,yaml,properties}`, `logback*prod*.xml` | `FIN-LOG-007` | CWE-532 |
| `finguard.config.debug-logging` | WARNING | `application*.{yml,yaml}`, `*.properties`, `logback*.xml` (위 prod 파일명 제외) | `FIN-LOG-008` | CWE-532 |

## ① 반박 반영 내역

**재현율 수호자 — "제안 본문이 자기모순이다: 헤더는 ERROR, 마지막 문장은 WARNING"**

반영. `finguard.java.http-client-full-logging` 의 severity 를 **WARNING 으로 확정**(헤더의 ERROR 표기 철회). 사유를 룰 주석에 남겼다 — FULL/BODY 로깅은 `if (BuildConfig.DEBUG)`·`@Profile("local")` 로 감싸인 경우가 흔한데 정규식은 그 감쌈을 못 보므로, ERROR 로 두면 기본 게이트(`FINGUARD_BLOCK_ON=ERROR`)가 로컬 전용 설정에 걸려 머지를 막는다.

**재현율 수호자 — "`org.apache.http.wire` 토큰은 그 로거를 *끄는* 설정에도 매칭되어 수정된 코드를 지적하는 오탐이 된다"**

반영. 같은 줄에 `OFF|ERROR|WARN|NONE|BASIC` 이 있으면 제외하는 `pattern-not-regex` 를 병기했다. `pattern-not-regex` 는 검출 범위를 **포함**할 때만 억제되므로(이 레포 `rules/config.yaml` 에 기록된 semgrep 1.169.0 실측) 억제 정규식이 줄 전체를 잡도록 썼다. 픽스처에 `Logger.getLogger("org.apache.http.wire").setLevel(Level.OFF)` 대조군과 logback `<logger name="org.apache.http.wire" level="OFF"/>` 대조군을 넣어 고정했다.

**재현율 수호자 + 구현가능성 렌즈 — "`sql`·`auth`·`security` 는 개발 프로파일 관용구를 대량으로 잡는다. 파일명 기반 ERROR/WARNING 분리를 반드시 지켜야 한다"**

반영. 어휘 목록은 유지하되(미탐이 오탐보다 비싼 도구다) **파일명 기반 severity 이원화를 그대로 구현**했다. 운영 파일명은 ERROR, 그 외는 WARNING 이고, WARNING 쪽은 `exclude` 로 운영 파일명을 빼 중복 코멘트를 막았다. 실코드 10개 레포 전수 측정 결과 증가분은 **1건뿐**이며 그 1건이 이슈의 대표 증거다(아래 ②).

**재현율 수호자 — "`(1)` 의 ERROR 승격(같은 설정 클래스의 Basic/Bearer 인터셉터)은 semgrep 으로 구현 가능한지 먼저 검증"**

검증 결과 **구현하지 않았다**. 인터셉터 등록은 다른 파일(`TossHeaderConfig.kt` 같은 별도 설정 클래스)에 있는 것이 일반적이라, semgrep OSS 의 파일 단위 스코프로는 판정할 수 없다. 규제 렌즈의 지시대로 **룰이 아니라 매핑 `explain` 의 일반 지침**으로 옮겼다 — "동일 클라이언트에 인증 헤더 인터셉터(BasicAuth·Bearer)가 등록돼 있으면 연동 자격증명이 Authorization 헤더째로 기록되므로 즉시 조치해야 합니다." 스캔 대상 파일에 대한 사실 단정은 하지 않는다.

**규제 렌즈 — "가장 위험한 실사례(`application-infrastructure.yml:55`)가 파일명에 prod 가 없어 WARNING 에 머문다. 그 한계를 코멘트 문구에 드러내라"**

반영. `finguard.config.debug-logging` 의 message 와 매핑 `explain` 에 "이 설정이 운영 프로파일에 적용되는지 확인이 필요합니다 — YAML 멀티도큐먼트의 프로파일 경계(`spring.config.activate.on-profile`)는 자동 판정할 수 없습니다" 를 명시했다. 룰 주석에도 이 한계를 이슈 증거와 함께 적었다.

**규제 렌즈 — kisa_item 표기 지정**

반영, 문자열 그대로. 세 엔트리 모두 `전자금융기반시설 평가기준(2026) 웹·모바일·HTS 59 (디버그 로그 내 중요정보 노출 방지)` — 기존 `FIN-LOG-004`(`mapping/rules.yaml`) 표기를 그대로 승계했다. `basis` 도 같은 CWE-532 기존 엔트리(`FIN-LOG-002`·`FIN-LOG-004`)의 `개발보안가이드 「에러처리 - 오류 메시지 정보노출」` 을 승계했다.

**추가로 발견해 반영한 것 — 이슈 제안의 `paths.include: ["*.java","*.kt"]` 는 중복 코멘트를 만든다**

이슈 작성 이후 #28(PR #48)에서 `finguard.kotlin.feign-full-logging`(FIN-LOG-004)이 `Logger.Level.(FULL|HEADERS)` 를 이미 커버하며 머지됐다. 제안대로 `*.kt` 를 포함하면 DuDoong `FeignCommonConfig.kt:31` 같은 줄에 코멘트가 두 번 달린다. **`*.java` 로만 한정**하고 룰 주석에 사유를 남겼다. 실측으로 확인했다 — r3 의 Feign FULL 검출은 before/after 모두 `finguard.kotlin.feign-full-logging` 1건이고 증가하지 않았다.

`.finguard.yml` 은 #24(PR #50)에서 `finguard.config.plaintext-secret` 의 include 가 `*.yml`/`*.yaml` 전체로 확장됐다. 신설 두 룰은 **패턴이 전혀 겹치지 않는다**(키 이름의 secret 어휘 vs. 로깅 레벨 값). 중복 룰을 만들지 않았음을 실측 delta 로 확인했다.

## ② 실코드 전/후 검출 비교

코퍼스 10개 레포 전수 재스캔.

| 레포 | 스택 | before | after | delta |
| :--- | :--- | ---: | ---: | ---: |
| r0 한국투자증권 | Python | 42 | 42 | +0 |
| r1 samchon/payments | TS | 8 | 8 | +0 |
| r2 CoinNow | Swift | 1 | 1 | +0 |
| r3 DuDoong-Backend | Kotlin | 11 | **12** | **+1** |
| r4 iamport-python | Python | 0 | 0 | +0 |
| r5 AXSnapshot | Swift | 0 | 0 | +0 |
| r6 reactive-crypto | Kotlin | 2 | 2 | +0 |
| r7 pybithumb | Python | 0 | 0 | +0 |
| r8 iamport-rest-client-java | Java | 0 | 0 | +0 |
| r9 upbitBar | Swift | 0 | 0 | +0 |

### 새로 터진 1건 전수 확인

| 룰 | 위치 | 판정 |
| :--- | :--- | :--- |
| `finguard.config.debug-logging` | `r3 DuDoong-Infrastructure/src/main/resources/application-infrastructure.yml:55` | **정탐** |

해당 줄은 `spring.config.activate.on-profile: prod` 문서 블록 안의 `band.gosrock.infrastructure.outer.api.tossPayments.* : debug` 로, **이슈 #32 가 근거로 든 바로 그 줄**이다. 같은 파일 46행의 staging 블록 `band.gosrock.infrastructure.outer.api.* : debug` 는 패키지명에 결제·인증 어휘가 없어 잡히지 않았다(설계대로 — 어휘 없는 광범위 debug 까지 잡으면 소음이 폭증한다. 알려진 미탐으로 남긴다).

**오탐 0건.** 로깅 룰이 정상 로깅 설정을 대량으로 잡는 우려는 이 코퍼스 범위에서는 실현되지 않았다. r3 는 `application*.yml` 9개·`logback*.xml` 4개를 가지고 있어 소음이 났다면 여기서 드러났을 것이다. 다만 코퍼스에 대형 Spring 백엔드가 r3 하나뿐이라 **표본이 작다는 한계**는 명시한다 — `security`·`sql` 어휘의 소음은 더 큰 레포에서 다시 측정할 필요가 있다.

`finguard.java.http-client-full-logging` 은 코퍼스 검출 **0건**이다. Java 코퍼스가 r8 하나뿐이고 그 레포는 Feign·OkHttp 를 쓰지 않는(순수 `HttpClient` 기반) PG REST 클라이언트라 **해당 패턴이 코퍼스에 없다**. 억지 검출을 만들지 않고 픽스처로만 검증했다.

## ③ 변이 시험

| 변이 | 기대 | 실제 |
| :--- | :--- | :--- |
| 정탐 줄(`com.example.openbanking: trace`)의 `// EXPECT:` 마커 제거 | 오탐 회귀로 FAIL | `FAIL … 오탐 회귀 — 마커가 없는데 검출됐다: application-prod.yml:15 finguard.config.prod-debug-logging` |
| 검출되지 않는 줄(`com.example.outer.api.kftc: info`)에 마커 추가 | 미탐 회귀로 FAIL | `FAIL … 미탐 회귀 — 마커가 있는데 검출되지 않았다: application-prod.yml:18 finguard.config.prod-debug-logging` |
| 원복 후 | PASS | `ok github.com/leeyudok/finguard/internal/scanner` |

또한 XML 픽스처를 만들면서 마커 인프라의 제약을 하나 확인했다 — `expectMarker` 정규식이 `(#|//) EXPECT: <룰ID>` 로 **줄이 끝날 것**을 요구하므로, 한 줄짜리 `<!-- ... -->` 주석은 마커가 될 수 없다(`-->` 가 뒤에 남는다). 주석을 다음 줄에서 닫고 대상 요소를 이어 쓰는 방식으로 해결했고 픽스처 상단에 사유를 적었다. `internal/scanner/integration_test.go` 는 수정하지 않았다.

## ④ 일부러 넣지 않은 패턴과 이유

- **`paths.include` 에 `*.kt`** — `finguard.kotlin.feign-full-logging`(#28)과 중복 코멘트. 위 ① 참조.
- **"같은 설정 클래스에 Basic/Bearer 인터셉터가 있으면 ERROR 승격"** — semgrep 파일 단위 스코프로 판정 불가. 매핑 `explain` 의 일반 지침으로 이전. 위 ① 참조.
- **YAML `on-profile: prod` 블록 경계 판정** — semgrep 이 멀티도큐먼트 경계를 알 수 없다. 추측으로 prod 라 단정하지 않고 파일명으로 근사했다(AGENTS.md 「지어내지 않는다」).
- **어휘 없는 광범위 debug 로깅(`com.example.outer.api.*: debug`)** — 잡으면 개발 프로파일 관용구 전체가 걸린다. 알려진 미탐으로 남긴다.
- **`logging.level.root: debug`** — 위와 같은 이유. 어휘 조건에 걸리지 않는다.
- **`*.xml` 전반** — `logback*.xml` 로만 한정했다. 임의 XML 에서 `<logger level="DEBUG">` 를 찾으면 스코프가 통제되지 않는다.

## 검증

| 명령 | 결과 |
| :--- | :--- |
| `semgrep --validate --config rules/` | `Configuration is valid - found 0 configuration error(s), and 111 rule(s).` (#37 의 108 → 111) |
| `go build -mod=vendor ./...` | 통과 |
| `go vet -mod=vendor ./...` | 통과 |
| `go test -race -mod=vendor ./...` | 전 패키지 `ok` |
| `go test -race -mod=vendor -tags semgrep_integration ./internal/scanner/` | `ok` |
| 룰 수 = 매핑 수 대조 | 룰 111 / 매핑 111, 매핑 없는 룰 0, 고아 매핑 0 |
