### PR TITLE
fix(#23): 플레이스홀더 억제에 한국어 안내문·unquoted 스칼라 보강

### DIFF
--- a/rules/config.yaml
+++ b/rules/config.yaml
@@ -66,6 +66,21 @@ rules:
           - pattern-regex: '\bAIza[0-9A-Za-z_-]{35}\b'
       # 마스킹 플레이스홀더는 시크릿이 아니다 — 오히려 가리는 코드다
       - pattern-not-regex: '(?i)["''`](\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|<[^>]*redact[^>]*>|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]|[:=]\s*(\*{3,}|•{3,}|#{3,})(?![\w-])'
+      # 값 전체가 플레이스홀더인 unquoted 스칼라도 억제한다 (#23).
+      # 따옴표를 optional 로 푸는 대신 값 경계(줄 끝)로 앵커해 "값 전체가 플레이스홀더"라는
+      # 원래 의미를 보존한다 — 무앵커 부분일치로 바꾸면 실키 안의 우연한 xxx·todo 까지 억제된다.
+      - pattern-not-regex: '(?im)^[ \t]*(?:export[ \t]+)?(-[ \t]+)?["'']?[\w.-]+["'']?[ \t]*[:=][ \t]*["''`]?(\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]?[ \t]*[,;)]*[ \t]*(?:#.*|//.*)?$'
+      # 국내 샘플 코드의 표준 관용구인 한국어 안내문은 시크릿이 아니라 입력 지시문이다 (#23).
+      - pattern-not-regex: '(?im)^[^\n]*[:=][ \t]*["''`]?[^"''`\n]*(입력[ \t]*(?:하세요|해[ \t]*주세요|해주세요|바랍니다|하십시오)|여기에?[ \t]*입력|발급[ \t]*받은|본인의|자신의|예시|샘플)[^\n]*$'
+      # 값 전체가 CONSTANT_CASE 인 스칼라는 시크릿이 아니라 상수명·자리표시자다 (#23).
+      # python·java·kotlin·go·ts 룰은 이미 같은 negative 를 pattern-regex 안의 lookahead 로
+      # 갖고 있는데 config 룰에만 없었다 — 정합성 보정이다. 트레일링은 개행을 삼키지 않도록
+      # \s* 가 아니라 [ \t]* 로 둔다.
+      #   한계: `jwt.secret: MY_SUPER_SECRET_KEY_2026` 처럼 가독성 문구를 실제 HMAC 시크릿으로
+      #   쓰는 사각지대가 언어 룰과 동일하게 config 로도 확대된다.
+      #   대소문자 무시 플래그를 켜면 안 된다 — (?i) 아래에서는 [A-Z] 가 소문자까지 먹어
+      #   `secret-key: test_sk_...` 같은 실키를 CONSTANT_CASE 로 오인해 억제한다(실측).
+      - pattern-not-regex: '(?m)^[ \t]*["'']?[\w.-]+["'']?[ \t]*[:=][ \t]*["'']?(?:[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)["'']?[ \t]*(?:#.*)?$'
       # pattern-not-regex 는 검출 범위를 "포함"할 때만 억제된다(semgrep 1.169.0 실측).
       # 값 부분만 매칭하는 정규식은 필터로 동작하지 않으므로 아래 억제 패턴은 줄 전체를 잡는다.
       #
@@ -127,6 +142,12 @@ rules:
       - pattern-not-regex: '(?im)^\s*["'']?(MYSQL_ROOT_PASSWORD|MONGO_INITDB_ROOT_PASSWORD|SA_PASSWORD)["'']?\s*[:=].*$'
       # 마스킹 플레이스홀더
       - pattern-not-regex: '(?i)["''`](\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|<[^>]*redact[^>]*>|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]|[:=]\s*(\*{3,}|•{3,}|#{3,})(?![\w-])'
+      # 값 전체가 플레이스홀더인 unquoted 스칼라도 억제한다 (#23).
+      # 따옴표를 optional 로 푸는 대신 값 경계(줄 끝)로 앵커해 "값 전체가 플레이스홀더"라는
+      # 원래 의미를 보존한다 — 무앵커 부분일치로 바꾸면 실키 안의 우연한 xxx·todo 까지 억제된다.
+      - pattern-not-regex: '(?im)^[ \t]*(?:export[ \t]+)?(-[ \t]+)?["'']?[\w.-]+["'']?[ \t]*[:=][ \t]*["''`]?(\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]?[ \t]*[,;)]*[ \t]*(?:#.*|//.*)?$'
+      # 국내 샘플 코드의 표준 관용구인 한국어 안내문은 시크릿이 아니라 입력 지시문이다 (#23).
+      - pattern-not-regex: '(?im)^[^\n]*[:=][ \t]*["''`]?[^"''`\n]*(입력[ \t]*(?:하세요|해[ \t]*주세요|해주세요|바랍니다|하십시오)|여기에?[ \t]*입력|발급[ \t]*받은|본인의|자신의|예시|샘플)[^\n]*$'
       - pattern-not-regex: '(?im)^\s*["'']?[\w.-]+["'']?\s*[:=]\s*["'']?(true|false|null|none|nil|yes|no|on|off|required|optional|string|integer|boolean|object|array|number)["'']?\s*(#.*)?$'
       # 시크릿 저장소 참조는 시크릿이 아니라 올바른 사용법이다
       - pattern-not-regex: '(?im)^\s*["'']?[\w.-]+["'']?\s*[:=]\s*["'']?(\$|\{\{|<%|%\(|env:|secretKeyRef|valueFrom|vault:|aws:|arn:).*$'

--- a/rules/go.yaml
+++ b/rules/go.yaml
@@ -71,6 +71,12 @@ rules:
       - pattern-regex: '(?i)\b\w*(password|passwd|pwd|secret|api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|credential|passphrase|private[_-]?key|signing[_-]?key|encrypt(?:ion)?[_-]?key|master[_-]?key|aes[_-]?key|hmac[_-]?key)\w*\s*(:?=)\s*"(?!(?-i:[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)")(?!(?-i:[a-z]+(?:_[a-z]+)+)")[^"%/][^"]{7,}"'
       # 마스킹 플레이스홀더는 시크릿이 아니다 — 오히려 가리는 코드다
       - pattern-not-regex: '(?i)["''`](\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|<[^>]*redact[^>]*>|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]|[:=]\s*(\*{3,}|•{3,}|#{3,})(?![\w-])'
+      # 값 전체가 플레이스홀더인 unquoted 스칼라도 억제한다 (#23).
+      # 따옴표를 optional 로 푸는 대신 값 경계(줄 끝)로 앵커해 "값 전체가 플레이스홀더"라는
+      # 원래 의미를 보존한다 — 무앵커 부분일치로 바꾸면 실키 안의 우연한 xxx·todo 까지 억제된다.
+      - pattern-not-regex: '(?im)^[ \t]*(?:export[ \t]+)?(-[ \t]+)?["'']?[\w.-]+["'']?[ \t]*[:=][ \t]*["''`]?(\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]?[ \t]*[,;)]*[ \t]*(?:#.*|//.*)?$'
+      # 국내 샘플 코드의 표준 관용구인 한국어 안내문은 시크릿이 아니라 입력 지시문이다 (#23).
+      - pattern-not-regex: '(?im)^[^\n]*[:=][ \t]*["''`]?[^"''`\n]*(입력[ \t]*(?:하세요|해[ \t]*주세요|해주세요|바랍니다|하십시오)|여기에?[ \t]*입력|발급[ \t]*받은|본인의|자신의|예시|샘플)[^\n]*$'
 
   - id: finguard.go.weak-crypto
     languages: [regex]

--- a/rules/java.yaml
+++ b/rules/java.yaml
@@ -119,6 +119,12 @@ rules:
       - pattern-regex: '(?i)String\s+\w*(password|passwd|pwd|secret|api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|credential|passphrase|private[_-]?key|signing[_-]?key|encrypt(?:ion)?[_-]?key|master[_-]?key|aes[_-]?key|hmac[_-]?key)\w*\s*=\s*"(?!(?-i:[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)")(?!(?-i:[a-z]+(?:_[a-z]+)+)")[^"]{4,}"'
       # 마스킹 플레이스홀더는 시크릿이 아니다 — 오히려 가리는 코드다
       - pattern-not-regex: '(?i)["''`](\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|<[^>]*redact[^>]*>|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]|[:=]\s*(\*{3,}|•{3,}|#{3,})(?![\w-])'
+      # 값 전체가 플레이스홀더인 unquoted 스칼라도 억제한다 (#23).
+      # 따옴표를 optional 로 푸는 대신 값 경계(줄 끝)로 앵커해 "값 전체가 플레이스홀더"라는
+      # 원래 의미를 보존한다 — 무앵커 부분일치로 바꾸면 실키 안의 우연한 xxx·todo 까지 억제된다.
+      - pattern-not-regex: '(?im)^[ \t]*(?:export[ \t]+)?(-[ \t]+)?["'']?[\w.-]+["'']?[ \t]*[:=][ \t]*["''`]?(\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]?[ \t]*[,;)]*[ \t]*(?:#.*|//.*)?$'
+      # 국내 샘플 코드의 표준 관용구인 한국어 안내문은 시크릿이 아니라 입력 지시문이다 (#23).
+      - pattern-not-regex: '(?im)^[^\n]*[:=][ \t]*["''`]?[^"''`\n]*(입력[ \t]*(?:하세요|해[ \t]*주세요|해주세요|바랍니다|하십시오)|여기에?[ \t]*입력|발급[ \t]*받은|본인의|자신의|예시|샘플)[^\n]*$'
 
   # 취약 해시 (CWE-328).
   #   - MessageDigest/Mac 직접 호출 외에, 알고리즘명을 문자열로 받는 사내 래퍼

--- a/rules/kotlin.yaml
+++ b/rules/kotlin.yaml
@@ -15,6 +15,12 @@ rules:
       - pattern-regex: '(?im)^\s*(?:private\s+|internal\s+|public\s+|protected\s+)?(?:const\s+)?(?:val|var)\s+\w*(?:password|passwd|pwd|secret|api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|credential|passphrase|private[_-]?key|signing[_-]?key|encrypt(?:ion)?[_-]?key|master[_-]?key|aes[_-]?key|hmac[_-]?key)\w*\s*(?::\s*[\w<>?.]+)?\s*=\s*"(?!(?-i:[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)")(?!(?-i:[a-z]+(?:_[a-z]+)+)")[^"]{8,}"'
       # 마스킹 플레이스홀더는 시크릿이 아니다 — 오히려 가리는 코드다
       - pattern-not-regex: '(?i)["''`](\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|<[^>]*redact[^>]*>|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]|[:=]\s*(\*{3,}|•{3,}|#{3,})(?![\w-])'
+      # 값 전체가 플레이스홀더인 unquoted 스칼라도 억제한다 (#23).
+      # 따옴표를 optional 로 푸는 대신 값 경계(줄 끝)로 앵커해 "값 전체가 플레이스홀더"라는
+      # 원래 의미를 보존한다 — 무앵커 부분일치로 바꾸면 실키 안의 우연한 xxx·todo 까지 억제된다.
+      - pattern-not-regex: '(?im)^[ \t]*(?:export[ \t]+)?(-[ \t]+)?["'']?[\w.-]+["'']?[ \t]*[:=][ \t]*["''`]?(\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]?[ \t]*[,;)]*[ \t]*(?:#.*|//.*)?$'
+      # 국내 샘플 코드의 표준 관용구인 한국어 안내문은 시크릿이 아니라 입력 지시문이다 (#23).
+      - pattern-not-regex: '(?im)^[^\n]*[:=][ \t]*["''`]?[^"''`\n]*(입력[ \t]*(?:하세요|해[ \t]*주세요|해주세요|바랍니다|하십시오)|여기에?[ \t]*입력|발급[ \t]*받은|본인의|자신의|예시|샘플)[^\n]*$'
 
   # 2. 취약 해시 (CWE-328)
   #   - MessageDigest/Mac 직접 호출 외에, 알고리즘명을 문자열로 받는 사내 래퍼

--- a/rules/python.yaml
+++ b/rules/python.yaml
@@ -13,6 +13,12 @@ rules:
       - pattern-regex: '(?i)\b\w*(password|passwd|pwd|secret|api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|credential|passphrase|private[_-]?key|signing[_-]?key|encrypt(?:ion)?[_-]?key|master[_-]?key|aes[_-]?key|hmac[_-]?key)\w*\s*=\s*(?:"(?!(?-i:[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)")(?!(?-i:[a-z]+(?:_[a-z]+)+)")[^"%/{][^"]{7,}"|''(?![A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+'')(?![a-z]+(?:_[a-z]+)+'')[^''%/{][^'']{7,}'')'
       # 마스킹 플레이스홀더는 시크릿이 아니다 — 오히려 가리는 코드다
       - pattern-not-regex: '(?i)["''`](\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|<[^>]*redact[^>]*>|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]|[:=]\s*(\*{3,}|•{3,}|#{3,})(?![\w-])'
+      # 값 전체가 플레이스홀더인 unquoted 스칼라도 억제한다 (#23).
+      # 따옴표를 optional 로 푸는 대신 값 경계(줄 끝)로 앵커해 "값 전체가 플레이스홀더"라는
+      # 원래 의미를 보존한다 — 무앵커 부분일치로 바꾸면 실키 안의 우연한 xxx·todo 까지 억제된다.
+      - pattern-not-regex: '(?im)^[ \t]*(?:export[ \t]+)?(-[ \t]+)?["'']?[\w.-]+["'']?[ \t]*[:=][ \t]*["''`]?(\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]?[ \t]*[,;)]*[ \t]*(?:#.*|//.*)?$'
+      # 국내 샘플 코드의 표준 관용구인 한국어 안내문은 시크릿이 아니라 입력 지시문이다 (#23).
+      - pattern-not-regex: '(?im)^[^\n]*[:=][ \t]*["''`]?[^"''`\n]*(입력[ \t]*(?:하세요|해[ \t]*주세요|해주세요|바랍니다|하십시오)|여기에?[ \t]*입력|발급[ \t]*받은|본인의|자신의|예시|샘플)[^\n]*$'
 
   - id: finguard.python.weak-hash
     languages: [python]

--- a/rules/shell.yaml
+++ b/rules/shell.yaml
@@ -11,6 +11,12 @@ rules:
       - pattern-regex: '(?im)^\s*(?:export\s+)?\w*(password|passwd|pwd|secret|api[_-]?key|token|credential|passphrase|private[_-]?key|signing[_-]?key|encrypt(?:ion)?[_-]?key|master[_-]?key|aes[_-]?key|hmac[_-]?key)\w*=["'']?(?!\$)(?![A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+["'']?\s*$)(?![a-z]+(?:_[a-z]+)+["'']?\s*$)[^"''\s#$][^"''\s#]{7,}'
       # 마스킹 플레이스홀더는 시크릿이 아니다 — 오히려 가리는 코드다
       - pattern-not-regex: '(?i)["''`](\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|<[^>]*redact[^>]*>|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]|[:=]\s*(\*{3,}|•{3,}|#{3,})(?![\w-])'
+      # 값 전체가 플레이스홀더인 unquoted 스칼라도 억제한다 (#23).
+      # 따옴표를 optional 로 푸는 대신 값 경계(줄 끝)로 앵커해 "값 전체가 플레이스홀더"라는
+      # 원래 의미를 보존한다 — 무앵커 부분일치로 바꾸면 실키 안의 우연한 xxx·todo 까지 억제된다.
+      - pattern-not-regex: '(?im)^[ \t]*(?:export[ \t]+)?(-[ \t]+)?["'']?[\w.-]+["'']?[ \t]*[:=][ \t]*["''`]?(\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]?[ \t]*[,;)]*[ \t]*(?:#.*|//.*)?$'
+      # 국내 샘플 코드의 표준 관용구인 한국어 안내문은 시크릿이 아니라 입력 지시문이다 (#23).
+      - pattern-not-regex: '(?im)^[^\n]*[:=][ \t]*["''`]?[^"''`\n]*(입력[ \t]*(?:하세요|해[ \t]*주세요|해주세요|바랍니다|하십시오)|여기에?[ \t]*입력|발급[ \t]*받은|본인의|자신의|예시|샘플)[^\n]*$'
 
   - id: finguard.shell.curl-insecure
     languages: [regex]

--- a/rules/swift.yaml
+++ b/rules/swift.yaml
@@ -24,6 +24,12 @@ rules:
       - pattern-regex: '(?i)(let|var)\s+\w*(password|passwd|pwd|secret|api[_-]?key|token|credential|passphrase|private[_-]?key|signing[_-]?key|encrypt(?:ion)?[_-]?key|master[_-]?key|aes[_-]?key|hmac[_-]?key)\w*\s*=\s*"(?!(?-i:[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)")(?!(?-i:[a-z]+(?:_[a-z]+)+)")[^"]{4,}"'
       # 마스킹 플레이스홀더는 시크릿이 아니다 — 오히려 가리는 코드다
       - pattern-not-regex: '(?i)["''`](\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|<[^>]*redact[^>]*>|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]|[:=]\s*(\*{3,}|•{3,}|#{3,})(?![\w-])'
+      # 값 전체가 플레이스홀더인 unquoted 스칼라도 억제한다 (#23).
+      # 따옴표를 optional 로 푸는 대신 값 경계(줄 끝)로 앵커해 "값 전체가 플레이스홀더"라는
+      # 원래 의미를 보존한다 — 무앵커 부분일치로 바꾸면 실키 안의 우연한 xxx·todo 까지 억제된다.
+      - pattern-not-regex: '(?im)^[ \t]*(?:export[ \t]+)?(-[ \t]+)?["'']?[\w.-]+["'']?[ \t]*[:=][ \t]*["''`]?(\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]?[ \t]*[,;)]*[ \t]*(?:#.*|//.*)?$'
+      # 국내 샘플 코드의 표준 관용구인 한국어 안내문은 시크릿이 아니라 입력 지시문이다 (#23).
+      - pattern-not-regex: '(?im)^[^\n]*[:=][ \t]*["''`]?[^"''`\n]*(입력[ \t]*(?:하세요|해[ \t]*주세요|해주세요|바랍니다|하십시오)|여기에?[ \t]*입력|발급[ \t]*받은|본인의|자신의|예시|샘플)[^\n]*$'
 
   - id: finguard.swift.http-url
     languages: [regex]

--- a/testdata/rule-fixtures/config_secrets.yml
+++ b/testdata/rule-fixtures/config_secrets.yml
@@ -13,6 +13,24 @@ payments:
   # EXPECT: finguard.config.plaintext-secret
   client_secret: 0d1f2a3b4c5d6e7f8091a2b3
 
+# 재현율 고정 (#23) — "값에 한글이 있고 ASCII 8연속 토큰이 없으면 억제" 안(원안 (b))은
+# 폐기했다. 한글+숫자+특수문자 조합은 국내 실비밀번호의 최빈형이므로 계속 발화해야 한다.
+korean_real_credentials:
+  # EXPECT: finguard.config.plaintext-secret
+  db.password: 금융보안1234!
+  # EXPECT: finguard.config.plaintext-secret
+  sms.api_key: 인증키abc123
+  # EXPECT: finguard.config.plaintext-secret
+  mail.password: 한국은행2026!
+
+# 값 전체가 플레이스홀더일 때만 억제한다 — 실키 안에 우연히 todo/xxx 가 들어가도
+# 억제되면 안 된다(따옴표 optional 화를 폐기하고 값 경계 앵커를 쓴 이유).
+partial_marker:
+  # EXPECT: finguard.config.plaintext-secret
+  api_key: "sk_live_todo9f8e7d6c5b4a3210"
+  # EXPECT: finguard.config.plaintext-secret
+  client_secret: "b3xxx7d6c5b4a32100011f2e"
+
 google:
   # 키 이름과 무관하게 값 자체가 Google API 키인 경우 (고신뢰 프리픽스)
   # EXPECT: finguard.config.plaintext-secret

--- a/testdata/rule-fixtures/python_vulns.py
+++ b/testdata/rule-fixtures/python_vulns.py
@@ -26,6 +26,14 @@ LEDGER_ENCRYPTION_KEY = "8f2b41c7d90e5a63b18c47f2e0d95a31"
 # EXPECT: finguard.python.hardcoded-secret
 KEYSTORE_PASSPHRASE = "Vault-Store-2026-Qz73"
 
+# 1-2) 재현율 고정 (#23) — 한글 혼합 실비밀번호는 계속 발화해야 한다.
+#      "값에 한글 + ASCII 8연속 없으면 억제"(원안 (b))는 국내 실비밀번호 최빈형을
+#      통째로 죽이므로 폐기했고, 그 결정을 아래 픽스처로 고정한다.
+# EXPECT: finguard.python.hardcoded-secret
+DB_PASSWORD = "금융보안1234!"
+# EXPECT: finguard.python.hardcoded-secret
+MAIL_PASSWORD = "한국은행2026!"
+
 
 # 2) finguard.python.weak-hash — MD5 로 비밀번호 해시를 생성한다.
 def hash_password(password: str) -> str:

--- a/testdata/rule-fixtures/safe_config.yml
+++ b/testdata/rule-fixtures/safe_config.yml
@@ -30,3 +30,17 @@ masked:
   password: "********"
   api_key: "your-api-key"
   client_secret: "CHANGE_ME"
+
+placeholder_unquoted:
+  # 따옴표 없는 스칼라 플레이스홀더 — 값 경계 앵커로 억제한다 (#23)
+  password: placeholder
+  api_key: your-api-key
+  client-secret: DUMMY_LOCAL_SECRET
+  signing_key: TODO
+
+korean_guidance:
+  # 국내 샘플 코드의 표준 관용구 — 입력 지시문이지 시크릿이 아니다 (#23)
+  app_secret: 앱 시크릿키를 입력하세요
+  api_key: 여기에 발급받은 키를 입력해 주세요
+  password: 본인의 비밀번호를 입력하세요
+  access_token: 예시 값입니다

--- a/testdata/rule-fixtures/safe_python.py
+++ b/testdata/rule-fixtures/safe_python.py
@@ -23,6 +23,10 @@ SECRET_PLACEHOLDER = "changeme"
 key = "Authorization-Bearer-Header"
 sort_key = "settlement_date_desc"
 cache_key = "user:1234:profile:v2"
+# 국내 샘플 코드의 표준 관용구인 한국어 안내문은 입력 지시문이지 시크릿이 아니다 (#23).
+g_appsecret = '앱 시크릿키를 입력하세요'
+g_api_key = '발급받은 키를 여기에 입력하세요'
+DEFAULT_PASSWORD = "본인의 비밀번호를 입력해 주세요"
 
 
 # 2) finguard.python.weak-hash — 비보안 용도(체크섬)로 명시한 MD5 는 대상이 아니다.


### PR DESCRIPTION
Closes #23

> **스택된 PR입니다.** #62 (`feat/issue-36-secret-vocabulary`, 이슈 #36) 위에 쌓았습니다.
> 같은 룰 계열의 같은 정규식을 건드리므로 **#62 를 먼저 머지**해야 diff 가 이 PR 의 변경분만 남습니다.

## 요약

7개 룰 파일에 문자 그대로 복붙돼 있던 **동일 플레이스홀더 억제 정규식**의 결함 두 개를 메운다.

1. 마커가 영문 전용(`change_me`/`placeholder`/`dummy`/`your_*`)이라 국내 금융 샘플 코드의
   표준 관용구인 **한국어 안내문**을 못 본다 → 코퍼스 오탐 11건의 단일 원인
2. 마커가 `["'`]...["'`]` 로 따옴표에 갇혀 있어 Spring Boot YAML 의 **unquoted 스칼라**를 못 본다.
   게다가 `config` 룰에는 다른 언어 룰이 모두 갖고 있는 CONSTANT_CASE negative 조차 없다

추가한 `pattern-not-regex` (config 룰은 3줄, 나머지 6개 룰은 2줄):

| | 내용 | 적용 |
| :--- | :--- | :--- |
| (a) | 한국어 안내문 억제 — `입력하세요`/`여기에 입력`/`발급받은`/`본인의`/`예시`/`샘플` | 7개 파일 |
| (b') | **값 전체가** 플레이스홀더인 unquoted 스칼라 억제 (값 경계 앵커) | 7개 파일 |
| (c) | **값 전체가** CONSTANT_CASE 인 스칼라 억제 | `config` 룰 전용 |

대상 룰 ID: `finguard.{python,java,go,kotlin,swift,shell}.hardcoded-secret`,
`finguard.config.plaintext-secret`, `finguard.ci.plaintext-secret`

## 반박·재설계 확정안 반영 내역

이슈 코멘트의 재설계 확정안을 그대로 따랐다.

| 원안 | 확정 판정 | 이 PR |
| :--- | :--- | :--- |
| (a) 한국어 안내문 억제 | 채택 | **구현** |
| (b) 값에 한글 + ASCII 8연속 없으면 억제 | **폐기** | **미구현.** `db.password: 금융보안1234!` 같은 국내 실비밀번호 최빈형을 통째로 죽인다. 폐기 결정을 **정탐 픽스처로 고정**했다 (아래) |
| (c) config 에 CONSTANT_CASE lookahead | 채택 | **구현** (config 룰 전용) |
| (d) 반복 필러 억제 | **보류** | **미구현.** 보상통제(`weak-credential` 룰)가 없어 평가기준 24 대상이 점검 누락으로 남는다 → **#63 으로 분리** |
| 따옴표 optional 화 | **폐기** | **미구현.** "값 전체가 플레이스홀더" 가 "값에 플레이스홀더가 포함" 으로 의미가 바뀐다. 대신 **값 경계(줄 끝) 앵커**로 원래 의미를 보존했고, 실키 안에 우연히 `todo`·`xxx` 가 들어간 케이스가 계속 발화하는지 픽스처로 고정했다 |
| `\s*` 개행 삼킴 = "치명적 버그" | **재현 안 됨** | 트레일링을 `[ \t]*` 로 쓰되 **버그 수정이 아니라 정밀도 위생**으로 채택. 개행을 넘지 않는 문자 클래스가 의도에 더 정확하다는 근거만 사용했다 |

### 재현율 픽스처 (재현율 렌즈 요구사항)

오탐 방지 픽스처만 넣으면 억제가 과했는지 알 수 없다. **한글 혼합 실비밀번호가 여전히
발화하는 정탐 픽스처**를 함께 넣어 (b) 폐기 결정을 테스트로 고정했다.

- `config_secrets.yml` — `db.password: 금융보안1234!`, `sms.api_key: 인증키abc123`,
  `mail.password: 한국은행2026!` 3건 모두 `EXPECT` 마커 부착
- `python_vulns.py` — `DB_PASSWORD = "금융보안1234!"`, `MAIL_PASSWORD = "한국은행2026!"`
- `config_secrets.yml` — 값 안에 `todo`/`xxx` 가 섞인 실키 2건도 `EXPECT` 부착
  (따옴표 optional 화 폐기 결정 고정)

## 구현 중 실측으로 잡은 함정

(c) 를 `(?im)` 로 쓰면 **대소문자 무시 플래그 아래에서 `[A-Z]` 가 소문자까지 먹는다.**
그 결과 DuDoong 의 `secret-key: test_sk_…` 같은 **실키가 CONSTANT_CASE 로 오인돼 억제**됐다
(1차 스캔에서 정탐 2건 소실로 관측). 언어 룰들이 `(?-i:[A-Z]…)` 로 감싸 둔 것과 같은 이유다.
`(?m)` 으로 고정하고 주석에 근거를 남겼다.

## 10개 레포 전/후 검출 표

기준선은 **#62 적용 상태**(= 이 PR 의 부모)다.

| 레포 | 전(#62) | 후(#23) | 델타 |
| :--- | ---: | ---: | ---: |
| r0 한국투자증권(Python) | 54 | **45** | **-9** |
| r1 samchon/payments(TS) | 14 | 14 | 0 |
| r2 CoinNow(Swift) | 1 | 1 | 0 |
| r3 DuDoong-Backend(Kotlin) | 12 | **11** | **-1** |
| r4 iamport-python | 0 | 0 | 0 |
| r5 AXSnapshot(Swift) | 0 | 0 | 0 |
| r6 reactive-crypto(Kotlin) | 2 | 2 | 0 |
| r7 pybithumb(Python) | 0 | 0 | 0 |
| r8 iamport-rest-client-java | 0 | 0 | 0 |
| r9 upbitBar(Swift) | 0 | 0 | 0 |
| **합계** | **85** | **75** | **-10** |

### 감소분 분석 (-10, 전수 확인)

| 건수 | 위치 | 판정 |
| ---: | :--- | :--- |
| 9 | r0 `legacy/websocket/python/*.py` (`ws_domestic_stock.py:142` 외 8건), `finguard.python.hardcoded-secret` | **오탐.** 값이 전부 `앱 시크릿키를 입력하세요` 형태의 한국어 입력 안내문. 캠페인 트리아지에서 오탐 판정된 r0 의 그 항목들이다 |
| 1 | r3 `DuDoong-Common/.../application-common-local.yml:11`, `finguard.config.plaintext-secret` | **오탐.** 값이 `DUMMY_LOCAL_` 접두 CONSTANT_CASE unquoted 스칼라. 같은 키의 운영 설정(`application-common.yml`)은 `${...}` 치환이라 로컬 더미임이 확증된다 |

캠페인 트리아지 기준 r0 의 11건 중 **9건**, r3 의 5건 중 **1건**이 이 PR 로 해소된다.
r0 의 나머지 2건과 r3 의 나머지 4건은 성격이 달라 이 PR 범위가 아니다
(r3 는 로컬 프로파일 파일 정책 문제 → #25 소관, 반복 필러 1건 → #63 소관).

### 증가분 분석 (0건)

새로 터진 검출 없음. 이 PR 은 `pattern-not-regex` 만 추가하므로 구조적으로 순감소다.

### 정탐 손실 없음 (역방향 확인)

- r3 `application-common-local.yml:17` **`toss.secret-key: test_sk_…`** — 이슈가 "회전 권고
  대상이므로 의도적으로 유지" 라고 명시한 항목. **계속 검출된다** (1차 시도에서 이게 사라진 것을
  보고 위 `(?im)` 함정을 발견했다)
- r1 `.env:30` 의 `*_SECRET` 항목도 그대로 유지
- 픽스처 기대값 144건 → 151건, 손실 0

## 변이 시험

`config_secrets.yml` 로 양방향 확인:

1. `db.password: 금융보안1234!` 의 `EXPECT` 마커 제거
   → `오탐 회귀 — 마커가 없는데 검출됐다: config_secrets.yml:19` **FAIL**
2. 억제되는 `app_secret: 앱 시크릿키를 입력하세요` 줄 위에 마커 추가
   → `미탐 회귀 — 마커가 있는데 검출되지 않았다: config_secrets.yml:40` **FAIL**

원복 후 재실행 → 기대·검출 전부 일치 PASS.

## 일부러 넣지 않은 것

- **원안 (b)** — 위 표 참조. 폐기 확정안 그대로.
- **원안 (d) 반복 필러 억제** — 보상통제 없이는 평가기준 24(유추 가능한 인증정보 이용 방지)
  점검 누락이 된다. **#63** 으로 분리했다(`weak-credential` 룰 신설 → 그 뒤 (d) 적용).
  그 결과 DuDoong `application-common-local.yml:3` 의 반복 필러 오탐 1건은 이 PR 이후에도 남는다.
- **따옴표 optional 화** — 위 표 참조.
- **`rules/typescript.yaml`** — 작업 시작 시점에 #29(taint source)가 이 파일을 수정 중이라 제외했다
  (#29 는 그 사이 머지됐고, 이 브랜치는 그 위로 리베이스했다).
  `finguard.ts.hardcoded-secret` 의 억제 정규식은 **여전히 구식**이며 **후속 PR 이 필요하다.**
- **`\s*` → `[ \t]*` 를 기존 억제 패턴 전체에 일괄 적용** — 신규 추가분에만 적용했다.
  재현 시험에서 기능 결함이 확인되지 않았으므로 기존 패턴을 함께 건드리면 전/후 비교에서
  원인 분리가 불가능해진다.

## 검증

```
semgrep --validate --config rules/        → Configuration is valid, 116 rule(s)
룰 수 116 = mapping/rules.yaml 매핑 수 116 (신규 룰 없음)
go build -mod=vendor ./...                → OK
go vet -mod=vendor ./...                  → OK
go test -race -mod=vendor ./...           → 전부 ok
go test -race -mod=vendor -tags semgrep_integration ./internal/scanner/
                                          → 기대 151건 · 검출 151건 · 전부 일치
```
