### PR TITLE
feat(#31): credential-at-rest 룰 — 토큰 파일 권한 미제한 검출 + UserDefaults 래퍼 커버

### DIFF
--- a/mapping/rules.yaml
+++ b/mapping/rules.yaml
@@ -1583,3 +1583,20 @@
     - 검증을 무력화하지 않는 상위 버전으로 교체하거나 대체 라이브러리를 선정
     - 불가피하면 반입 심사 기록에 수용 위험(accepted risk)으로 등록하고 사용 범위를 제한
     ```
+
+# ── 자격증명 파일 영속화 (#31) ────────────────────────────────────────────
+
+- rule_id: finguard.python.credential-file-write
+  code: FIN-STO-003
+  cwe: CWE-922
+  title: 자격증명 파일 저장 시 권한 미제한
+  severity: WARNING
+  basis: 개발보안가이드 「보안기능 - 중요정보 평문 저장」
+  kisa_item: ""
+  explain: 런타임에 발급받은 액세스 토큰·시크릿을 로컬 파일에 저장하면서 파일 권한을 소유자 전용으로 좁히지 않고 있습니다. 기본 umask(0022)에서는 0644 로 생성되어 다중 사용자 호스트의 다른 계정이 그대로 읽을 수 있고, 탈취된 토큰으로 계좌조회·주문 API 를 호출할 수 있습니다. 이미 chmod 를 호출하고 있다면 권한값이 0o600/0o400 인지 확인해야 합니다.
+  fix_example: |
+    ```python
+    with open(token_path, "w", encoding="utf-8") as f:
+        f.write(token)
+    os.chmod(token_path, 0o600)   # 소유자만 읽기·쓰기
+    ```

--- a/rules/python.yaml
+++ b/rules/python.yaml
@@ -182,3 +182,113 @@ rules:
       - pattern-not: $APP.add_middleware(CORSMiddleware, ..., allow_credentials=True, ...)
       - pattern-not: CORSMiddleware(..., allow_credentials=True, ...)
       - pattern-not: CORS(..., supports_credentials=True, ...)
+
+  # 자격증명 파일 영속화 (#31).
+  #
+  # 기존 시크릿 룰은 전부 '리터럴 대입' 만 본다. 금융 API 클라이언트의 실제 공통 결함은
+  # 그게 아니라 런타임에 발급받은 액세스 토큰을 로컬에 떨구면서 권한을 좁히지 않는 것이다.
+  # 기본 umask(0022) 로 0644 가 되면 다중 사용자 호스트에서 타 계정이 읽어 계좌조회·주문
+  # API 를 그대로 호출할 수 있다.
+  #
+  # 억제 조건 설계:
+  #   - pattern-not-inside 의 스코프는 with 블록이 아니라 **감싸는 함수 전체**다. chmod 는
+  #     파일 핸들이 필요 없어 실무에서는 with 블록을 빠져나온 뒤 호출하는 형태가 흔하고,
+  #     with 블록으로 스코프를 잡으면 그 안전한 코드를 억제하지 못한다(실측 확인).
+  #   - chmod 존재만으로 억제하지 않는다. **소유자 전용 권한**(0o600/0o400/S_IRUSR 계열,
+  #     umask 0o077, os.open 0o600)일 때만 억제한다 — os.chmod(path, 0o644) 나
+  #     무관한 대상에 대한 os.chmod(LOG_DIR, 0o777) 는 억제 대상이 아니다.
+  #
+  # 싱크는 f.write 하나로 좁히지 않는다. json.dump·pickle.dump·Path.write_text·
+  # configparser.write 로 떨구는 형태가 실제로는 더 많다. 자격증명 어휘는 쓰이는 값뿐
+  # 아니라 대상 경로·파일 핸들 변수명에도 건다(값이 이름 있는 변수가 아니면 미매칭이므로).
+  - id: finguard.python.credential-file-write
+    languages: [python]
+    severity: WARNING
+    message: 런타임에 발급받은 자격증명(액세스 토큰·시크릿·비밀번호)을 로컬 파일에 저장하면서 파일 권한을 소유자 전용으로 좁히지 않고 있습니다. 저장 직후 os.chmod(path, 0o600) 으로 권한을 제한하거나 OS 자격증명 저장소를 사용해야 합니다. 이미 chmod 를 하고 있다면 권한값이 0o600/0o400 인지 확인이 필요합니다.
+    paths:
+      exclude: ["test_*.py", "*_test.py", "conftest.py"]
+    patterns:
+      - pattern-inside: |
+          def $FUNC(...):
+              ...
+      - pattern-either:
+          - patterns:
+              - pattern-either:
+                  - pattern: $F.write($S)
+                  - pattern: $F.writelines($S)
+                  - pattern: json.dump($S, ...)
+                  - pattern: pickle.dump($S, ...)
+                  - pattern: $P.write_text($S, ...)
+                  - pattern: $P.write_bytes($S, ...)
+              - metavariable-regex:
+                  metavariable: $S
+                  regex: '(?is).*(access[_-]?token|refresh[_-]?token|token|secret|password|passwd|api[_-]?key|appsecret|credential|private[_-]?key|access[_-]?key).*'
+          - patterns:
+              - pattern-either:
+                  - pattern: $F.write(...)
+                  - pattern: $F.writelines(...)
+                  - pattern: json.dump(..., $F, ...)
+                  - pattern: pickle.dump(..., $F, ...)
+              - metavariable-regex:
+                  metavariable: $F
+                  regex: '(?is).*(access[_-]?token|refresh[_-]?token|token|secret|password|passwd|api[_-]?key|appsecret|credential|private[_-]?key|access[_-]?key).*'
+          - patterns:
+              - pattern-either:
+                  - pattern: $P.write_text(...)
+                  - pattern: $P.write_bytes(...)
+              - metavariable-regex:
+                  metavariable: $P
+                  regex: '(?is).*(access[_-]?token|refresh[_-]?token|token|secret|password|passwd|api[_-]?key|appsecret|credential|private[_-]?key|access[_-]?key).*'
+          - patterns:
+              - pattern-inside: |
+                  with open($P, ...) as $F:
+                      ...
+              - pattern-either:
+                  - pattern: $F.write(...)
+                  - pattern: $F.writelines(...)
+                  - pattern: json.dump(..., $F, ...)
+                  - pattern: pickle.dump(..., $F, ...)
+                  - pattern: $CP.write($F)
+              - metavariable-regex:
+                  metavariable: $P
+                  regex: '(?is).*(access[_-]?token|refresh[_-]?token|token|secret|password|passwd|api[_-]?key|appsecret|credential|private[_-]?key|access[_-]?key).*'
+      - pattern-not-inside: |
+          def $SAFE(...):
+              ...
+              os.chmod(..., 0o600)
+              ...
+      - pattern-not-inside: |
+          def $SAFE(...):
+              ...
+              os.chmod(..., 0o400)
+              ...
+      - pattern-not-inside: |
+          def $SAFE(...):
+              ...
+              os.chmod(..., stat.S_IRUSR | stat.S_IWUSR)
+              ...
+      - pattern-not-inside: |
+          def $SAFE(...):
+              ...
+              os.chmod(..., stat.S_IRUSR)
+              ...
+      - pattern-not-inside: |
+          def $SAFE(...):
+              ...
+              $Q.chmod(0o600)
+              ...
+      - pattern-not-inside: |
+          def $SAFE(...):
+              ...
+              $Q.chmod(0o400)
+              ...
+      - pattern-not-inside: |
+          def $SAFE(...):
+              ...
+              os.umask(0o077)
+              ...
+      - pattern-not-inside: |
+          def $SAFE(...):
+              ...
+              os.open(..., 0o600)
+              ...

--- a/rules/swift.yaml
+++ b/rules/swift.yaml
@@ -43,6 +43,13 @@ rules:
       exclude: ["**/build/**", "**/DerivedData/**", "**/*.xcframework/**"]
     pattern-regex: '(?im)^(?![ \t]*(?://|\*|/\*)).*"ws://(?!localhost|127\.0\.0\.1|0\.0\.0\.0|schemas\.|xmlns|(?:www\.)?w3\.org|(?:[\w.]+\.)?apache\.org|[\w.]*xml\.org|java\.sun\.com|(?:www\.)?example\.(?:com|org)|(?:www\.)?unicode\.org|(?:www\.)?jflex\.de|purl\.org|iana\.org|ietf\.org|slf4j\.org|json-schema\.org)[^"]+"'
 
+  # UserDefaults 평문 저장 (#31).
+  # 'UserDefaults ... .set(... 민감어휘)' 를 한 줄에서 요구하면 Swift 관용구인
+  # @propertyWrapper 에서 매칭이 끊긴다 — 저장 메커니즘(UserDefaults.standard.set)은
+  # 래퍼 선언부에 있고 키 이름은 사용부에 있어 두 줄이 서로 다른 파일일 수도 있다.
+  # 그래서 '키 이름에 민감 어휘가 있는 사용부' 를 별도 대안으로 본다.
+  # 저장 메커니즘 선언부(UserDefaults.standard.set 단독)는 잡지 않는다 — 래퍼가 무엇을
+  # 담는지 그 줄만 봐서는 알 수 없어 오탐 폭탄이 된다.
   - id: finguard.swift.userdefaults-sensitive
     languages: [regex]
     severity: ERROR
@@ -50,7 +57,12 @@ rules:
     paths:
       include: ["*.swift"]
       exclude: ["**/build/**", "**/DerivedData/**", "**/*.xcframework/**"]
-    pattern-regex: '(?i)UserDefaults[^\n]*\.set\([^\n]*(password|passwd|token|secret|pin|cardno|card_no|accountno)'
+    pattern-either:
+      - pattern-regex: '(?i)UserDefaults[^\n]*\.set\([^\n]*(password|passwd|token|secret|pin|cardno|card_no|accountno)'
+      # UserDefaults 를 감싸는 커스텀 propertyWrapper 의 사용부 (@UserDefault/@Storage/@UserInfo …)
+      - pattern-regex: '(?i)@\w*(?:UserDefault|Storage|Preference|UserInfo)\w*\s*\(\s*key\s*:\s*[^)\n]*(?:password|passwd|secret|token|pin|accesskey|secretkey|credential)'
+      # SwiftUI 표준 UserDefaults 래퍼 — 키를 첫 인자로 직접 받는다
+      - pattern-regex: '(?i)@AppStorage\s*\(\s*"[^"\n]*(?:password|passwd|secret|token|pin|accesskey|secretkey|credential)'
 
   - id: finguard.swift.uiwebview
     languages: [regex]

--- a/testdata/rule-fixtures/python_credential_at_rest.py
+++ b/testdata/rule-fixtures/python_credential_at_rest.py
@@ -1,0 +1,63 @@
+"""룰 회귀 픽스처 — finguard.python.credential-file-write (#31).
+
+런타임에 발급받은 자격증명을 로컬 파일에 떨구면서 권한을 좁히지 않는 형태.
+합성 코드이며 실제 자격증명 값은 들어 있지 않다.
+"""
+
+import json
+import os
+import pickle
+import stat
+from pathlib import Path
+
+
+# 증거 형태 — 한국투자증권 open-trading-api kis_auth.save_token 과 동일 구조
+def save_token(my_token, valid_date):
+    with open(token_tmp, "w", encoding="utf-8") as f:
+        # EXPECT: finguard.python.credential-file-write
+        f.write(f"token: {my_token}\n")
+        # EXPECT: finguard.python.credential-file-write
+        f.write(f"valid-date: {valid_date}\n")
+
+
+# json.dump 싱크 — 대상 경로 변수명에 자격증명 어휘가 있다
+def dump_credentials(cfg):
+    with open(access_token_path, "w") as f:
+        # EXPECT: finguard.python.credential-file-write
+        json.dump(cfg, f)
+
+
+# Path.write_text 싱크
+def persist_secret(value):
+    # EXPECT: finguard.python.credential-file-write
+    secret_path.write_text(value)
+
+
+# pickle 싱크
+def dump_session(obj):
+    with open(credential_file, "wb") as f:
+        # EXPECT: finguard.python.credential-file-write
+        pickle.dump(obj, f)
+
+
+# configparser 싱크 — 쓰기 인자가 파일 핸들이다
+def dump_ini(cp):
+    with open(api_key_file, "w") as f:
+        # EXPECT: finguard.python.credential-file-write
+        cp.write(f)
+
+
+# chmod 는 하지만 0o644 라 소유자 전용이 아니다 — 억제 대상이 아니다
+def save_token_loose_mode(my_token):
+    with open(token_tmp, "w") as f:
+        # EXPECT: finguard.python.credential-file-write
+        f.write(f"access_token: {my_token}")
+    os.chmod(token_tmp, 0o644)
+
+
+# 무관한 대상에 대한 chmod 한 줄이 있어도 억제되면 안 된다
+def save_token_unrelated_chmod(my_token):
+    os.chmod(LOG_DIR, 0o777)
+    with open(token_tmp, "w") as f:
+        # EXPECT: finguard.python.credential-file-write
+        f.write(f"access_token: {my_token}")

--- a/testdata/rule-fixtures/safe_python_credential_at_rest.py
+++ b/testdata/rule-fixtures/safe_python_credential_at_rest.py
@@ -1,0 +1,44 @@
+"""대조군 — 어떤 룰에도 걸리면 안 된다 (#31).
+
+토큰을 저장하되 소유자 전용 권한을 실제로 부여하는 정상 구현들. chmod 를 with 블록
+밖에서 호출하는 실무 관용구(파일 핸들이 필요 없는 오퍼레이션)도 함께 둔다.
+"""
+
+import os
+import stat
+from pathlib import Path
+
+
+# with 블록을 빠져나온 뒤 소유자 전용 권한 부여 — 실무에서 가장 흔한 안전 형태
+def save_token(my_token):
+    with open(token_tmp, "w", encoding="utf-8") as f:
+        f.write(f"token: {my_token}\n")
+    os.chmod(token_tmp, 0o600)
+
+
+# stat 상수 조합
+def save_token_stat(my_token):
+    with open(token_tmp, "w", encoding="utf-8") as f:
+        f.write(f"token: {my_token}\n")
+    os.chmod(token_tmp, stat.S_IRUSR | stat.S_IWUSR)
+
+
+# Path.chmod
+def save_token_pathlib(my_token):
+    p = Path(token_tmp)
+    p.write_text(f"token: {my_token}")
+    p.chmod(0o600)
+
+
+# umask 로 그룹·타인 권한을 미리 차단
+def save_token_umask(my_token):
+    os.umask(0o077)
+    with open(token_tmp, "w", encoding="utf-8") as f:
+        f.write(f"token: {my_token}\n")
+
+
+# 자격증명이 아닌 일반 파일 쓰기는 대상이 아니다
+def write_report(rows, report_path):
+    with open(report_path, "w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(row + "\n")

--- a/testdata/rule-fixtures/swift_userdefaults_wrapper.swift
+++ b/testdata/rule-fixtures/swift_userdefaults_wrapper.swift
@@ -1,0 +1,42 @@
+//
+//  룰 회귀 픽스처 — finguard.swift.userdefaults-sensitive (#31)
+//
+//  @propertyWrapper 로 저장 메커니즘과 키 이름이 다른 선언으로 갈라지는 Swift 관용구.
+//  단일 라인 정규식은 이 형태에서 연결이 끊긴다. 합성 코드이며 실제 키 값은 없다.
+//
+
+import Foundation
+import SwiftUI
+
+@propertyWrapper
+struct UserInfo<T> {
+    private let key: String
+    private let defaultValue: T
+
+    var wrappedValue: T {
+        // 저장 메커니즘 선언부는 잡지 않는다 — 무엇을 담는지 이 줄만으로는 알 수 없다
+        get { return UserDefaults.standard.object(forKey: key) as? T ?? defaultValue }
+        set { UserDefaults.standard.set(newValue, forKey: key) }
+    }
+
+    init(key: String, defaultValue: T) {
+        self.key = key
+        self.defaultValue = defaultValue
+    }
+}
+
+struct ExchangeKeys {
+    // EXPECT: finguard.swift.userdefaults-sensitive
+    @UserInfo(key: ExchangeKey.accessKey.rawValue, defaultValue: "") var accessToken: String
+    // EXPECT: finguard.swift.userdefaults-sensitive
+    @UserInfo(key: ExchangeKey.secretKey.rawValue, defaultValue: "") var secretToken: String
+    // 민감 어휘가 없는 키는 대상이 아니다
+    @UserInfo(key: ExchangeKey.refreshInterval.rawValue, defaultValue: 1) var refreshInterval: Int
+}
+
+struct SettingsView {
+    // EXPECT: finguard.swift.userdefaults-sensitive
+    @AppStorage("auth_access_token") var authToken: String = ""
+    // 화면 설정 값은 대상이 아니다
+    @AppStorage("is_dark_mode") var isDarkMode: Bool = false
+}


### PR DESCRIPTION
Closes #31

> **이 PR 은 #33 PR(#54, `feat/issue-33-ats-coverage`) 위에 쌓았다.** 두 이슈가
> `rules/swift.yaml` 을 공유하므로 충돌을 피하려고 순차로 작업했다. base 를 `main` 이 아니라
> `feat/issue-33-ats-coverage` 로 잡아 diff 에 이 PR 의 변경만 보이게 했다.
> **#54 를 먼저 머지**하면 GitHub 이 base 를 `main` 으로 자동 재지정한다.

## 요약

| 룰 ID | 상태 | severity | 매핑 |
| :--- | :--- | :--- | :--- |
| `finguard.python.credential-file-write` | **신설** | WARNING | FIN-STO-003 |
| `finguard.swift.userdefaults-sensitive` | 확장 (propertyWrapper·@AppStorage) | ERROR | FIN-STO-001 (기존) |

## 검증에서 나온 반박 반영 내역

### (1) `pattern-not-inside` 스코프 — semgrep 렌즈의 실측 지적 반영

원안의 `pattern-not-inside: with open(...) as $F: ... os.chmod(...) ...` 는 chmod 를
**with 블록 안**에서 호출할 때만 억제한다. chmod 는 파일 핸들이 필요 없는 오퍼레이션이라
실무 관용구는 with 블록을 빠져나온 뒤 호출한다. 지적대로 **스코프를 감싸는 함수 전체**
(`def $SAFE(...): ... <chmod> ...`)로 바꿨다. 대조군 픽스처
`safe_python_credential_at_rest.py::save_token` 이 정확히 이 형태이고, 검출 0건이다.

### (2) chmod 존재만으로 억제하지 않는다 — 재현율·규제 렌즈 지적 반영

"함수 안에 chmod 어휘가 있으면 억제"는 `os.chmod(LOG_DIR, 0o777)` 한 줄로 토큰 파일
문제를 통째로 무음화한다. 그래서 **권한값이 소유자 전용일 때만** 억제한다.

| 억제 O | 억제 X (그대로 발화) |
| :--- | :--- |
| `os.chmod(p, 0o600)` / `0o400` | `os.chmod(p, 0o644)` |
| `os.chmod(p, stat.S_IRUSR \| stat.S_IWUSR)` / `stat.S_IRUSR` | `os.chmod(LOG_DIR, 0o777)` (무관한 대상) |
| `Path.chmod(0o600)` / `0o400`, `os.umask(0o077)`, `os.open(..., 0o600)` | chmod 자체가 없는 경우 |

두 경우 모두 픽스처에 정탐 마커로 고정했다(`save_token_loose_mode`,
`save_token_unrelated_chmod`). "권한값 검증은 후속 이슈로" 하지 않고 같은 룰에서 처리했다.

### (3) 패턴 shape 확장 — 재현율 렌즈 지적 반영

`with open($P,"w") as $F: ... $F.write($S)` + $S 어휘 조건만으로는 실제 다수 형태를
놓친다는 지적을 반영해 싱크를 넓혔다: `f.write` / `f.writelines` / `json.dump` /
`pickle.dump` / `Path.write_text` / `Path.write_bytes` / `configparser.write($F)`.
또 자격증명 어휘를 **쓰이는 값뿐 아니라 대상 경로·파일 핸들 변수명에도** 건다
(값이 이름 있는 변수가 아니면 미매칭이라는 지적 반영). 증거 코드
`kis_auth.save_token` 의 `f.write(f"valid-date: {valid_date}")` 는 값에 자격증명 어휘가
없지만 `with open(token_tmp, ...)` 경로 어휘로 잡힌다.

### (4) Swift propertyWrapper — 원안 채택 + 단서 유지

`@\w*(UserDefault|Storage|Preference|UserInfo)\w*\(key: ... 민감어휘)` 를 추가했고,
**저장 메커니즘 선언부(`UserDefaults.standard.set` 단독)는 잡지 않는다**는 단서를
그대로 유지했다. 픽스처의 래퍼 선언부(`set { UserDefaults.standard.set(newValue, forKey: key) }`)는
검출 0건임을 대조로 고정했다.

이슈 원안에 없던 항목 하나를 추가했다 — **`@AppStorage("…token…")`**. SwiftUI 표준
UserDefaults 래퍼이고 키를 첫 인자로 직접 받는 형태라 커스텀 래퍼 정규식(`key:` 라벨 요구)에
걸리지 않는다. 같은 결함 유형의 가장 흔한 현대적 관용구라 빼면 커버리지 구멍이 그대로 남는다.

### (5) 매핑 basis·kisa_item

지어내지 않았다. `basis` 는 같은 CWE-922 의 기존 엔트리 FIN-STO-001 값
(`개발보안가이드 「보안기능 - 중요정보 평문 저장」`)을 문자열 그대로 승계했다.
`kisa_item` 은 **빈 문자열**로 뒀다 — 규제 렌즈가 "평가기준 26 이 파일 권한까지
포괄하는지 원문 대조 후 확실하면 기입, 아니면 빈 문자열"이라고 단서를 달았는데,
항목 26 은 '단말기 내 중요정보 저장 방지'로 모바일 단말 대상이고 이 룰은 서버·데스크톱
Python 클라이언트의 파일 권한을 본다. 원문 대조 없이 감사 근거로 쓸 수 없어 비웠다
(레포에 동일 선례 10건 존재).

## 실코드 전/후 검출 비교

`before` = #33 머지 후 상태(= 이 PR 의 base), `after` = 이 PR 적용 후. 코퍼스 10개 전체.

| 레포 | 스택 | before | after | delta |
| :--- | :--- | ---: | ---: | ---: |
| r0 한국투자증권 OpenAPI | Python | 42 | 54 | **+12** |
| r1 samchon/payments | TS | 8 | 8 | 0 |
| r2 CoinNow | Swift | 1 | 1 | 0 |
| r3 DuDoong-Backend | Kotlin | 11 | 11 | 0 |
| r4 iamport-python | Python | 0 | 0 | 0 |
| r5 AXSnapshot | Swift | 0 | 0 | 0 |
| r6 reactive-crypto | Kotlin | 2 | 2 | 0 |
| r7 pybithumb | Python | 0 | 0 | 0 |
| r8 iamport-java | Java | 0 | 0 | 0 |
| r9 upbitBar | Swift | 0 | **2** | **+2** |
| **합계** | | **64** | **78** | **+14** |

### 신규 14건 전수 확인 — **오탐 0건**

**r0 — `finguard.python.credential-file-write` 12건 (6개 파일 × 2줄)**

| 파일 | 줄 |
| :--- | :--- |
| `backtester/kis_auth.py` | 82, 83 |
| `examples_llm/kis_auth.py` | 74, 75 |
| `examples_user/kis_auth.py` | 74, 75 |
| `legacy/Sample01/kis_auth.py` | 70, 71 |
| `legacy/rest/kis_auth.py` | 56, 57 |
| `strategy_builder/kis_auth.py` | 82, 83 |

6개 파일 전부 동일한 `save_token()` 사본이다. OAuth 액세스 토큰과 만료일을
`with open(token_tmp, "w", encoding="utf-8")` 로 평문 기록하고, 각 파일에
`os.chmod`·`umask`·`keyring` 이 **하나도 없음**을 전수 확인했다. 전부 정탐이다.
(이슈 본문은 4개 파일로 적었으나 실제 코퍼스에는 6개 사본이 있다.)

한 함수에서 `f.write` 2줄이 각각 잡혀 인접 두 줄에 코멘트가 달린다. 값 인자에 어휘가 있는
줄(`token: {my_token}`)과 경로 어휘로 잡히는 줄(`valid-date: …`)이 따로 매칭되기 때문인데,
줄 단위 코멘트라 reviewdog 이 합쳐주지는 않는다. 재현율을 깎지 않으려고 그대로 뒀다.

**r9 — `finguard.swift.userdefaults-sensitive` 2건**

`Sources/Utils/UserInfo.swift:28`(`@UserInfo(key: UpbitKey.accessKey.rawValue, …)`),
`:29`(`… secretKey …`). 업비트 API accessKey/secretKey 를 Keychain 이 아닌 UserDefaults
(plist 평문)에 저장한다. 확장 전에는 저장 메커니즘(`:18`)과 키 이름(`:28-29`)이 다른
선언으로 갈라져 있어 단일 라인 정규식이 연결에 실패했다. 정탐이다.

**오탐 없음 확인**: r2 CoinNow 는 UserDefaults 를 광범위하게 쓰지만(사이트 종류, 코인,
UI 플래그) 키 이름에 민감 어휘가 없어 전부 미검출이다. r4 iamport-python·r7 pybithumb 도
증가 0건 — 두 라이브러리는 토큰을 파일에 영속화하지 않고 메모리에만 둔다.

## 변이 시험

픽스처를 일부러 깨뜨려 통합 테스트가 실제로 실패하는지 확인했다(확인 후 원복).

| 변이 | 기대 | 결과 |
| :--- | :--- | :--- |
| `json.dump(cfg, f)` 마커 제거 | 오탐 회귀 검출 | ✅ `오탐 회귀 — 마커가 없는데 검출됐다: python_credential_at_rest.py:26 finguard.python.credential-file-write` |
| 안전한 `os.chmod(token_tmp, 0o600)` 함수를 추가하고 그 write 줄에 마커 부여 | 미탐 회귀 검출 | ✅ `미탐 회귀 — 마커가 있는데 검출되지 않았다: python_credential_at_rest.py:69 finguard.python.credential-file-write` |
| `@AppStorage("auth_access_token")` 마커 제거 | 오탐 회귀 검출 | ✅ `오탐 회귀 — 마커가 없는데 검출됐다: swift_userdefaults_wrapper.swift:38 finguard.swift.userdefaults-sensitive` |

두 번째 변이는 "chmod 0o600 억제가 실제로 동작한다"는 것까지 같이 증명한다.
원복 후 `기대 91건 · 검출 91건 · 전부 일치`.

## 일부러 넣지 않은 패턴

- **모듈 최상위(함수 밖) 파일 쓰기** — 룰이 `pattern-inside: def $FUNC(...)` 를 요구한다.
  chmod 억제 판정에 함수 스코프가 필요해서 생긴 제약이다. 스크립트 최상위에서 토큰을
  떨구는 형태는 놓치지만, 함수 스코프를 버리면 억제 장치 자체가 성립하지 않는다.
- **`os.chmod` 를 다른 함수(헬퍼)에서 호출하는 형태** — semgrep 은 함수 간 데이터플로우를
  이 룰 형태로 추적하지 않는다. 억제되지 않고 발화하므로 **미탐이 아니라 오탐** 쪽이며,
  메시지에 "이미 chmod 를 하고 있다면 권한값이 0o600/0o400 인지 확인이 필요합니다"를
  넣어 리뷰어가 판정할 수 있게 했다(재현율 렌즈의 '억제 대신 부기' 처방).
- **`UserDefaults.standard.set` 선언부 단독** — 이슈 단서대로 제외했다. 래퍼가 무엇을
  담는지 그 줄만으로는 알 수 없어 오탐 폭탄이 된다.
- **`open()` 을 `with` 없이 변수에 담는 형태(`f = open(p,"w")`)** — 값·핸들 변수명에
  자격증명 어휘가 있으면 잡히지만, 둘 다 중립적 이름이면 놓친다. 경로 어휘 조건이
  `with open($P, ...)` 형태에만 걸려 있기 때문이다.
- **다른 언어(Java/Kotlin/Go/TS)의 동종 패턴** — 파일 소유권 경계상 이번 PR 범위 밖이다.

## 검증 결과

```
semgrep --validate --config rules/   → Configuration is valid, 110 rule(s)  (#33 기준 109 → +1)
룰 110 = 매핑 110, 누락 0 · 고아 0
go build -mod=vendor ./...           → OK
go vet -mod=vendor ./...             → OK
go test -race -mod=vendor ./...      → 전부 ok
go test -race -tags semgrep_integration ./internal/scanner/ -v → 기대 91건 · 검출 91건 · 전부 일치
```

`code` 중복 점검 중 **기존** `FIN-SQLI-004` 가 두 엔트리에 쓰이고 있는 것을 발견했다.
이번 변경과 무관한 선재 결함이라 건드리지 않았다 — 별도 이슈로 정리하는 것이 좋겠다.



---

ــ 운영 메모: 이 PR 은 #56 을 대체한다. #56 은 스택드 base(`feat/issue-33-ats-coverage`)가 #33 머지로 삭제되면서 닫혔고, 같은 커밋을 `main` 기준으로 리베이스해 다시 올린 것이다. 내용 변경 없음.
