### PR TITLE
feat(#34): 공용 crypto 래퍼 경유 취약 알고리즘 검출 확장(Java)

### DIFF
--- a/mapping/rules.yaml
+++ b/mapping/rules.yaml
@@ -1682,3 +1682,23 @@
       level:
         com.example.outer.api.tossPayments: debug
     ```
+
+# ── 공용 crypto 래퍼 경유 취약 알고리즘 — Java (#34) ─────────────────────────
+# basis·kisa_item 은 같은 CWE(327) 기존 엔트리 FIN-CRY-005 값을 문자열 그대로 승계한다.
+# finguard.java.weak-hash 확장분은 기존 FIN-CRY-004 엔트리를 그대로 쓴다(신규 매핑 없음).
+
+- rule_id: finguard.java.weak-cipher-wrapper
+  code: FIN-CRY-015
+  cwe: CWE-327
+  title: 취약한 암호 알고리즘(공용 래퍼 경유·알고리즘 상수, Java)
+  severity: WARNING
+  basis: 개발보안가이드 「보안기능 - 취약한 암호화 알고리즘 사용」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 52 (취약한 HTTPS 암호 알고리즘 이용)"
+  explain: DES·3DES·RC4·Blowfish 알고리즘 이름이 암·복호화 함수의 인자 또는 알고리즘 상수로 지정돼 있습니다. 공용 CryptUtil 등 래퍼를 경유하더라도 내부에서 그 알고리즘이 실제로 사용됩니다. 함수명 어휘와 알고리즘 리터럴로 판정하는 휴리스틱이므로, 해당 상수·인자가 실제 암호 연산에 쓰이는지 확인한 뒤 AES/GCM 등 인증 암호로 교체해야 합니다.
+  fix_example: |
+    ```java
+    // 알고리즘을 상수로 빼더라도 값 자체를 인증 암호로 교체한다.
+    private static final String CIPHER_ALGORITHM = "AES/GCM/NoPadding";
+
+    Cipher cipher = Cipher.getInstance(CIPHER_ALGORITHM);
+    ```

--- a/rules/java.yaml
+++ b/rules/java.yaml
@@ -106,14 +106,44 @@ rules:
       # 마스킹 플레이스홀더는 시크릿이 아니다 — 오히려 가리는 코드다
       - pattern-not-regex: '(?i)["''`](\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|<[^>]*redact[^>]*>|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]|[:=]\s*(\*{3,}|•{3,}|#{3,})(?![\w-])'
 
+  # 취약 해시 (CWE-328).
+  #   - MessageDigest/Mac 직접 호출 외에, 알고리즘명을 문자열로 받는 사내 래퍼
+  #     (CryptUtil.encrypt("MD5", ...) 류)와 DigestUtils.md5* 계열까지 본다 (#34).
+  #     금융권 공용 CryptUtil/SignUtil 은 알고리즘명을 파라미터로 넘기는 구조가 표준에
+  #     가까워, 정의부에는 리터럴이 없고(getInstance(algorithm)) 호출부에는 MessageDigest
+  #     문자열이 없어 종전 패턴은 양쪽 다 보지 못했다.
+  #   - 상수 선언형(static final String HASH_ALGORITHM = "MD5")도 본다. 알고리즘명을 상수로
+  #     빼고 래퍼에 넘기는 형태가 호출부 정규식으로는 잡히지 않는 최빈 미탐이었다.
+  #   - 함수명 휴리스틱을 필수로 둬서 임의 함수의 첫 인자 "MD5" 오탐을 막는다.
+  #   - Kotlin 대응은 finguard.kotlin.weak-hash(#28)가 이미 담당한다.
   - id: finguard.java.weak-hash
     languages: [regex]
     severity: WARNING
-    message: 취약한 해시 알고리즘(MD5/SHA-1)을 사용하고 있습니다.
+    message: 취약한 해시 알고리즘(MD5/SHA-1)을 사용하고 있습니다. SHA-256 이상(서명은 HMAC-SHA256)을 사용해야 합니다. 알고리즘명을 문자열로 받는 공용 래퍼를 경유하는 호출도 포함됩니다.
     paths:
       include: ["*.java"]
       exclude: ["*Test.java"]
-    pattern-regex: 'MessageDigest\.getInstance\(\s*"(MD5|SHA-?1)"'
+    pattern-regex: '(?:MessageDigest|Mac)\.getInstance\(\s*"(?i:MD5|SHA-?1|HmacMD5|HmacSHA-?1)"|\b(?:DigestUtils|Hashing)\.(?:md5|sha1)\w*\s*\(|\b\w*(?i:digest|hash|encrypt|decrypt|sign|hmac|crypt)\w*\s*\(\s*"(?i:MD5|SHA-?1|HmacMD5|HmacSHA-?1)"|\b(?:static\s+final\s+String|final\s+String|String)\s+\w*(?i:alg|algorithm|digest|hash|hmac)\w*\s*=\s*"(?i:MD5|SHA-?1|HmacMD5|HmacSHA-?1)"'
+
+  # 취약 암호 알고리즘 — 공용 래퍼 경유 호출·상수 선언형 (CWE-327) (#34).
+  #
+  # finguard.java.weak-cipher(ERROR)와 분리한 별도 룰이다. 이쪽은 "함수명 어휘 + 알고리즘
+  # 리터럴" 이라는 휴리스틱 매치라, 원 룰과 같은 ERROR 를 매기면 오탐이 기본 게이트
+  # (FINGUARD_BLOCK_ON=ERROR)로 머지를 직접 막는다. WARNING 으로 시작하고 승격은 실코드
+  # 검증 후 별도 판단한다.
+  #
+  # 알려진 한계: 알고리즘명이 호출부에도 상수에도 리터럴로 나타나지 않고 설정/DB 에서
+  # 주입되는 형태는 정적 분석으로 확정할 수 없다. 정의부(getInstance($ALG))에 INFO 룰을
+  # 두는 안은 채택하지 않았다 — 잘 작성된 crypto 래퍼일수록 더 많이 발화하는 구조라
+  # MR 인라인 코멘트의 신호 대 잡음비를 직접 훼손한다.
+  - id: finguard.java.weak-cipher-wrapper
+    languages: [regex]
+    severity: WARNING
+    message: 취약한 암호 알고리즘(DES·3DES·RC4·Blowfish) 이름이 암·복호화 함수의 인자 또는 알고리즘 상수로 지정돼 있습니다. 공용 래퍼를 경유하더라도 실제로 그 알고리즘이 사용됩니다. AES/GCM 등 인증 암호로 교체해야 합니다.
+    paths:
+      include: ["*.java"]
+      exclude: ["*Test.java"]
+    pattern-regex: '\b\w*(?i:encrypt|decrypt|cipher|crypt|seal|unseal)\w*\s*\(\s*"(?i:DES|DESede|TripleDES|RC4|ARCFOUR|Blowfish)[^"]*"|\b(?:static\s+final\s+String|final\s+String|String)\s+\w*(?i:alg|algorithm|cipher|transformation)\w*\s*=\s*"(?i:DES|DESede|TripleDES|RC4|ARCFOUR|Blowfish)[^"]*"'
 
   - id: finguard.java.weak-cipher
     languages: [regex]

--- a/testdata/rule-fixtures/java_weak_crypto.java
+++ b/testdata/rule-fixtures/java_weak_crypto.java
@@ -1,0 +1,65 @@
+// finguard.java.weak-hash · finguard.java.weak-cipher-wrapper (#34) 정탐 픽스처.
+//
+// 금융권 공용 CryptUtil/SignUtil 은 알고리즘명을 문자열 파라미터로 넘기는 구조가 표준에
+// 가깝다. 그러면 정의부에는 리터럴이 없고(getInstance(algorithm)) 호출부에는 MessageDigest
+// 문자열이 없어 종전 정규식이 양쪽 다 보지 못했다.
+// 마커 없는 줄은 오탐 방지 대조군이다.
+package fixtures;
+
+import java.security.MessageDigest;
+import javax.crypto.Mac;
+import org.apache.commons.codec.digest.DigestUtils;
+
+public class SignUtil {
+
+    // 알고리즘명을 상수로 빼고 래퍼에 넘기는 최빈 형태 — 호출부 정규식만으로는 못 본다.
+    // EXPECT: finguard.java.weak-hash
+    private static final String HASH_ALGORITHM = "MD5";
+
+    // EXPECT: finguard.java.weak-cipher-wrapper
+    private static final String CIPHER_ALGORITHM = "DESede/CBC/PKCS5Padding";
+
+    // 공용 래퍼 경유 — 거래소 API 요청 서명 생성 형태.
+    public String sign(String plainText) {
+        // EXPECT: finguard.java.weak-hash
+        return CryptUtil.encrypt("MD5", plainText);
+    }
+
+    public String legacyDigest(String plainText) {
+        // EXPECT: finguard.java.weak-hash
+        return DigestUtils.md5Hex(plainText);
+    }
+
+    // 직접 호출 형태도 계속 검출된다(회귀 방지).
+    public byte[] directDigest(byte[] raw) throws Exception {
+        // EXPECT: finguard.java.weak-hash
+        MessageDigest md = MessageDigest.getInstance("SHA-1");
+        return md.digest(raw);
+    }
+
+    public Mac legacyMac() throws Exception {
+        // EXPECT: finguard.java.weak-hash
+        return Mac.getInstance("HmacMD5");
+    }
+
+    // 래퍼 경유 취약 암호.
+    public String encryptLegacy(String plainText) {
+        // EXPECT: finguard.java.weak-cipher-wrapper
+        return CryptUtil.encrypt("DES/ECB/PKCS5Padding", plainText);
+    }
+
+    // 대조군 — SHA-256 은 대상이 아니다.
+    public String safeSign(String plainText) {
+        return CryptUtil.encrypt("SHA-256", plainText);
+    }
+
+    // 대조군 — 함수명 휴리스틱에 걸리지 않는 임의 함수의 첫 인자.
+    public String lookupCode() {
+        return registry.resolve("MD5");
+    }
+
+    // 대조군 — AES 는 대상이 아니다.
+    public String encryptModern(String plainText) {
+        return CryptUtil.encrypt("AES/GCM/NoPadding", plainText);
+    }
+}

--- a/testdata/rule-fixtures/safe_java_weak_crypto.java
+++ b/testdata/rule-fixtures/safe_java_weak_crypto.java
@@ -1,0 +1,35 @@
+// finguard.java.weak-hash · finguard.java.weak-cipher-wrapper (#34) 대조군 —
+// 어떤 룰에도 걸리면 안 된다.
+package fixtures;
+
+import java.security.MessageDigest;
+import javax.crypto.Mac;
+
+public class SafeSignUtil {
+
+    private static final String HASH_ALGORITHM = "SHA-256";
+    private static final String CIPHER_ALGORITHM = "AES/GCM/NoPadding";
+
+    public byte[] digest(byte[] raw) throws Exception {
+        MessageDigest md = MessageDigest.getInstance(HASH_ALGORITHM);
+        return md.digest(raw);
+    }
+
+    public Mac mac() throws Exception {
+        return Mac.getInstance("HmacSHA256");
+    }
+
+    public String sign(String plainText) {
+        return CryptUtil.encrypt("SHA-256", plainText);
+    }
+
+    // 함수명 휴리스틱에 걸리지 않는 임의 함수의 첫 인자는 알고리즘 지정이 아니다.
+    public String describe() {
+        return registry.resolve("MD5");
+    }
+
+    // 알고리즘명이 아니라 지원 목록 표기다.
+    public String[] supported() {
+        return new String[] {"SHA-256", "SHA-512"};
+    }
+}


### PR DESCRIPTION
Closes #34

> **⚠️ 이 PR 은 #32 PR(#55) 위에 쌓았고, #55 는 다시 #37 PR(#53) 위에 쌓여 있다.** 세 이슈가 모두 `rules/java.yaml` 을 건드려 `#53 → #55 → 이 PR` 순차 스택으로 구성했다. 이 PR 의 base 는 `feat/issue-32-http-full-logging` 이다. **#53 → #55 순으로 머지한 뒤 이 PR 의 base 를 `main` 으로 바꿔 머지해야 한다.**

> **범위 축소 공지 — Kotlin 부분은 #28 에서 선행 처리됨.** 이슈 #34 원안은 `kotlin.weak-hash`/`kotlin.weak-cipher` 와 `java.weak-hash`/`java.weak-cipher` 를 모두 다뤘다. 그러나 Kotlin 쪽은 이슈 #28(PR #48, 머지 완료)에서 이미 구현됐다 — `finguard.kotlin.weak-hash` 가 알고리즘명을 문자열 인자로 받는 래퍼·`Mac.getInstance`·`DigestUtils.md5*` 를 모두 잡고, `reactive-crypto` 의 `CoinealSignUtil.kt`(`CryptUtil.encrypt("MD5", ...)`)에서 실증까지 끝났다(코퍼스 r6 의 기존 검출 1건이 그것이다). **이 PR 은 `rules/java.yaml` 만 다루며 `rules/kotlin.yaml` 은 건드리지 않았다.** 머지된 Kotlin 구현을 읽고 같은 접근을 Java 문법 차이(`val`/`const val` → `static final String`)를 반영해 이식했다.

## 변경 룰

| 룰 ID | 변경 | severity | 매핑 | CWE |
| :--- | :--- | :--- | :--- | :--- |
| `finguard.java.weak-hash` | 확장 | WARNING (유지) | `FIN-CRY-004` (기존) | CWE-328 |
| `finguard.java.weak-cipher-wrapper` | **신설** | WARNING | `FIN-CRY-015` | CWE-327 |
| `finguard.java.weak-cipher` | 변경 없음 | ERROR | `FIN-CRY-005` | CWE-327 |

`finguard.java.weak-hash` 에 추가한 대안은 네 가지다.

1. `Mac.getInstance("HmacMD5" | "HmacSHA1")`
2. `DigestUtils.md5*` / `Hashing.md5*` / `.sha1*` 계열
3. 함수명 휴리스틱 기반 래퍼 호출부 — `\w*(digest|hash|encrypt|decrypt|sign|hmac|crypt)\w*("MD5" …)`
4. 알고리즘 상수 선언형 — `static final String HASH_ALGORITHM = "MD5"`

기존 `MessageDigest.getInstance("MD5"|"SHA-1")` 직접 호출 검출은 그대로 유지되며 픽스처로 회귀를 고정했다.

## ① 반박 반영 내역

**재현율 수호자 — "제안이 커버한다고 주장하는 범위보다 실제 커버리지가 좁다. `const val ALGO = "MD5"` 를 선언해 두고 `CryptUtil.encrypt(ALGO, x)` 로 넘기는 최빈 형태는 호출부 정규식도 정의부 INFO 룰도 확정 판정을 못 한다"**

반영. 검증자가 제시한 **상수 선언형 대안을 추가**했다(Java 문법으로 이식: `(?:static\s+final\s+String|final\s+String|String)\s+\w*(?i:alg|algorithm|digest|hash|hmac)\w*\s*=\s*"(?i:MD5|SHA-?1|…)"`, WARNING). 픽스처에 `private static final String HASH_ALGORITHM = "MD5";` 를 정탐으로 고정했다.

남는 미탐은 **정직하게 명시**한다 — 알고리즘명이 호출부에도 상수에도 리터럴로 나타나지 않고 설정 파일·DB 에서 주입되는 형태는 정적 분석으로 확정할 수 없다. 룰 주석에 "알려진 한계"로 적었다.

**규제 렌즈 — "보조 룰 `crypto-algorithm-parameterized`(INFO)는 반대한다. `getInstance($ALG)` 에서 `$ALG` 가 리터럴이 아닌 형태는 잘 작성된 crypto 래퍼라면 거의 전부 해당하므로 '정상 구현일수록 더 많이 발화' 하는 구조다"**

반영, **폐기**했다. 재현율 수호자는 유지하되 메시지를 '호출부 확인 필요' 로 한정하라고 했고 규제 렌즈는 폐기 또는 미등록 내부 진단 전용을 제시했으나, 2표 기준으로 "MR 인라인 코멘트를 내지 않는다"는 점에서 두 의견이 수렴한다. 이 도구의 출력이 곧 MR 인라인 코멘트이므로 **룰 자체를 만들지 않는 것**이 가장 단순하고 정확한 구현이다. 폐기 사유를 `finguard.java.weak-cipher-wrapper` 주석에 남겨 다음 사람이 같은 제안을 반복하지 않게 했다.

**규제 렌즈 — "호출부 변형의 severity 를 원 룰과 맞추지 말고 한 단계 낮춘다. weak-cipher 호출부 변형은 ERROR 가 아니라 WARNING 으로 시작"**

반영. `finguard.java.weak-cipher`(ERROR)를 건드리지 않고 **별도 룰 `finguard.java.weak-cipher-wrapper`(WARNING)로 분리**했다. 한 룰에 두 severity 를 둘 수 없어 분리가 유일한 구현 경로다. 사유를 룰 주석에 남겼다 — 함수명 어휘 기반 휴리스틱을 ERROR 로 두면 오탐이 기본 게이트(`FINGUARD_BLOCK_ON=ERROR`)로 머지를 직접 막는다.

weak-hash 호출부 변형은 원 룰과 같은 WARNING 이므로(검증자 판단대로) 기존 룰에 그대로 합쳤다 — 노이즈 등급이 올라가지 않는다.

**재현율 수호자 + 규제 렌즈 + 구현가능성 렌즈 — "함수명 휴리스틱을 필수로 둬 임의 함수의 첫 인자 `"MD5"` 오탐을 막는 설계는 적절"**

반영. 알고리즘 리터럴 단독으로는 절대 발화하지 않는다. 대조군 픽스처에 `registry.resolve("MD5")` 를 넣어 고정했다(함수명이 어휘에 걸리지 않으므로 미검출).

**구현가능성 렌즈 — "정규식 컴파일 정상, 백트래킹 위험(중첩 가변 quantifier) 없음"**

확인. `semgrep --validate` 통과, 10개 레포 전수 스캔이 타임아웃 없이 완료됐다.

## ② 실코드 전/후 검출 비교

코퍼스 10개 레포 전수 재스캔. `before` 는 이 PR 직전(#32 반영 상태), `main` 대비 열도 함께 싣는다.

| 레포 | 스택 | main | #32 까지 | 이 PR 후 | 이 PR 의 delta |
| :--- | :--- | ---: | ---: | ---: | ---: |
| r0 한국투자증권 | Python | 42 | 42 | 42 | +0 |
| r1 samchon/payments | TS | 8 | 8 | 8 | +0 |
| r2 CoinNow | Swift | 1 | 1 | 1 | +0 |
| r3 DuDoong-Backend | Kotlin | 11 | 12 | 12 | +0 |
| r4 iamport-python | Python | 0 | 0 | 0 | +0 |
| r5 AXSnapshot | Swift | 0 | 0 | 0 | +0 |
| r6 reactive-crypto | Kotlin | 2 | 2 | 2 | +0 |
| r7 pybithumb | Python | 0 | 0 | 0 | +0 |
| r8 iamport-rest-client-java | Java | 0 | 0 | 0 | +0 |
| r9 upbitBar | Swift | 0 | 0 | 0 | +0 |

**신규 검출 0건. 오탐 0건.**

사유를 사실대로 적는다. **Java 코퍼스에 해당 패턴이 존재하지 않는다.**

- Java 코퍼스는 r8(`iamport-rest-client-java`) 하나뿐이고 `*.java` 81개 규모다.
- 그 레포 전체에 `md5` · `sha-1` · `DESede` · `RC4` · `Blowfish` · `MessageDigest` · `Cipher.getInstance` 문자열이 **한 건도 없다**(대소문자 무시 grep 실측 0건). 해시·암호 연산 자체를 하지 않는 REST 클라이언트다.
- 이슈가 근거로 든 실사례(`reactive-crypto` `CoinealSignUtil.kt:37` → `CryptUtil.encrypt("MD5", …)`)는 **Kotlin** 이고, r6 의 `finguard.kotlin.weak-hash` 1건으로 **이미 잡히고 있다**(#28). before/after 모두에 포함되어 delta 로 나타나지 않는다.

없는 사례를 지어내지 않고 **픽스처로만 검증**했다. 코퍼스 검출이 0건이므로 `finguard.java.weak-cipher-wrapper` 의 ERROR 승격은 하지 않는다(규제 렌즈의 "실코드 검증 후 승격 판단" 조건 미충족).

## ③ 변이 시험

| 변이 | 기대 | 실제 |
| :--- | :--- | :--- |
| 정탐 줄(`static final String CIPHER_ALGORITHM = "DESede/…"`)의 `// EXPECT:` 마커 제거 | 오탐 회귀로 FAIL | `FAIL … 오탐 회귀 — 마커가 없는데 검출됐다: java_weak_crypto.java:19 finguard.java.weak-cipher-wrapper` |
| 검출되지 않는 줄(`CryptUtil.encrypt("AES/GCM/NoPadding", …)`)에 마커 추가 | 미탐 회귀로 FAIL | `FAIL … 미탐 회귀 — 마커가 있는데 검출되지 않았다: java_weak_crypto.java:64 finguard.java.weak-cipher-wrapper` |
| 원복 후 | PASS | `ok github.com/leeyudok/finguard/internal/scanner` |

## ④ 일부러 넣지 않은 패턴과 이유

- **`finguard.java.crypto-algorithm-parameterized`(INFO, 정의부 `getInstance($ALG)`)** — 규제 렌즈 반대. 정상 구현일수록 더 많이 발화하는 구조라 MR 코멘트 신호 대 잡음비를 훼손한다. 위 ① 참조.
- **`rules/kotlin.yaml` 수정** — #28(PR #48)에서 선행 처리 완료. 중복 구현이다.
- **`finguard.java.weak-cipher`(ERROR) 정규식에 래퍼 대안 합치기** — 휴리스틱 매치가 ERROR 게이트로 머지를 막는다. 별도 WARNING 룰로 분리.
- **알고리즘명이 설정·DB 에서 주입되는 형태** — 리터럴이 소스 어디에도 없어 정적 분석으로 확정 불가. 알려진 미탐으로 룰 주석에 명시.
- **`"AES"` 단독 · `"RSA"`** — 취약 알고리즘이 아니다. `"AES/ECB/…"` 같은 운영모드 문제는 기존 `finguard.java.weak-cipher` 담당이라 중복시키지 않았다.
- **`SHA-224`·`SHA-512/224` 등 경계 알고리즘** — 개발보안가이드가 취약으로 규정한 범위(MD5·SHA-1)를 넘어서므로 지어내지 않았다.

## 검증

| 명령 | 결과 |
| :--- | :--- |
| `semgrep --validate --config rules/` | `Configuration is valid - found 0 configuration error(s), and 112 rule(s).` (#32 의 111 → 112) |
| `go build -mod=vendor ./...` | 통과 |
| `go vet -mod=vendor ./...` | 통과 |
| `go test -race -mod=vendor ./...` | 전 패키지 `ok` |
| `go test -race -mod=vendor -tags semgrep_integration ./internal/scanner/` | `ok` |
| 룰 수 = 매핑 수 대조 | 룰 112 / 매핑 112, 매핑 없는 룰 0, 고아 매핑 0 |



---

운영 메모: 이 PR 은 #57 을 대체한다. #57 은 스택드 base 삭제 후 리베이스 과정에서 브랜치가 원격에서 제거돼 닫혔고, 같은 변경(`f138fbb`)을 `main` 기준으로 다시 올린 것이다. 내용 변경 없음.
