### PR TITLE
feat(#34): 공용 crypto 래퍼 경유 취약 알고리즘 검출 확장(Java)

### DIFF
--- a/mapping/rules.yaml
+++ b/mapping/rules.yaml
@@ -1572,3 +1572,59 @@
         }
     }
     ```
+
+# ── 연동 클라이언트 전체 로깅 · 결제/인증 패키지 debug 로깅 (#32) ─────────────
+# basis 는 같은 CWE(532) 의 기존 엔트리(FIN-LOG-002·FIN-LOG-004) 값을 그대로 승계한다.
+# kisa_item 은 FIN-LOG-004 의 항목 59 표기를 문자열 그대로 쓴다.
+
+- rule_id: finguard.java.http-client-full-logging
+  code: FIN-LOG-006
+  cwe: CWE-532
+  title: 로그 중요정보 노출(HTTP 클라이언트 전체 로깅, Java)
+  severity: WARNING
+  basis: 개발보안가이드 「에러처리 - 오류 메시지 정보노출」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 59 (디버그 로그 내 중요정보 노출 방지)"
+  explain: 외부 연동 HTTP 클라이언트가 요청·응답을 통째로 로깅하도록 설정돼 있습니다. 헤더와 본문이 그대로 로그에 남습니다. 동일 클라이언트에 인증 헤더 인터셉터(BasicAuth·Bearer)가 등록돼 있으면 연동 자격증명이 Authorization 헤더째로 기록되므로 즉시 조치해야 합니다. 로깅 레벨을 BASIC 이하로 낮추거나 민감 헤더·본문을 마스킹해야 합니다.
+  fix_example: |
+    ```java
+    // 요청 메서드·URL·상태코드·소요시간만 남긴다. 헤더·본문은 남기지 않는다.
+    @Bean
+    public Logger.Level feignLoggerLevel() {
+        return Logger.Level.BASIC;
+    }
+    ```
+
+- rule_id: finguard.config.prod-debug-logging
+  code: FIN-LOG-007
+  cwe: CWE-532
+  title: 운영 프로파일 설정의 결제·인증 패키지 debug 로깅
+  severity: ERROR
+  basis: 개발보안가이드 「에러처리 - 오류 메시지 정보노출」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 59 (디버그 로그 내 중요정보 노출 방지)"
+  explain: 파일명으로 운영 적용이 확인되는 설정 파일에서 결제·인증·연동 패키지의 로깅 레벨이 debug/trace 입니다. 연동 클라이언트의 요청·응답이 운영 로그에 상세히 기록되어 자격증명과 거래 정보가 평문으로 남습니다. info 이상으로 낮춰야 합니다.
+  fix_example: |
+    ```yaml
+    logging:
+      level:
+        com.example.outer.api.tossPayments: info   # 운영은 info 이상
+    ```
+
+- rule_id: finguard.config.debug-logging
+  code: FIN-LOG-008
+  cwe: CWE-532
+  title: 결제·인증 패키지 debug 로깅(운영 적용 여부 확인 필요)
+  severity: WARNING
+  basis: 개발보안가이드 「에러처리 - 오류 메시지 정보노출」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 59 (디버그 로그 내 중요정보 노출 방지)"
+  explain: 결제·인증·연동 패키지의 로깅 레벨이 debug/trace 로 설정돼 있습니다. 이 설정이 운영 프로파일에 적용되는지는 자동으로 판정할 수 없습니다 — YAML 멀티도큐먼트의 프로파일 경계(spring.config.activate.on-profile)를 정적 분석으로 확정할 수 없기 때문입니다. 해당 블록이 어느 프로파일에 속하는지 확인하고, 운영에 적용된다면 info 이상으로 낮춰야 합니다.
+  fix_example: |
+    ```yaml
+    # 개발 프로파일에만 debug 를 두고, 운영 문서에 그 경계를 명시한다.
+    spring:
+      config:
+        activate:
+          on-profile: local
+    logging:
+      level:
+        com.example.outer.api.tossPayments: debug
+    ```

--- a/mapping/rules.yaml
+++ b/mapping/rules.yaml
@@ -1545,3 +1545,30 @@
       variables:
         ARTIFACT_API_KEY: $ARTIFACT_API_KEY   # 평문 값 대신 CI 변수 참조
     ```
+
+# ── 개발용 인증 우회 엔드포인트 — Java (#37) ─────────────────────────────────
+# basis·kisa_item 은 지어내지 않는다. kisa_item 은 docs/평가기준_웹모바일HTS_66항목.md:46
+# 의 항목 37 표기를 그대로 쓴다.
+
+- rule_id: finguard.java.dev-auth-endpoint
+  code: FIN-DBG-002
+  cwe: CWE-306
+  title: 자격증명 검증 없는 개발용 토큰 발급 엔드포인트(Java)
+  severity: WARNING
+  basis: 개발보안가이드 「보안기능 - 적절한 인증 없이 중요기능 허용」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 37 (불충분한 이용자 인증)"
+  explain: 개발·로컬 전용으로 보이는 경로에서 자격증명 검증 없이 정식 access/refresh 토큰을 발급하고 있습니다. 프로파일 조건만으로는 외부망에 노출된 검증계/개발계를 막지 못합니다. 운영 빌드에서 엔드포인트를 제거하거나(빌드 프로파일 분리), 실제 자격증명 검증을 추가하거나, 네트워크 계층에서 접근을 차단해야 합니다.
+  fix_example: |
+    ```java
+    // 개발 전용 컨트롤러는 프로파일로 격리해 운영 컨텍스트에 등록되지 않게 하고,
+    // 노출되는 경로에는 실제 자격증명 검증을 둔다.
+    @Profile({"local", "dev"})
+    @RestController
+    class LocalLoginController {
+        @PostMapping("/dev/login")
+        public TokenResponse login(@RequestBody LoginRequest request) {
+            authService.verifyCredential(request.getEmail(), request.getRawPassword());
+            return jwtTokenProvider.generateAccessToken(request.getEmail());
+        }
+    }
+    ```

