### PR TITLE
feat(#36): 시크릿 식별자 어휘를 7개 룰 파일 공통 목록으로 통일

### DIFF
--- a/rules/config.yaml
+++ b/rules/config.yaml
@@ -53,10 +53,15 @@ rules:
         - ".circleci/**"
         - "**/.circleci/**"
     patterns:
+      # 식별자 어휘는 언어 룰과 공통 목록이다 (#36) — ENCRYPTION_KEY·PASSPHRASE·
+      # SIGNING_KEY 계열이 언어에 따라 잡히기도 안 잡히기도 하던 불일치를 없앤다.
+      # 단독 `key` 는 넣지 않는다(맵 키·헤더명 오탐). 단독 `token` 은 이 룰의 기존
+      # 항목이라 유지한다.
+      #
       # 구분자 뒤 공백을 [ \t]* 로 제한한다 — \s* 는 개행을 넘어가 "값이 비어 있는 키"
       # (예: openapi 의 `ApiKeyAuth:`) 가 다음 줄을 값으로 삼는 오탐을 만든다.
       - pattern-either:
-          - pattern-regex: '(?i)^[ \t]*["'']?[\w.-]*(password|passwd|secret|token|api[_-]?key)[\w.-]*["'']?[ \t]*[:=][ \t]*(?![ \t]*$)(?!\$\{)(?!ENC\()["'']?[^\s"''#][^#\n]{3,}'
+          - pattern-regex: '(?i)^[ \t]*["'']?[\w.-]*(password|passwd|pwd|secret|api[_-]?key|token|credential|passphrase|private[_-]?key|signing[_-]?key|encrypt(?:ion)?[_-]?key|master[_-]?key|aes[_-]?key|hmac[_-]?key)[\w.-]*["'']?[ \t]*[:=][ \t]*(?![ \t]*$)(?!\$\{)(?!ENC\()["'']?[^\s"''#][^#\n]{3,}'
           # 고신뢰 프리픽스 — 키 이름과 무관하게 값 자체가 Google API 키다
           - pattern-regex: '\bAIza[0-9A-Za-z_-]{35}\b'
       # 마스킹 플레이스홀더는 시크릿이 아니다 — 오히려 가리는 코드다
@@ -114,7 +119,7 @@ rules:
         - "**/.circleci/**"
     patterns:
       # `- KEY=값` 형태의 script 스텝도 CI 에서 흔한 유출 지점이라 목록 항목 접두를 허용한다.
-      - pattern-regex: '(?i)^[ \t]*(-[ \t]+)?["'']?[\w.-]*(password|passwd|secret|token|api[_-]?key)[\w.-]*["'']?[ \t]*[:=][ \t]*(?![ \t]*$)(?!\$\{)(?!ENC\()["'']?[^\s"''#][^#\n]{3,}'
+      - pattern-regex: '(?i)^[ \t]*(-[ \t]+)?["'']?[\w.-]*(password|passwd|pwd|secret|api[_-]?key|token|credential|passphrase|private[_-]?key|signing[_-]?key|encrypt(?:ion)?[_-]?key|master[_-]?key|aes[_-]?key|hmac[_-]?key)[\w.-]*["'']?[ \t]*[:=][ \t]*(?![ \t]*$)(?!\$\{)(?!ENC\()["'']?[^\s"''#][^#\n]{3,}'
       # 억제 패턴은 줄 전체를 잡아야 필터로 동작한다(위 룰의 주석 참조).
       #
       # 컨테이너 부트스트랩 변수 — services:/image: 로 띄우는 일회성 로컬 자격증명

--- a/rules/go.yaml
+++ b/rules/go.yaml
@@ -67,7 +67,8 @@ rules:
       include: ["*.go"]
       exclude: ["*_test.go"]
     patterns:
-      - pattern-regex: '(?i)\b\w*(password|passwd|secret|apikey|api_key|appsecret)\w*\s*(:?=)\s*"(?!(?-i:[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)")(?!(?-i:[a-z]+(?:_[a-z]+)+)")[^"%/][^"]{7,}"'
+      # 식별자 어휘는 6개 언어 공통 목록이다 (#36). 단독 `key` 는 넣지 않는다.
+      - pattern-regex: '(?i)\b\w*(password|passwd|pwd|secret|api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|credential|passphrase|private[_-]?key|signing[_-]?key|encrypt(?:ion)?[_-]?key|master[_-]?key|aes[_-]?key|hmac[_-]?key)\w*\s*(:?=)\s*"(?!(?-i:[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)")(?!(?-i:[a-z]+(?:_[a-z]+)+)")[^"%/][^"]{7,}"'
       # 마스킹 플레이스홀더는 시크릿이 아니다 — 오히려 가리는 코드다
       - pattern-not-regex: '(?i)["''`](\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|<[^>]*redact[^>]*>|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]|[:=]\s*(\*{3,}|•{3,}|#{3,})(?![\w-])'
 

--- a/rules/java.yaml
+++ b/rules/java.yaml
@@ -115,7 +115,8 @@ rules:
       include: ["*.java"]
       exclude: ["*Test.java"]
     patterns:
-      - pattern-regex: '(?i)String\s+\w*(password|passwd|secret|apikey|api_key|appsecret)\w*\s*=\s*"(?!(?-i:[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)")(?!(?-i:[a-z]+(?:_[a-z]+)+)")[^"]{4,}"'
+      # 식별자 어휘는 6개 언어 공통 목록이다 (#36). 단독 `key` 는 넣지 않는다.
+      - pattern-regex: '(?i)String\s+\w*(password|passwd|pwd|secret|api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|credential|passphrase|private[_-]?key|signing[_-]?key|encrypt(?:ion)?[_-]?key|master[_-]?key|aes[_-]?key|hmac[_-]?key)\w*\s*=\s*"(?!(?-i:[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)")(?!(?-i:[a-z]+(?:_[a-z]+)+)")[^"]{4,}"'
       # 마스킹 플레이스홀더는 시크릿이 아니다 — 오히려 가리는 코드다
       - pattern-not-regex: '(?i)["''`](\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|<[^>]*redact[^>]*>|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]|[:=]\s*(\*{3,}|•{3,}|#{3,})(?![\w-])'
 

--- a/rules/kotlin.yaml
+++ b/rules/kotlin.yaml
@@ -11,7 +11,8 @@ rules:
       include: ["*.kt", "*.kts"]
       exclude: ["*Test.kt", "*Test.kts"]
     patterns:
-      - pattern-regex: '(?im)^\s*(?:private\s+|internal\s+|public\s+|protected\s+)?(?:const\s+)?(?:val|var)\s+\w*(?:password|passwd|secret|apikey|api_key|appsecret|privatekey)\w*\s*(?::\s*[\w<>?.]+)?\s*=\s*"(?!(?-i:[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)")(?!(?-i:[a-z]+(?:_[a-z]+)+)")[^"]{8,}"'
+      # 식별자 어휘는 6개 언어 공통 목록이다 (#36). 단독 `key` 는 넣지 않는다.
+      - pattern-regex: '(?im)^\s*(?:private\s+|internal\s+|public\s+|protected\s+)?(?:const\s+)?(?:val|var)\s+\w*(?:password|passwd|pwd|secret|api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|credential|passphrase|private[_-]?key|signing[_-]?key|encrypt(?:ion)?[_-]?key|master[_-]?key|aes[_-]?key|hmac[_-]?key)\w*\s*(?::\s*[\w<>?.]+)?\s*=\s*"(?!(?-i:[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)")(?!(?-i:[a-z]+(?:_[a-z]+)+)")[^"]{8,}"'
       # 마스킹 플레이스홀더는 시크릿이 아니다 — 오히려 가리는 코드다
       - pattern-not-regex: '(?i)["''`](\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|<[^>]*redact[^>]*>|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]|[:=]\s*(\*{3,}|•{3,}|#{3,})(?![\w-])'
 

--- a/rules/python.yaml
+++ b/rules/python.yaml
@@ -7,7 +7,10 @@ rules:
       include: ["*.py"]
       exclude: ["test_*.py", "*_test.py", "conftest.py"]
     patterns:
-      - pattern-regex: '(?i)\b\w*(password|passwd|secret|apikey|api_key|appsecret)\w*\s*=\s*(?:"(?!(?-i:[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)")(?!(?-i:[a-z]+(?:_[a-z]+)+)")[^"%/{][^"]{7,}"|''(?![A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+'')(?![a-z]+(?:_[a-z]+)+'')[^''%/{][^'']{7,}'')'
+      # 식별자 어휘는 6개 언어 공통 목록이다 (#36). 단독 `key` 는 넣지 않는다 —
+      # map key·헤더명으로 오탐이 폭증한다. app_secret·client_secret 은 `secret` 이,
+      # apikey 는 `api[_-]?key` 가 이미 포섭하므로 중복 항목은 두지 않는다.
+      - pattern-regex: '(?i)\b\w*(password|passwd|pwd|secret|api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|credential|passphrase|private[_-]?key|signing[_-]?key|encrypt(?:ion)?[_-]?key|master[_-]?key|aes[_-]?key|hmac[_-]?key)\w*\s*=\s*(?:"(?!(?-i:[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)")(?!(?-i:[a-z]+(?:_[a-z]+)+)")[^"%/{][^"]{7,}"|''(?![A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+'')(?![a-z]+(?:_[a-z]+)+'')[^''%/{][^'']{7,}'')'
       # 마스킹 플레이스홀더는 시크릿이 아니다 — 오히려 가리는 코드다
       - pattern-not-regex: '(?i)["''`](\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|<[^>]*redact[^>]*>|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]|[:=]\s*(\*{3,}|•{3,}|#{3,})(?![\w-])'
 

--- a/rules/shell.yaml
+++ b/rules/shell.yaml
@@ -6,7 +6,9 @@ rules:
     paths:
       include: ["*.sh", "*.bash", "*.zsh"]
     patterns:
-      - pattern-regex: '(?im)^\s*(?:export\s+)?\w*(password|passwd|secret|apikey|api_key|token)\w*=["'']?(?!\$)(?![A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+["'']?\s*$)(?![a-z]+(?:_[a-z]+)+["'']?\s*$)[^"''\s#$][^"''\s#]{7,}'
+      # 식별자 어휘는 6개 언어 공통 목록이다 (#36). 단독 `key` 는 넣지 않는다.
+      # 단독 `token` 은 이 룰의 기존 항목이라 유지한다.
+      - pattern-regex: '(?im)^\s*(?:export\s+)?\w*(password|passwd|pwd|secret|api[_-]?key|token|credential|passphrase|private[_-]?key|signing[_-]?key|encrypt(?:ion)?[_-]?key|master[_-]?key|aes[_-]?key|hmac[_-]?key)\w*=["'']?(?!\$)(?![A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+["'']?\s*$)(?![a-z]+(?:_[a-z]+)+["'']?\s*$)[^"''\s#$][^"''\s#]{7,}'
       # 마스킹 플레이스홀더는 시크릿이 아니다 — 오히려 가리는 코드다
       - pattern-not-regex: '(?i)["''`](\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|<[^>]*redact[^>]*>|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]|[:=]\s*(\*{3,}|•{3,}|#{3,})(?![\w-])'
 

--- a/rules/swift.yaml
+++ b/rules/swift.yaml
@@ -18,7 +18,10 @@ rules:
       include: ["*.swift"]
       exclude: ["**/build/**", "**/DerivedData/**", "**/*.xcframework/**"]
     patterns:
-      - pattern-regex: '(?i)(let|var)\s+\w*(password|passwd|secret|api_?key|token|credential)\w*\s*=\s*"(?!(?-i:[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)")(?!(?-i:[a-z]+(?:_[a-z]+)+)")[^"]{4,}"'
+      # 식별자 어휘는 6개 언어 공통 목록이다 (#36). 단독 `key` 는 넣지 않는다.
+      # 단독 `token` 은 이 룰에 원래 있던 항목이라 유지한다 — 공통 목록으로 대체하면
+      # Swift 만 기존 커버리지가 축소되는 회귀가 된다.
+      - pattern-regex: '(?i)(let|var)\s+\w*(password|passwd|pwd|secret|api[_-]?key|token|credential|passphrase|private[_-]?key|signing[_-]?key|encrypt(?:ion)?[_-]?key|master[_-]?key|aes[_-]?key|hmac[_-]?key)\w*\s*=\s*"(?!(?-i:[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)")(?!(?-i:[a-z]+(?:_[a-z]+)+)")[^"]{4,}"'
       # 마스킹 플레이스홀더는 시크릿이 아니다 — 오히려 가리는 코드다
       - pattern-not-regex: '(?i)["''`](\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|<[^>]*redact[^>]*>|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]|[:=]\s*(\*{3,}|•{3,}|#{3,})(?![\w-])'
 

--- a/testdata/rule-fixtures/go_secret_vocab.go
+++ b/testdata/rule-fixtures/go_secret_vocab.go
@@ -1,0 +1,18 @@
+// 룰 회귀 픽스처 — finguard.go.hardcoded-secret 공통 어휘 통일 (#36).
+// 값은 전부 합성 더미다. testdata 하위라 go 툴체인이 컴파일 대상으로 삼지 않는다.
+package fixtures
+
+const (
+	// EXPECT: finguard.go.hardcoded-secret
+	tradingAccessToken = "eyJhbGciOiJIUzI1NiJ9.c3ViOjEyMzQ1"
+
+	// EXPECT: finguard.go.hardcoded-secret
+	ledgerEncryptionKey = "8f2b41c7d90e5a63b18c47f2e0d95a31"
+
+	// EXPECT: finguard.go.hardcoded-secret
+	keystorePassphrase = "Vault-Store-2026-Qz73"
+
+	// 단독 `key` 는 공통 어휘에서 제외한다.
+	key     = "Authorization-Bearer-Header"
+	sortKey = "settlement_date_desc"
+)

--- a/testdata/rule-fixtures/java_secret_vocab.java
+++ b/testdata/rule-fixtures/java_secret_vocab.java
@@ -1,0 +1,22 @@
+// 룰 회귀 픽스처 — finguard.java.hardcoded-secret 공통 어휘 통일 (#36).
+// ACCESS_TOKEN·ENCRYPTION_KEY·PASSPHRASE·CREDENTIAL 계열은 확장 전 어휘
+// (password|passwd|secret|apikey|api_key|appsecret)로는 미검출이었다.
+// 값은 전부 합성 더미다.
+public class SecretVocabSample {
+
+    // EXPECT: finguard.java.hardcoded-secret
+    String tradingAccessToken = "eyJhbGciOiJIUzI1NiJ9.c3ViOjEyMzQ1";
+
+    // EXPECT: finguard.java.hardcoded-secret
+    String ledgerEncryptionKey = "8f2b41c7d90e5a63b18c47f2e0d95a31";
+
+    // EXPECT: finguard.java.hardcoded-secret
+    String keystorePassphrase = "Vault-Store-2026-Qz73";
+
+    // EXPECT: finguard.java.hardcoded-secret
+    String settlementSigningKey = "c41d7e93b2a86f05d3e97c18a4b60f2d";
+
+    // 단독 `key` 는 공통 어휘에서 제외한다 — 맵 키·헤더명 오탐이 폭증한다.
+    String key = "Authorization-Bearer-Header";
+    String sortKey = "settlement_date_desc";
+}

--- a/testdata/rule-fixtures/kotlin_secret_vocab.kt
+++ b/testdata/rule-fixtures/kotlin_secret_vocab.kt
@@ -1,0 +1,17 @@
+// 룰 회귀 픽스처 — finguard.kotlin.hardcoded-secret 공통 어휘 통일 (#36).
+// 값은 전부 합성 더미다.
+object SecretVocabSample {
+
+    // EXPECT: finguard.kotlin.hardcoded-secret
+    const val TRADING_ACCESS_TOKEN = "eyJhbGciOiJIUzI1NiJ9.c3ViOjEyMzQ1"
+
+    // EXPECT: finguard.kotlin.hardcoded-secret
+    private val ledgerEncryptionKey = "8f2b41c7d90e5a63b18c47f2e0d95a31"
+
+    // EXPECT: finguard.kotlin.hardcoded-secret
+    val keystorePassphrase: String = "Vault-Store-2026-Qz73"
+
+    // 단독 `key` 는 공통 어휘에서 제외한다.
+    val key = "Authorization-Bearer-Header"
+    val sortKey = "settlement_date_desc"
+}

--- a/testdata/rule-fixtures/python_vulns.py
+++ b/testdata/rule-fixtures/python_vulns.py
@@ -17,6 +17,15 @@ import yaml
 # EXPECT: finguard.python.hardcoded-secret
 PAYMENT_API_KEY = "sk-test-9f8e7d6c5b4a3210"
 
+# 1-1) 공통 어휘 통일(#36) — ACCESS_TOKEN·ENCRYPTION_KEY·PASSPHRASE 계열은
+#      확장 전 어휘(password|passwd|secret|apikey|api_key|appsecret)로는 미검출이었다.
+# EXPECT: finguard.python.hardcoded-secret
+TRADING_ACCESS_TOKEN = "eyJhbGciOiJIUzI1NiJ9.c3ViOjEyMzQ1"
+# EXPECT: finguard.python.hardcoded-secret
+LEDGER_ENCRYPTION_KEY = "8f2b41c7d90e5a63b18c47f2e0d95a31"
+# EXPECT: finguard.python.hardcoded-secret
+KEYSTORE_PASSPHRASE = "Vault-Store-2026-Qz73"
+
 
 # 2) finguard.python.weak-hash — MD5 로 비밀번호 해시를 생성한다.
 def hash_password(password: str) -> str:

--- a/testdata/rule-fixtures/safe_python.py
+++ b/testdata/rule-fixtures/safe_python.py
@@ -19,6 +19,10 @@ import yaml
 PAYMENT_API_KEY = os.getenv("PAYMENT_API_KEY")
 DB_PASSWORD = ""
 SECRET_PLACEHOLDER = "changeme"
+# 단독 `key` 는 공통 어휘에서 제외한다 (#36) — 맵 키·헤더명 오탐이 폭증한다.
+key = "Authorization-Bearer-Header"
+sort_key = "settlement_date_desc"
+cache_key = "user:1234:profile:v2"
 
 
 # 2) finguard.python.weak-hash — 비보안 용도(체크섬)로 명시한 MD5 는 대상이 아니다.

--- a/testdata/rule-fixtures/sample.env
+++ b/testdata/rule-fixtures/sample.env
@@ -7,6 +7,15 @@ DB_HOST=db.example.com
 DB_PASSWORD=Ops-Db-2026-Xk91
 # EXPECT: finguard.config.plaintext-secret
 PG_API_KEY=live_11223344556677889900
+# 공통 어휘 통일(#36) — ENCRYPTION_KEY 계열은 확장 전 어휘로는 미검출이었다.
+# EXPECT: finguard.config.plaintext-secret
+PAY_HISTORY_ENCRYPTION_KEY=8f2b41c7d90e5a63b18c47f2e0d95a31
+# EXPECT: finguard.config.plaintext-secret
+KEYSTORE_PASSPHRASE=Vault-Store-2026-Qz73
+# EXPECT: finguard.config.plaintext-secret
+JWT_SIGNING_KEY=c41d7e93b2a86f05d3e97c18a4b60f2d
+# 단독 `key` 는 공통 어휘에 넣지 않는다 — 맵 키·헤더명 오탐이 폭증한다 (#36).
+IAMPORT_KEY=1234567890123456
 # 시크릿 저장소·환경변수 참조는 값이 아니다 (억제 대상)
 VAULT_TOKEN=${VAULT_TOKEN}
 FEATURE_TOKEN_ROTATION=true

--- a/testdata/rule-fixtures/shell_secret_vocab.sh
+++ b/testdata/rule-fixtures/shell_secret_vocab.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# 룰 회귀 픽스처 — finguard.shell.hardcoded-secret 공통 어휘 통일 (#36).
+# 값은 전부 합성 더미다.
+
+# EXPECT: finguard.shell.hardcoded-secret
+export LEDGER_ENCRYPTION_KEY=8f2b41c7d90e5a63b18c47f2e0d95a31
+# EXPECT: finguard.shell.hardcoded-secret
+export KEYSTORE_PASSPHRASE=Vault-Store-2026-Qz73
+# 단독 `key` 는 공통 어휘에서 제외한다.
+export SORT_KEY=settlement_date_desc

--- a/testdata/rule-fixtures/swift_secret_vocab.swift
+++ b/testdata/rule-fixtures/swift_secret_vocab.swift
@@ -1,0 +1,18 @@
+// 룰 회귀 픽스처 — finguard.swift.hardcoded-secret 공통 어휘 통일 (#36).
+// 기존 단독 `token`·`credential` 은 유지하고 PASSPHRASE·ENCRYPTION_KEY 계열을 더한다.
+// 값은 전부 합성 더미다.
+struct SecretVocabSample {
+
+    // EXPECT: finguard.swift.hardcoded-secret
+    let ledgerEncryptionKey = "8f2b41c7d90e5a63b18c47f2e0d95a31"
+
+    // EXPECT: finguard.swift.hardcoded-secret
+    let keystorePassphrase = "Vault-Store-2026-Qz73"
+
+    // 기존 커버리지(단독 token)가 유지되는지 고정한다.
+    // EXPECT: finguard.swift.hardcoded-secret
+    let sessionToken = "eyJhbGciOiJIUzI1NiJ9.c3ViOjEyMzQ1"
+
+    // 단독 `key` 는 공통 어휘에서 제외한다.
+    let key = "Authorization-Bearer-Header"
+}


### PR DESCRIPTION
Closes #36

## 요약

`hardcoded-secret` / `plaintext-secret` 계열 룰의 **시크릿 식별자 어휘를 공통 목록으로 통일**한다.
확장 전에는 같은 CWE-798 을 겨냥한 룰인데도 언어별 목록이 제각각이라
`ENCRYPTION_KEY`·`PASSPHRASE`·`ACCESS_TOKEN`·`SIGNING_KEY` 가 언어에 따라 잡히기도, 안 잡히기도 했다.

공통 어휘(7개 룰 파일 동일):

```
password|passwd|pwd|secret|api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token
|credential|passphrase|private[_-]?key|signing[_-]?key|encrypt(?:ion)?[_-]?key
|master[_-]?key|aes[_-]?key|hmac[_-]?key
```

수정 대상 룰 ID:

- `finguard.python.hardcoded-secret`
- `finguard.java.hardcoded-secret`
- `finguard.go.hardcoded-secret`
- `finguard.kotlin.hardcoded-secret`
- `finguard.swift.hardcoded-secret`
- `finguard.shell.hardcoded-secret`
- `finguard.config.plaintext-secret`
- `finguard.ci.plaintext-secret`

## 반박·재설계안 반영 내역

| 지적 | 반영 |
| :--- | :--- |
| 단독 `key` 는 절대 넣지 말 것 (맵 키·헤더명 오탐 폭증) | **반영.** 공통 목록에 단독 `key` 없음. `safe_python.py`·`java_secret_vocab.java` 등에 `key`/`sortKey`/`cacheKey` 대조군을 넣어 테스트로 고정했다 |
| 통합 목록에서 단독 `token` 을 빼면 Swift 룰의 기존 커버리지가 **축소**되는 회귀 (semgrep 렌즈) | **반영.** 단독 `token` 은 원래 갖고 있던 룰(swift·shell·config)에서만 유지하고 새 언어로 전파하지 않는다. `swift_secret_vocab.swift` 에 `sessionToken` 픽스처로 기존 커버리지 유지를 고정했다 |
| 확장 어휘 때문에 오탐이 폭증할 우려 (재현율·규제 렌즈) | **실측으로 확인.** 10개 레포 전수 스캔에서 신규 오탐 0건, 손실 0건. 이 결과에 근거해 이슈가 제안한 "신규 `*_key` 어휘 전용 16자 엔트로피 게이트"는 **넣지 않았다** (아래 참조) |
| 중복 어휘 | `app_secret`·`client_secret`·`appsecret` 은 식별자 래퍼가 `\w*(...)\w*` 이므로 `secret` 이 이미 포섭한다. `apikey`/`api_key` 는 `api[_-]?key` 로 통합. 중복 항목은 두지 않는다 |

## 10개 레포 전/후 검출 표

`semgrep 1.169.0` · `--config rules/` · 코퍼스 10개 레포 전체 소스.

| 레포 | 전 | 후 | 델타 |
| :--- | ---: | ---: | ---: |
| r0 한국투자증권(Python) | 54 | 54 | 0 |
| r1 samchon/payments(TS) | 10 | **14** | **+4** |
| r2 CoinNow(Swift) | 1 | 1 | 0 |
| r3 DuDoong-Backend(Kotlin) | 12 | 12 | 0 |
| r4 iamport-python | 0 | 0 | 0 |
| r5 AXSnapshot(Swift) | 0 | 0 | 0 |
| r6 reactive-crypto(Kotlin) | 2 | 2 | 0 |
| r7 pybithumb(Python) | 0 | 0 | 0 |
| r8 iamport-rest-client-java | 0 | 0 | 0 |
| r9 upbitBar(Swift) | 0 | 0 | 0 |
| **합계** | **81** | **85** | **+4** |

### 증가분 분석 (+4, 전수 확인)

전부 r1 `packages/payment-backend/.env` 의 `*_ENCRYPTION_KEY` 4개 항목(18·20·22·24행),
`finguard.config.plaintext-secret`. 커밋된 `.env` 에 32자 대칭키가 평문으로 박혀 있는
**정탐**이다. 확장 전 어휘에 `encrypt(?:ion)?[_-]?key` 가 없어 미탐이던 항목으로,
이슈 #36 이 실증 근거로 든 바로 그 사례다. 같은 파일의 `*_PASSWORD`·`*_SECRET` 은
확장 전에도 잡히고 있었다.

### 감소분 분석 (0건)

사라진 검출 없음. 어휘 확장은 순증 변경이고, 어떤 룰에서도 기존 어휘 항목을 빼지 않았다
(단독 `token` 유지 결정 포함).

### 여전히 잡히지 않는 항목 (의도)

r1 `.env` 의 `PAYMENT_IAMPORT_KEY` 는 식별자가 단독 `key` 로 끝나 검출되지 않는다.
단독 `key` 는 맵 키·헤더명 오탐 때문에 공통 어휘에서 명시적으로 제외한 항목이며,
이슈 본문·검증 3개 렌즈가 모두 동의한 판단이다. 탐지 정책상 제외로 기록한다.

## 변이 시험

`java_secret_vocab.java` 로 양방향 확인:

1. `ledgerEncryptionKey` 줄의 `EXPECT` 마커 제거 → `오탐 회귀 — 마커가 없는데 검출됐다: java_secret_vocab.java:10` **FAIL**
2. 검출되지 않는 `String key = "Authorization-Bearer-Header";` 줄 위에 마커 추가 → `미탐 회귀 — 마커가 있는데 검출되지 않았다: java_secret_vocab.java:20` **FAIL**

원복 후 재실행 → 기대·검출 전부 일치 PASS.

## 일부러 넣지 않은 것

- **`rules/typescript.yaml`** — 작업 시작 시점에 #29(taint source)가 이 파일을 수정 중이라
  충돌을 피해 제외했다(#29 는 그 사이 머지됐고, 이 브랜치는 그 위로 리베이스했다). `finguard.ts.hardcoded-secret` 의 어휘는 여전히
  `password|passwd|secret|apikey|api_key` 5개뿐이므로 **후속 PR 이 필요하다.**
- **이슈 (2) 신규 `*_key` 어휘 전용 엔트로피 게이트(16자)** — 도입 근거는 "오탐 폭증 억제"인데,
  10개 레포 실측에서 확장으로 인한 신규 오탐이 0건이었다. 근거 없는 임계는 정탐만 깎으므로
  넣지 않는다. 실제 오탐이 관측되면 그때 데이터와 함께 도입한다.
- **이슈 (3) TS 구문 앵커 확장(객체 리터럴·`===` 비교식)** — 대상 파일이 `typescript.yaml` 이라
  위와 같은 이유로 제외. 또한 재현율 렌즈가 지적한
  `secretName === "payment-gateway-key"` 류 대량 오탐 문제(kebab-case·경로형 negative 미비)가
  선결이라, negative 보강 설계와 함께 별도로 다뤄야 한다.
- **bare `token` 비교식 전용 룰(고신뢰 벤더 프리픽스 한정)** — 재현율 렌즈가 제안한 분리 룰.
  TS 증거(`FakeTossConfiguration.ts:52`)가 근거라 `typescript.yaml` 소유권 문제로 이번 범위 밖.
- **길이 임계 통일** — java/swift 4자, python/go 8자, kotlin 8자로 제각각이지만 어휘 통일과
  독립적인 축이고, 함께 바꾸면 전/후 비교에서 원인 분리가 불가능해진다.

## 검증

```
semgrep --validate --config rules/        → Configuration is valid, 116 rule(s)
룰 수 116 = mapping/rules.yaml 매핑 수 116 (신규 룰 없음)
go build -mod=vendor ./...                → OK
go vet -mod=vendor ./...                  → OK
go test -race -mod=vendor ./...           → 전부 ok
go test -race -mod=vendor -tags semgrep_integration ./internal/scanner/ -v
                                          → 기대 144건 · 검출 144건 · 전부 일치
```