--- a/mapping/rules.yaml
+++ b/mapping/rules.yaml
@@ -1628,3 +1628,23 @@
       level:
         com.example.outer.api.tossPayments: debug
     ```
+
+# ── 공용 crypto 래퍼 경유 취약 알고리즘 — Java (#34) ─────────────────────────
+# basis·kisa_item 은 같은 CWE(327) 기존 엔트리 FIN-CRY-005 값을 문자열 그대로 승계한다.
+# finguard.java.weak-hash 확장분은 기존 FIN-CRY-004 엔트리를 그대로 쓴다(신규 매핑 없음).
+
+- rule_id: finguard.java.weak-cipher-wrapper
+  code: FIN-CRY-015
+  cwe: CWE-327
+  title: 취약한 암호 알고리즘(공용 래퍼 경유·알고리즘 상수, Java)
+  severity: WARNING
+  basis: 개발보안가이드 「보안기능 - 취약한 암호화 알고리즘 사용」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 52 (취약한 HTTPS 암호 알고리즘 이용)"
+  explain: DES·3DES·RC4·Blowfish 알고리즘 이름이 암·복호화 함수의 인자 또는 알고리즘 상수로 지정돼 있습니다. 공용 CryptUtil 등 래퍼를 경유하더라도 내부에서 그 알고리즘이 실제로 사용됩니다. 함수명 어휘와 알고리즘 리터럴로 판정하는 휴리스틱이므로, 해당 상수·인자가 실제 암호 연산에 쓰이는지 확인한 뒤 AES/GCM 등 인증 암호로 교체해야 합니다.
+  fix_example: |
+    ```java
+    // 알고리즘을 상수로 빼더라도 값 자체를 인증 암호로 교체한다.
+    private static final String CIPHER_ALGORITHM = "AES/GCM/NoPadding";
+
+    Cipher cipher = Cipher.getInstance(CIPHER_ALGORITHM);
+    ```

--- a/rules/config.yaml
+++ b/rules/config.yaml
@@ -126,3 +126,64 @@ rules:
       # 시크릿 저장소 참조는 시크릿이 아니라 올바른 사용법이다
       - pattern-not-regex: '(?im)^\s*["'']?[\w.-]+["'']?\s*[:=]\s*["'']?(\$|\{\{|<%|%\(|env:|secretKeyRef|valueFrom|vault:|aws:|arn:).*$'
       - pattern-not-regex: '(?im)^\s*["'']?[\w.-]+["'']?\s*[:=]\s*["'']?[\w-]{0,6}\.{2,}["'']?\s*$'
+
+  # ── 결제·인증 패키지 debug/trace 로깅 (CWE-532) (#32) ────────────────────────
+  #
+  # 연동 클라이언트의 전체 로깅(finguard.java.http-client-full-logging ·
+  # finguard.kotlin.feign-full-logging)이 실제 유출로 완성되는 지점은 "그 패키지의 로깅
+  # 레벨이 debug/trace 로 켜져 있는가" 다. 설정 파일 쪽 절반을 여기서 본다.
+  #
+  # semgrep 은 YAML 멀티도큐먼트의 `spring.config.activate.on-profile: prod` 경계를 판정할 수
+  # 없다. 추측으로 prod 라고 단정하지 않고 **파일명으로 근사**해 두 룰로 분리한다.
+  #   - application*prod*  → ERROR (finguard.config.prod-debug-logging)
+  #   - 그 외 설정 파일    → WARNING (finguard.config.debug-logging), 프로파일 확인 필요 문구 병기
+  #
+  # 알려진 한계: 이슈의 대표 증거(DuDoong application-infrastructure.yml 의 prod 프로파일 블록
+  # 안 tossPayments debug)는 파일명에 prod 가 없어 WARNING 에 머문다. 자동 판정 불가 구간이므로
+  # WARNING 코멘트가 리뷰어에게 프로파일 경계를 직접 확인하도록 요구한다.
+  - id: finguard.config.prod-debug-logging
+    languages: [regex]
+    severity: ERROR
+    message: 운영 프로파일 설정 파일에서 결제·인증·연동 패키지의 로깅 레벨이 debug/trace 입니다. 해당 패키지의 요청·응답이 운영 로그에 상세히 기록되어 연동 자격증명·거래 정보가 평문으로 남습니다. info 이상으로 낮춰야 합니다.
+    paths:
+      include:
+        - "application*prod*.yml"
+        - "application*prod*.yaml"
+        - "application*prod*.properties"
+        - "logback*prod*.xml"
+      exclude:
+        - "**/node_modules/**"
+        - "**/vendor/**"
+        - "*.example"
+        - "*.sample"
+        - "*.template"
+    pattern-either:
+      # key: debug 형태 (yml/properties 공통). 값이 다음 줄로 넘어가지 않도록 [ \t]* 로 제한.
+      - pattern-regex: '(?im)^[ \t]*(?:logging\.level\.)?[\w.$*-]*(?:pay(?:ment)?|pg|toss|inicis|kcp|nice|kftc|openbanking|card|auth|security|jdbc|sql)[\w.$*-]*[ \t]*[:=][ \t]*["'']?(?i:debug|trace)["'']?[ \t]*$'
+      # logback <logger name="..." level="DEBUG"/>
+      - pattern-regex: '(?is)<logger[^>]*name\s*=\s*"[^"]*(?:pay(?:ment)?|pg|toss|inicis|kcp|nice|kftc|openbanking|card|auth|security|jdbc|sql)[^"]*"[^>]*level\s*=\s*"(?i:debug|trace)"'
+
+  - id: finguard.config.debug-logging
+    languages: [regex]
+    severity: WARNING
+    message: 결제·인증·연동 패키지의 로깅 레벨이 debug/trace 로 설정돼 있습니다. 이 설정이 운영 프로파일에 적용되는지 확인이 필요합니다 — YAML 멀티도큐먼트의 프로파일 경계는 자동 판정할 수 없습니다. 운영에 적용된다면 연동 자격증명·거래 정보가 로그에 평문으로 남으므로 info 이상으로 낮춰야 합니다.
+    paths:
+      include:
+        - "application*.yml"
+        - "application*.yaml"
+        - "*.properties"
+        - "logback*.xml"
+      exclude:
+        # 운영 파일명은 finguard.config.prod-debug-logging(ERROR) 담당 — 중복 코멘트 방지
+        - "application*prod*.yml"
+        - "application*prod*.yaml"
+        - "application*prod*.properties"
+        - "logback*prod*.xml"
+        - "**/node_modules/**"
+        - "**/vendor/**"
+        - "*.example"
+        - "*.sample"
+        - "*.template"
+    pattern-either:
+      - pattern-regex: '(?im)^[ \t]*(?:logging\.level\.)?[\w.$*-]*(?:pay(?:ment)?|pg|toss|inicis|kcp|nice|kftc|openbanking|card|auth|security|jdbc|sql)[\w.$*-]*[ \t]*[:=][ \t]*["'']?(?i:debug|trace)["'']?[ \t]*$'
+      - pattern-regex: '(?is)<logger[^>]*name\s*=\s*"[^"]*(?:pay(?:ment)?|pg|toss|inicis|kcp|nice|kftc|openbanking|card|auth|security|jdbc|sql)[^"]*"[^>]*level\s*=\s*"(?i:debug|trace)"'

--- a/rules/java.yaml
+++ b/rules/java.yaml
@@ -495,3 +495,32 @@ rules:
               - metavariable-regex:
                   metavariable: $P
                   regex: '(?i)\w*(?:jwt|token)\w*'
+
+  # ------------------------------------------------------------------
+  # 11. 외부 연동 HTTP 클라이언트 전체 로깅 (CWE-532) (#32)
+  # ------------------------------------------------------------------
+  # 기존 로그 룰(finguard.java.print-sensitive)은 호출부 인자의 어휘만 보므로, 설정 한 줄로
+  # 모든 요청·응답 헤더와 본문을 흘리는 구조를 원리적으로 볼 수 없다. Feign Logger.Level.FULL
+  # 이 BasicAuth/Bearer 인터셉터와 결합하면 연동 시크릿이 담긴 Authorization 헤더와 결제 승인
+  # 응답 본문이 그대로 로그에 남는다.
+  #
+  # severity 는 WARNING 이다. FULL/BODY 로깅은 `if (BuildConfig.DEBUG)`·@Profile("local") 로
+  # 감싸인 경우가 흔한데 정규식은 그 감쌈을 보지 못한다 — ERROR 로 두면 기본 게이트
+  # (FINGUARD_BLOCK_ON=ERROR)가 로컬 전용 설정에 걸려 머지를 막는다.
+  # "같은 설정 클래스에 인증 헤더 인터셉터가 등록된 경우만 ERROR 승격" 은 semgrep 단독으로
+  # 판정할 수 없어(등록이 다른 파일에 있을 수 있다) 룰이 아니라 매핑 explain 의 일반 지침으로 옮겼다.
+  #
+  # paths 는 *.java 만이다. Kotlin 은 finguard.kotlin.feign-full-logging(#28)이 이미 담당한다 —
+  # 여기에 *.kt 를 넣으면 같은 줄에 코멘트가 두 번 달린다.
+  - id: finguard.java.http-client-full-logging
+    languages: [regex]
+    severity: WARNING
+    message: 외부 연동 HTTP 클라이언트가 요청·응답을 통째로 로깅하도록 설정돼 있습니다. 헤더와 본문이 그대로 로그에 남아 연동 자격증명(Authorization)과 결제·계좌 응답이 노출됩니다. 로깅 레벨을 BASIC 이하로 낮추거나 민감 헤더·본문을 마스킹해야 합니다.
+    paths:
+      include: ["*.java"]
+      exclude: ["*Test.java"]
+    patterns:
+      - pattern-regex: '(?im)^(?![ \t]*(?://|\*|/\*)).*(?:\bLogger\.Level\.(?:FULL|HEADERS)\b|\bHttpLoggingInterceptor\.Level\.(?:BODY|HEADERS)\b|\bsetLevel\s*\(\s*(?:HttpLoggingInterceptor\.)?(?:Level\.)?(?:FULL|BODY)\s*\)|org\.apache\.http\.wire)'
+      # org.apache.http.wire 로거를 *끄는* 설정은 오히려 수정된 코드다.
+      # pattern-not-regex 는 검출 범위를 포함할 때만 억제되므로 줄 전체를 잡는다.
+      - pattern-not-regex: '(?im)^.*org\.apache\.http\.wire.*\b(?:OFF|ERROR|WARN|NONE|BASIC)\b.*$'

--- a/rules/java.yaml
+++ b/rules/java.yaml
@@ -430,3 +430,68 @@ rules:
               - pattern: $E.evaluate($CTX, $W, $TAG, $X)
               - pattern: $E.evaluateExpression($X, ...)
           - focus-metavariable: $X
+
+  # ------------------------------------------------------------------
+  # 10. 개발용 인증 우회 엔드포인트 — 자격증명 검증 없이 토큰 발급 (CWE-489) (#37)
+  # ------------------------------------------------------------------
+  # 여러 줄에 걸친 AND 조건(매핑 애노테이션 경로 어휘 + 같은 메서드 본문의 토큰 발급 호출)이라
+  # 정규식으로는 표현할 수 없어 semantic 모드로 구성했다. Kotlin 문법(fun ...)을 같은 룰에
+  # 섞으면 Java 파서가 파싱 에러를 내므로 languages 는 [java] 단일로 둔다 — Kotlin 대응은
+  # finguard.kotlin.dev-backdoor-endpoint(#28)가 이미 담당한다.
+  #
+  # 억제 사유로 인정하지 않는 것: @Profile("!prod") · 런타임 isProdProfile() 게이트.
+  # 그 게이트는 인터넷에 공개된 staging/검증계에서는 무효라 실제 사고의 유일한(그리고
+  # 뚫린) 방어선이었다.
+  #
+  # 경로 어휘는 "세그먼트" 단위로만 인정한다(/dev/, /local-login/). 부분문자열 매칭이면
+  # /api/v1/devices 같은 정상 경로가 걸린다.
+  - id: finguard.java.dev-auth-endpoint
+    languages: [java]
+    severity: WARNING
+    message: |
+      개발·로컬 전용으로 보이는 경로에서 자격증명 검증 없이 토큰을 발급하고 있습니다. 프로파일 조건(@Profile("!prod")·isProdProfile())만으로는 외부망에 노출된 검증계/개발계를 막지 못합니다. 운영 빌드에서 엔드포인트를 제거하거나(빌드·프로파일 분리), 실제 자격증명 검증을 추가하거나, 네트워크 계층에서 접근을 차단해야 합니다. 이미 그런 완화를 적용했다면 대상 레포의 .finguard.yml `ignore` 에 해당 파일을 명시해 승인 사실을 남기십시오.
+    paths:
+      exclude: ["*Test.java"]
+    patterns:
+      # (A) 개발·로컬 어휘가 경로 세그먼트로 들어간 매핑 애노테이션이 붙은 메서드 안일 것
+      - pattern-either:
+          # @PostMapping("/dev/login") — 인자 하나짜리 축약형
+          - patterns:
+              - pattern-inside: |
+                  @$ANN($PATH)
+                  $RT $M(...) { ... }
+              - metavariable-regex:
+                  metavariable: $ANN
+                  regex: '^(?:Get|Post|Put|Patch|Delete|Request)Mapping$'
+              - metavariable-regex:
+                  metavariable: $PATH
+                  regex: '(?i)^"(?:[^"]*/)?(?:dev|develop|local|test|debug|stub|mock|impersonate|switch-?user|su)(?:[-_]\w+)*(?:/[^"]*)?"$'
+          # @RequestMapping(value = "/debug/switch-user", method = ...) — 명시 인자형
+          - patterns:
+              - pattern-inside: |
+                  @$ANN(value = $PATH, ...)
+                  $RT $M(...) { ... }
+              - metavariable-regex:
+                  metavariable: $ANN
+                  regex: '^(?:Get|Post|Put|Patch|Delete|Request)Mapping$'
+              - metavariable-regex:
+                  metavariable: $PATH
+                  regex: '(?i)^"(?:[^"]*/)?(?:dev|develop|local|test|debug|stub|mock|impersonate|switch-?user|su)(?:[-_]\w+)*(?:/[^"]*)?"$'
+      # (B) 같은 메서드 본문에 토큰 발급 호출이 있을 것 — 코멘트는 이 줄에 달린다
+      - pattern-either:
+          - pattern: $X.generateAccessToken(...)
+          - pattern: $X.createAccessToken(...)
+          - pattern: $X.generateRefreshToken(...)
+          - pattern: $X.createRefreshToken(...)
+          - pattern: $X.generateToken(...)
+          - pattern: $X.createToken(...)
+          - pattern: $X.issueToken(...)
+          # 제공자 객체 이름에 Jwt/Token 이 들어간 경우의 일반 발급 메서드
+          - patterns:
+              - pattern-either:
+                  - pattern: $P.generate(...)
+                  - pattern: $P.create(...)
+                  - pattern: $P.issue(...)
+              - metavariable-regex:
+                  metavariable: $P
+                  regex: '(?i)\w*(?:jwt|token)\w*'

--- a/rules/java.yaml
+++ b/rules/java.yaml
@@ -106,14 +106,44 @@ rules:
       # 마스킹 플레이스홀더는 시크릿이 아니다 — 오히려 가리는 코드다
       - pattern-not-regex: '(?i)["''`](\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|<[^>]*redact[^>]*>|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]|[:=]\s*(\*{3,}|•{3,}|#{3,})(?![\w-])'
 
+  # 취약 해시 (CWE-328).
+  #   - MessageDigest/Mac 직접 호출 외에, 알고리즘명을 문자열로 받는 사내 래퍼
+  #     (CryptUtil.encrypt("MD5", ...) 류)와 DigestUtils.md5* 계열까지 본다 (#34).
+  #     금융권 공용 CryptUtil/SignUtil 은 알고리즘명을 파라미터로 넘기는 구조가 표준에
+  #     가까워, 정의부에는 리터럴이 없고(getInstance(algorithm)) 호출부에는 MessageDigest
+  #     문자열이 없어 종전 패턴은 양쪽 다 보지 못했다.
+  #   - 상수 선언형(static final String HASH_ALGORITHM = "MD5")도 본다. 알고리즘명을 상수로
+  #     빼고 래퍼에 넘기는 형태가 호출부 정규식으로는 잡히지 않는 최빈 미탐이었다.
+  #   - 함수명 휴리스틱을 필수로 둬서 임의 함수의 첫 인자 "MD5" 오탐을 막는다.
+  #   - Kotlin 대응은 finguard.kotlin.weak-hash(#28)가 이미 담당한다.
   - id: finguard.java.weak-hash
     languages: [regex]
     severity: WARNING
-    message: 취약한 해시 알고리즘(MD5/SHA-1)을 사용하고 있습니다.
+    message: 취약한 해시 알고리즘(MD5/SHA-1)을 사용하고 있습니다. SHA-256 이상(서명은 HMAC-SHA256)을 사용해야 합니다. 알고리즘명을 문자열로 받는 공용 래퍼를 경유하는 호출도 포함됩니다.
     paths:
       include: ["*.java"]
       exclude: ["*Test.java"]
-    pattern-regex: 'MessageDigest\.getInstance\(\s*"(MD5|SHA-?1)"'
+    pattern-regex: '(?:MessageDigest|Mac)\.getInstance\(\s*"(?i:MD5|SHA-?1|HmacMD5|HmacSHA-?1)"|\b(?:DigestUtils|Hashing)\.(?:md5|sha1)\w*\s*\(|\b\w*(?i:digest|hash|encrypt|decrypt|sign|hmac|crypt)\w*\s*\(\s*"(?i:MD5|SHA-?1|HmacMD5|HmacSHA-?1)"|\b(?:static\s+final\s+String|final\s+String|String)\s+\w*(?i:alg|algorithm|digest|hash|hmac)\w*\s*=\s*"(?i:MD5|SHA-?1|HmacMD5|HmacSHA-?1)"'
+
+  # 취약 암호 알고리즘 — 공용 래퍼 경유 호출·상수 선언형 (CWE-327) (#34).
+  #
+  # finguard.java.weak-cipher(ERROR)와 분리한 별도 룰이다. 이쪽은 "함수명 어휘 + 알고리즘
+  # 리터럴" 이라는 휴리스틱 매치라, 원 룰과 같은 ERROR 를 매기면 오탐이 기본 게이트
+  # (FINGUARD_BLOCK_ON=ERROR)로 머지를 직접 막는다. WARNING 으로 시작하고 승격은 실코드
+  # 검증 후 별도 판단한다.
+  #
+  # 알려진 한계: 알고리즘명이 호출부에도 상수에도 리터럴로 나타나지 않고 설정/DB 에서
+  # 주입되는 형태는 정적 분석으로 확정할 수 없다. 정의부(getInstance($ALG))에 INFO 룰을
+  # 두는 안은 채택하지 않았다 — 잘 작성된 crypto 래퍼일수록 더 많이 발화하는 구조라
+  # MR 인라인 코멘트의 신호 대 잡음비를 직접 훼손한다.
+  - id: finguard.java.weak-cipher-wrapper
+    languages: [regex]
+    severity: WARNING
+    message: 취약한 암호 알고리즘(DES·3DES·RC4·Blowfish) 이름이 암·복호화 함수의 인자 또는 알고리즘 상수로 지정돼 있습니다. 공용 래퍼를 경유하더라도 실제로 그 알고리즘이 사용됩니다. AES/GCM 등 인증 암호로 교체해야 합니다.
+    paths:
+      include: ["*.java"]
+      exclude: ["*Test.java"]
+    pattern-regex: '\b\w*(?i:encrypt|decrypt|cipher|crypt|seal|unseal)\w*\s*\(\s*"(?i:DES|DESede|TripleDES|RC4|ARCFOUR|Blowfish)[^"]*"|\b(?:static\s+final\s+String|final\s+String|String)\s+\w*(?i:alg|algorithm|cipher|transformation)\w*\s*=\s*"(?i:DES|DESede|TripleDES|RC4|ARCFOUR|Blowfish)[^"]*"'
 
   - id: finguard.java.weak-cipher
     languages: [regex]

--- a/testdata/rule-fixtures/application-infrastructure.yml
+++ b/testdata/rule-fixtures/application-infrastructure.yml
@@ -1,0 +1,28 @@
+# finguard.config.debug-logging (#32) 정탐 픽스처.
+#
+# 파일명으로는 운영 적용 여부를 알 수 없는 설정 파일 — WARNING.
+# YAML 멀티도큐먼트의 on-profile 경계는 semgrep 이 판정할 수 없어 추측하지 않는다.
+# 마커 없는 줄은 오탐 방지 대조군이다.
+spring:
+  config:
+    activate:
+      on-profile: staging
+
+logging:
+  level:
+    # EXPECT: finguard.config.debug-logging
+    com.example.outer.api.tossPayments.*: debug
+    # 대조군 — warn 은 대상이 아니다
+    com.example.outer.api.inicis: warn
+---
+spring:
+  config:
+    activate:
+      on-profile: prod
+
+logging:
+  level:
+    # EXPECT: finguard.config.debug-logging
+    com.example.outer.api.card: debug
+    # 대조군 — 어휘 없는 패키지
+    com.example.common.mapper: debug

--- a/testdata/rule-fixtures/application-prod.yml
+++ b/testdata/rule-fixtures/application-prod.yml
@@ -1,0 +1,25 @@
+# finguard.config.prod-debug-logging (#32) 정탐 픽스처.
+#
+# 파일명에 prod 가 들어간 설정 파일 — 운영 적용이 파일명으로 확인되므로 ERROR.
+# 마커 없는 줄은 오탐 방지 대조군이다.
+spring:
+  config:
+    activate:
+      on-profile: prod
+
+logging:
+  level:
+    root: info
+    # EXPECT: finguard.config.prod-debug-logging
+    com.example.outer.api.tossPayments.*: debug
+    # EXPECT: finguard.config.prod-debug-logging
+    com.example.openbanking: trace
+    # 대조군 — info 는 대상이 아니다
+    com.example.outer.api.kftc: info
+    # 대조군 — 결제·인증 어휘가 없는 패키지
+    com.example.batch.scheduler: debug
+
+management:
+  endpoint:
+    health:
+      show-details: never

--- a/testdata/rule-fixtures/java_dev_auth.java
+++ b/testdata/rule-fixtures/java_dev_auth.java
@@ -1,0 +1,51 @@
+// finguard.java.dev-auth-endpoint (#37) 정탐 픽스처.
+//
+// 자격증명 검증 없이 요청 본문만으로 정식 토큰을 발급하는 개발/로컬 전용 엔드포인트.
+// 매핑 애노테이션의 경로 세그먼트 어휘(dev/local/debug/impersonate/...) 와 같은 메서드
+// 본문의 토큰 발급 호출이 동시에 성립할 때만 검출된다.
+package fixtures;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+public class DevAuthController {
+
+    private JwtTokenProvider jwtTokenProvider;
+    private TokenService tokenService;
+    private UserRepository userRepository;
+
+    // 요청 본문의 email 만으로 사용자를 upsert 하고 정식 access 토큰을 발급한다.
+    @PostMapping("/oauth/local/login")
+    public TokenResponse localLogin(@RequestBody RegisterRequest request) {
+        User user = userRepository.findOrCreate(request.getEmail());
+        // EXPECT: finguard.java.dev-auth-endpoint
+        return jwtTokenProvider.generateAccessToken(user.getId());
+    }
+
+    // 명시 인자형 애노테이션 + 계정 전환(임의 계정 사칭) 경로.
+    @RequestMapping(value = "/debug/switch-user", method = RequestMethod.POST)
+    public TokenResponse switchUser(@RequestBody RegisterRequest request) {
+        User user = userRepository.findByEmail(request.getEmail());
+        // EXPECT: finguard.java.dev-auth-endpoint
+        return tokenService.createToken(user);
+    }
+
+    // 제공자 이름에 Jwt 가 들어간 일반 발급 메서드도 토큰 발급으로 본다.
+    @PostMapping("/dev-login")
+    public TokenResponse devLogin(@RequestBody RegisterRequest request) {
+        // EXPECT: finguard.java.dev-auth-endpoint
+        return jwtProvider.generate(request.getEmail());
+    }
+
+    // 개발 전용 경로지만 토큰을 발급하지 않으므로 검출 대상이 아니다.
+    @GetMapping("/dev/health")
+    public String devHealth() {
+        return "ok";
+    }
+}

--- a/testdata/rule-fixtures/java_http_logging.java
+++ b/testdata/rule-fixtures/java_http_logging.java
@@ -1,0 +1,38 @@
+// finguard.java.http-client-full-logging (#32) 정탐 픽스처.
+//
+// 설정 한 줄로 요청·응답 전체를 로그에 흘리는 구조. 마커 없는 줄은 오탐 방지 대조군이다.
+package fixtures;
+
+import feign.Logger;
+import okhttp3.logging.HttpLoggingInterceptor;
+
+public class HttpClientLoggingConfig {
+
+    // Feign 전역 로깅 레벨 — 헤더와 본문이 통째로 남는다.
+    // EXPECT: finguard.java.http-client-full-logging
+    public Logger.Level feignLoggerLevel() { return Logger.Level.FULL; }
+
+    // HEADERS 도 Authorization 헤더를 그대로 남긴다.
+    // EXPECT: finguard.java.http-client-full-logging
+    public Logger.Level feignHeaderLevel() { return Logger.Level.HEADERS; }
+
+    // OkHttp 본문 로깅.
+    public HttpLoggingInterceptor okHttpInterceptor() {
+        HttpLoggingInterceptor interceptor = new HttpLoggingInterceptor();
+        // EXPECT: finguard.java.http-client-full-logging
+        interceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
+        return interceptor;
+    }
+
+    // 대조군 1 — BASIC 은 메서드·URL·상태코드만 남긴다.
+    public Logger.Level safeLoggerLevel() { return Logger.Level.BASIC; }
+
+    // 대조군 2 — wire 로거를 끄는 설정은 오히려 수정된 코드다.
+    public void disableWireLog() {
+        java.util.logging.Logger.getLogger("org.apache.http.wire").setLevel(java.util.logging.Level.OFF);
+    }
+
+    // 대조군 3 — 주석 안의 설정 예시는 실제 설정이 아니다.
+    // interceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
+    public void documented() { }
+}

--- a/testdata/rule-fixtures/java_weak_crypto.java
+++ b/testdata/rule-fixtures/java_weak_crypto.java
@@ -1,0 +1,65 @@
+// finguard.java.weak-hash · finguard.java.weak-cipher-wrapper (#34) 정탐 픽스처.
+//
+// 금융권 공용 CryptUtil/SignUtil 은 알고리즘명을 문자열 파라미터로 넘기는 구조가 표준에
+// 가깝다. 그러면 정의부에는 리터럴이 없고(getInstance(algorithm)) 호출부에는 MessageDigest
+// 문자열이 없어 종전 정규식이 양쪽 다 보지 못했다.
+// 마커 없는 줄은 오탐 방지 대조군이다.
+package fixtures;
+
+import java.security.MessageDigest;
+import javax.crypto.Mac;
+import org.apache.commons.codec.digest.DigestUtils;
+
+public class SignUtil {
+
+    // 알고리즘명을 상수로 빼고 래퍼에 넘기는 최빈 형태 — 호출부 정규식만으로는 못 본다.
+    // EXPECT: finguard.java.weak-hash
+    private static final String HASH_ALGORITHM = "MD5";
+
+    // EXPECT: finguard.java.weak-cipher-wrapper
+    private static final String CIPHER_ALGORITHM = "DESede/CBC/PKCS5Padding";
+
+    // 공용 래퍼 경유 — 거래소 API 요청 서명 생성 형태.
+    public String sign(String plainText) {
+        // EXPECT: finguard.java.weak-hash
+        return CryptUtil.encrypt("MD5", plainText);
+    }
+
+    public String legacyDigest(String plainText) {
+        // EXPECT: finguard.java.weak-hash
+        return DigestUtils.md5Hex(plainText);
+    }
+
+    // 직접 호출 형태도 계속 검출된다(회귀 방지).
+    public byte[] directDigest(byte[] raw) throws Exception {
+        // EXPECT: finguard.java.weak-hash
+        MessageDigest md = MessageDigest.getInstance("SHA-1");
+        return md.digest(raw);
+    }
+
+    public Mac legacyMac() throws Exception {
+        // EXPECT: finguard.java.weak-hash
+        return Mac.getInstance("HmacMD5");
+    }
+
+    // 래퍼 경유 취약 암호.
+    public String encryptLegacy(String plainText) {
+        // EXPECT: finguard.java.weak-cipher-wrapper
+        return CryptUtil.encrypt("DES/ECB/PKCS5Padding", plainText);
+    }
+
+    // 대조군 — SHA-256 은 대상이 아니다.
+    public String safeSign(String plainText) {
+        return CryptUtil.encrypt("SHA-256", plainText);
+    }
+
+    // 대조군 — 함수명 휴리스틱에 걸리지 않는 임의 함수의 첫 인자.
+    public String lookupCode() {
+        return registry.resolve("MD5");
+    }
+
+    // 대조군 — AES 는 대상이 아니다.
+    public String encryptModern(String plainText) {
+        return CryptUtil.encrypt("AES/GCM/NoPadding", plainText);
+    }
+}

--- a/testdata/rule-fixtures/logback-payment.xml
+++ b/testdata/rule-fixtures/logback-payment.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  finguard.config.debug-logging (#32) 정탐 픽스처 — logback 문법.
+
+  XML 에는 줄 주석이 없어 EXPECT 마커(`#|// EXPECT: <룰ID>` 로 줄이 끝나야 한다)를
+  한 줄짜리 <!-- ... --> 안에 넣을 수 없다. 주석을 다음 줄에서 닫고 대상 요소를 이어 쓴다.
+  마커 없는 줄은 오탐 방지 대조군이다.
+-->
+<configuration>
+  <!-- # EXPECT: finguard.config.debug-logging
+  --><logger name="com.example.outer.api.tossPayments" level="DEBUG"/>
+
+  <!-- 대조군 — INFO 는 대상이 아니다 -->
+  <logger name="com.example.outer.api.kftc" level="INFO"/>
+
+  <!-- 대조군 — wire 로거를 끄는 설정은 수정된 코드다 -->
+  <logger name="org.apache.http.wire" level="OFF"/>
+
+  <root level="info">
+    <appender-ref ref="STDOUT"/>
+  </root>
+</configuration>

--- a/testdata/rule-fixtures/safe_java_dev_auth.java
+++ b/testdata/rule-fixtures/safe_java_dev_auth.java
@@ -1,0 +1,44 @@
+// finguard.java.dev-auth-endpoint (#37) 대조군 — 어떤 룰에도 걸리면 안 된다.
+//
+// 검증 항목
+//   - 정상 로그인: 자격증명 검증 후 토큰 발급. 경로에 개발 어휘가 없다.
+//   - /api/v1/devices: "dev" 를 부분문자열로 포함하지만 경로 세그먼트가 아니다.
+//   - /local/config: 개발 경로지만 토큰 발급 호출이 없다.
+//   - testReport: 메서드명에 test 가 들어간 정상 업무 엔드포인트.
+package fixtures;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+public class SafeAuthController {
+
+    private JwtTokenProvider jwtTokenProvider;
+    private AuthService authService;
+    private DeviceService deviceService;
+
+    @PostMapping("/auth/login")
+    public TokenResponse login(@RequestBody LoginRequest request) {
+        authService.verifyCredential(request.getEmail(), request.getRawPassword());
+        return jwtTokenProvider.generateAccessToken(request.getEmail());
+    }
+
+    @GetMapping("/devices/list")
+    public DeviceList devices() {
+        return deviceService.list();
+    }
+
+    @GetMapping("/local/config")
+    public ConfigView localConfig() {
+        return ConfigView.current();
+    }
+
+    @PostMapping("/settlement/test-report")
+    public ReportView testReport(@RequestBody ReportRequest request) {
+        return deviceService.report(request);
+    }
+}

--- a/testdata/rule-fixtures/safe_java_http_logging.java
+++ b/testdata/rule-fixtures/safe_java_http_logging.java
@@ -1,0 +1,23 @@
+// finguard.java.http-client-full-logging (#32) 대조군 — 어떤 룰에도 걸리면 안 된다.
+package fixtures;
+
+import feign.Logger;
+import okhttp3.logging.HttpLoggingInterceptor;
+
+public class SafeHttpClientLoggingConfig {
+
+    // 메서드·URL·상태코드·소요시간만 남는다.
+    public Logger.Level feignLoggerLevel() { return Logger.Level.BASIC; }
+
+    // NONE 은 아무것도 남기지 않는다.
+    public Logger.Level feignNoneLevel() { return Logger.Level.NONE; }
+
+    public HttpLoggingInterceptor okHttpInterceptor() {
+        HttpLoggingInterceptor interceptor = new HttpLoggingInterceptor();
+        interceptor.setLevel(HttpLoggingInterceptor.Level.NONE);
+        return interceptor;
+    }
+
+    // 레벨 상수를 참조만 하고 클라이언트에 적용하지 않는 헬퍼.
+    public String describeLevel() { return "BASIC"; }
+}

--- a/testdata/rule-fixtures/safe_java_weak_crypto.java
+++ b/testdata/rule-fixtures/safe_java_weak_crypto.java
@@ -1,0 +1,35 @@
+// finguard.java.weak-hash · finguard.java.weak-cipher-wrapper (#34) 대조군 —
+// 어떤 룰에도 걸리면 안 된다.
+package fixtures;
+
+import java.security.MessageDigest;
+import javax.crypto.Mac;
+
+public class SafeSignUtil {
+
+    private static final String HASH_ALGORITHM = "SHA-256";
+    private static final String CIPHER_ALGORITHM = "AES/GCM/NoPadding";
+
+    public byte[] digest(byte[] raw) throws Exception {
+        MessageDigest md = MessageDigest.getInstance(HASH_ALGORITHM);
+        return md.digest(raw);
+    }
+
+    public Mac mac() throws Exception {
+        return Mac.getInstance("HmacSHA256");
+    }
+
+    public String sign(String plainText) {
+        return CryptUtil.encrypt("SHA-256", plainText);
+    }
+
+    // 함수명 휴리스틱에 걸리지 않는 임의 함수의 첫 인자는 알고리즘 지정이 아니다.
+    public String describe() {
+        return registry.resolve("MD5");
+    }
+
+    // 알고리즘명이 아니라 지원 목록 표기다.
+    public String[] supported() {
+        return new String[] {"SHA-256", "SHA-512"};
+    }
+}


### PR DESCRIPTION
Closes #34

> **⚠️ 이 PR 은 #32 PR(#55) 위에 쌓았고, #55 는 다시 #37 PR(#53) 위에 쌓여 있다.** 세 이슈가 모두 `rules/java.yaml` 을 건드려 `#53 → #55 → 이 PR` 순차 스택으로 구성했다. 이 PR 의 base 는 `feat/issue-32-http-full-logging` 이다. **#53 → #55 순으로 머지한 뒤 이 PR 의 base 를 `main` 으로 바꿔 머지해야 한다.**

> **범위 축소 공지 — Kotlin 부분은 #28 에서 선행 처리됨.** 이슈 #34 원안은 `kotlin.weak-hash`/`kotlin.weak-cipher` 와 `java.weak-hash`/`java.weak-cipher` 를 모두 다뤘다. 그러나 Kotlin 쪽은 이슈 #28(PR #48, 머지 완료)에서 이미 구현됐다 — `finguard.kotlin.weak-hash` 가 알고리즘명을 문자열 인자로 받는 래퍼·`Mac.getInstance`·`DigestUtils.md5*` 를 모두 잡고, `reactive-crypto` 의 `CoinealSignUtil.kt`(`CryptUtil.encrypt("MD5", ...)`)에서 실증까지 끝났다(코퍼스 r6 의 기존 검출 1건이 그것이다). **이 PR 은 `rules/java.yaml` 만 다루며 `rules/kotlin.yaml` 은 건드리지 않았다.** 머지된 Kotlin 구현을 읽고 같은 접근을 Java 문법 차이(`val`/`const val` → `static final String`)를 반영해 이식했다.

## 변경 룰

| 룰 ID | 변경 | severity | 매핑 | CWE |
| :--- | :--- | :--- | :--- | :--- |
| `finguard.java.weak-hash` | 확장 | WARNING (유지) | `FIN-CRY-004` (기존) | CWE-328 |
| `finguard.java.weak-cipher-wrapper` | **신설** | WARNING | `FIN-CRY-015` | CWE-327 |
| `finguard.java.weak-cipher` | 변경 없음 | ERROR | `FIN-CRY-005` | CWE-327 |

`finguard.java.weak-hash` 에 추가한 대안은 네 가지다.

1. `Mac.getInstance("HmacMD5" | "HmacSHA1")`
2. `DigestUtils.md5*` / `Hashing.md5*` / `.sha1*` 계열
3. 함수명 휴리스틱 기반 래퍼 호출부 — `\w*(digest|hash|encrypt|decrypt|sign|hmac|crypt)\w*("MD5" …)`
4. 알고리즘 상수 선언형 — `static final String HASH_ALGORITHM = "MD5"`

기존 `MessageDigest.getInstance("MD5"|"SHA-1")` 직접 호출 검출은 그대로 유지되며 픽스처로 회귀를 고정했다.

## ① 반박 반영 내역

**재현율 수호자 — "제안이 커버한다고 주장하는 범위보다 실제 커버리지가 좁다. `const val ALGO = "MD5"` 를 선언해 두고 `CryptUtil.encrypt(ALGO, x)` 로 넘기는 최빈 형태는 호출부 정규식도 정의부 INFO 룰도 확정 판정을 못 한다"**

반영. 검증자가 제시한 **상수 선언형 대안을 추가**했다(Java 문법으로 이식: `(?:static\s+final\s+String|final\s+String|String)\s+\w*(?i:alg|algorithm|digest|hash|hmac)\w*\s*=\s*"(?i:MD5|SHA-?1|…)"`, WARNING). 픽스처에 `private static final String HASH_ALGORITHM = "MD5";` 를 정탐으로 고정했다.

남는 미탐은 **정직하게 명시**한다 — 알고리즘명이 호출부에도 상수에도 리터럴로 나타나지 않고 설정 파일·DB 에서 주입되는 형태는 정적 분석으로 확정할 수 없다. 룰 주석에 "알려진 한계"로 적었다.

**규제 렌즈 — "보조 룰 `crypto-algorithm-parameterized`(INFO)는 반대한다. `getInstance($ALG)` 에서 `$ALG` 가 리터럴이 아닌 형태는 잘 작성된 crypto 래퍼라면 거의 전부 해당하므로 '정상 구현일수록 더 많이 발화' 하는 구조다"**

반영, **폐기**했다. 재현율 수호자는 유지하되 메시지를 '호출부 확인 필요' 로 한정하라고 했고 규제 렌즈는 폐기 또는 미등록 내부 진단 전용을 제시했으나, 2표 기준으로 "MR 인라인 코멘트를 내지 않는다"는 점에서 두 의견이 수렴한다. 이 도구의 출력이 곧 MR 인라인 코멘트이므로 **룰 자체를 만들지 않는 것**이 가장 단순하고 정확한 구현이다. 폐기 사유를 `finguard.java.weak-cipher-wrapper` 주석에 남겨 다음 사람이 같은 제안을 반복하지 않게 했다.

**규제 렌즈 — "호출부 변형의 severity 를 원 룰과 맞추지 말고 한 단계 낮춘다. weak-cipher 호출부 변형은 ERROR 가 아니라 WARNING 으로 시작"**

반영. `finguard.java.weak-cipher`(ERROR)를 건드리지 않고 **별도 룰 `finguard.java.weak-cipher-wrapper`(WARNING)로 분리**했다. 한 룰에 두 severity 를 둘 수 없어 분리가 유일한 구현 경로다. 사유를 룰 주석에 남겼다 — 함수명 어휘 기반 휴리스틱을 ERROR 로 두면 오탐이 기본 게이트(`FINGUARD_BLOCK_ON=ERROR`)로 머지를 직접 막는다.

weak-hash 호출부 변형은 원 룰과 같은 WARNING 이므로(검증자 판단대로) 기존 룰에 그대로 합쳤다 — 노이즈 등급이 올라가지 않는다.

**재현율 수호자 + 규제 렌즈 + 구현가능성 렌즈 — "함수명 휴리스틱을 필수로 둬 임의 함수의 첫 인자 `"MD5"` 오탐을 막는 설계는 적절"**

반영. 알고리즘 리터럴 단독으로는 절대 발화하지 않는다. 대조군 픽스처에 `registry.resolve("MD5")` 를 넣어 고정했다(함수명이 어휘에 걸리지 않으므로 미검출).

**구현가능성 렌즈 — "정규식 컴파일 정상, 백트래킹 위험(중첩 가변 quantifier) 없음"**

확인. `semgrep --validate` 통과, 10개 레포 전수 스캔이 타임아웃 없이 완료됐다.

## ② 실코드 전/후 검출 비교

코퍼스 10개 레포 전수 재스캔. `before` 는 이 PR 직전(#32 반영 상태), `main` 대비 열도 함께 싣는다.

| 레포 | 스택 | main | #32 까지 | 이 PR 후 | 이 PR 의 delta |
| :--- | :--- | ---: | ---: | ---: | ---: |
| r0 한국투자증권 | Python | 42 | 42 | 42 | +0 |
| r1 samchon/payments | TS | 8 | 8 | 8 | +0 |
| r2 CoinNow | Swift | 1 | 1 | 1 | +0 |
| r3 DuDoong-Backend | Kotlin | 11 | 12 | 12 | +0 |
| r4 iamport-python | Python | 0 | 0 | 0 | +0 |
| r5 AXSnapshot | Swift | 0 | 0 | 0 | +0 |
| r6 reactive-crypto | Kotlin | 2 | 2 | 2 | +0 |
| r7 pybithumb | Python | 0 | 0 | 0 | +0 |
| r8 iamport-rest-client-java | Java | 0 | 0 | 0 | +0 |
| r9 upbitBar | Swift | 0 | 0 | 0 | +0 |

**신규 검출 0건. 오탐 0건.**

사유를 사실대로 적는다. **Java 코퍼스에 해당 패턴이 존재하지 않는다.**

- Java 코퍼스는 r8(`iamport-rest-client-java`) 하나뿐이고 `*.java` 81개 규모다.
- 그 레포 전체에 `md5` · `sha-1` · `DESede` · `RC4` · `Blowfish` · `MessageDigest` · `Cipher.getInstance` 문자열이 **한 건도 없다**(대소문자 무시 grep 실측 0건). 해시·암호 연산 자체를 하지 않는 REST 클라이언트다.
- 이슈가 근거로 든 실사례(`reactive-crypto` `CoinealSignUtil.kt:37` → `CryptUtil.encrypt("MD5", …)`)는 **Kotlin** 이고, r6 의 `finguard.kotlin.weak-hash` 1건으로 **이미 잡히고 있다**(#28). before/after 모두에 포함되어 delta 로 나타나지 않는다.

없는 사례를 지어내지 않고 **픽스처로만 검증**했다. 코퍼스 검출이 0건이므로 `finguard.java.weak-cipher-wrapper` 의 ERROR 승격은 하지 않는다(규제 렌즈의 "실코드 검증 후 승격 판단" 조건 미충족).

## ③ 변이 시험

| 변이 | 기대 | 실제 |
| :--- | :--- | :--- |
| 정탐 줄(`static final String CIPHER_ALGORITHM = "DESede/…"`)의 `// EXPECT:` 마커 제거 | 오탐 회귀로 FAIL | `FAIL … 오탐 회귀 — 마커가 없는데 검출됐다: java_weak_crypto.java:19 finguard.java.weak-cipher-wrapper` |
| 검출되지 않는 줄(`CryptUtil.encrypt("AES/GCM/NoPadding", …)`)에 마커 추가 | 미탐 회귀로 FAIL | `FAIL … 미탐 회귀 — 마커가 있는데 검출되지 않았다: java_weak_crypto.java:64 finguard.java.weak-cipher-wrapper` |
| 원복 후 | PASS | `ok github.com/leeyudok/finguard/internal/scanner` |

## ④ 일부러 넣지 않은 패턴과 이유

- **`finguard.java.crypto-algorithm-parameterized`(INFO, 정의부 `getInstance($ALG)`)** — 규제 렌즈 반대. 정상 구현일수록 더 많이 발화하는 구조라 MR 코멘트 신호 대 잡음비를 훼손한다. 위 ① 참조.
- **`rules/kotlin.yaml` 수정** — #28(PR #48)에서 선행 처리 완료. 중복 구현이다.
- **`finguard.java.weak-cipher`(ERROR) 정규식에 래퍼 대안 합치기** — 휴리스틱 매치가 ERROR 게이트로 머지를 막는다. 별도 WARNING 룰로 분리.
- **알고리즘명이 설정·DB 에서 주입되는 형태** — 리터럴이 소스 어디에도 없어 정적 분석으로 확정 불가. 알려진 미탐으로 룰 주석에 명시.
- **`"AES"` 단독 · `"RSA"`** — 취약 알고리즘이 아니다. `"AES/ECB/…"` 같은 운영모드 문제는 기존 `finguard.java.weak-cipher` 담당이라 중복시키지 않았다.
- **`SHA-224`·`SHA-512/224` 등 경계 알고리즘** — 개발보안가이드가 취약으로 규정한 범위(MD5·SHA-1)를 넘어서므로 지어내지 않았다.

## 검증

| 명령 | 결과 |
| :--- | :--- |
| `semgrep --validate --config rules/` | `Configuration is valid - found 0 configuration error(s), and 112 rule(s).` (#32 의 111 → 112) |
| `go build -mod=vendor ./...` | 통과 |
| `go vet -mod=vendor ./...` | 통과 |
| `go test -race -mod=vendor ./...` | 전 패키지 `ok` |
| `go test -race -mod=vendor -tags semgrep_integration ./internal/scanner/` | `ok` |
| 룰 수 = 매핑 수 대조 | 룰 112 / 매핑 112, 매핑 없는 룰 0, 고아 매핑 0 |
