### PR TITLE
fix(#29): NestJS·Spring 컨트롤러 파라미터를 taint source 로 인식하도록 확장

### DIFF
--- a/mapping/rules.yaml
+++ b/mapping/rules.yaml
@@ -1702,3 +1702,23 @@
 
     Cipher cipher = Cipher.getInstance(CIPHER_ALGORITHM);
     ```
+
+# 2차(stored) SSRF (#29). basis·kisa_item 은 같은 CWE(918) 기존 엔트리 FIN-SSRF-003 값을
+# 문자열 그대로 승계한다.
+
+- rule_id: finguard.ts.stored-ssrf
+  code: FIN-SSRF-005
+  cwe: CWE-918
+  title: 서버측 요청 위조(저장된 콜백/웹훅 URL, TS/JS)
+  severity: WARNING
+  basis: 개발보안가이드 「입력데이터 검증 및 표현 - 서버사이드 요청 위조」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 61 (서버 사이드 요청 위조 (SSRF))"
+  explain: 콜백/웹훅 URL 필드가 서버 측 HTTP 요청 대상으로 사용되고 있습니다. 이 값이 가맹점·이용자가 등록한 값이라면 저장 후 호출되는 시점에는 오염 추적이 끊기므로, 등록 시점에 호스트 허용 목록과 사설 IP 대역 차단을 적용했는지 확인해야 합니다.
+  fix_example: |
+    ```ts
+    // 등록 시점에 검증하고, 검증된 값만 저장한다.
+    const u = new URL(input.webhook_url);
+    if (u.protocol !== "https:") throw new Error("https only");
+    if (!ALLOW_HOSTS.includes(u.hostname)) throw new Error("blocked host");
+    await prisma.payment_histories.update({ data: { webhook_url: u.href }, where });
+    ```

--- a/rules/java.yaml
+++ b/rules/java.yaml
@@ -9,11 +9,24 @@ rules:
       exclude: ["*Test.java"]
     mode: taint
     pattern-sources:
+      # (a) Servlet 원시 API
       - pattern: $R.getParameter(...)
       - pattern: $R.getParameterValues(...)
       - pattern: $R.getHeader(...)
       - pattern: $R.getQueryString()
       - pattern: $R.getCookies()
+      # (b) Spring MVC 컨트롤러 파라미터 애노테이션 (#29).
+      #     메서드 시그니처 전체를 감싸고 focus-metavariable 로 파라미터를 지목해야
+      #     taint 가 실제로 전파된다. bare `@RequestBody $T $X` 는 --validate 는 통과하지만
+      #     파라미터 선언 노드만 매치할 뿐 오염이 흐르지 않아 0건이 된다
+      #     (semgrep 1.169.0 실측). `@X(...)` 는 인자 없는 `@X` 도 함께 매칭한다.
+      - patterns:
+          - pattern-either:
+              - pattern: "class $C { $RT $M(..., @RequestBody(...) $T $X, ...) { ... } }"
+              - pattern: "class $C { $RT $M(..., @RequestParam(...) $T $X, ...) { ... } }"
+              - pattern: "class $C { $RT $M(..., @PathVariable(...) $T $X, ...) { ... } }"
+              - pattern: "class $C { $RT $M(..., @RequestHeader(...) $T $X, ...) { ... } }"
+          - focus-metavariable: $X
     pattern-sinks:
       - patterns:
           - pattern-either:
@@ -206,11 +219,24 @@ rules:
       exclude: ["*Test.java"]
     mode: taint
     pattern-sources:
+      # (a) Servlet 원시 API
       - pattern: $R.getParameter(...)
       - pattern: $R.getParameterValues(...)
       - pattern: $R.getHeader(...)
       - pattern: $R.getQueryString()
       - pattern: $R.getCookies()
+      # (b) Spring MVC 컨트롤러 파라미터 애노테이션 (#29).
+      #     메서드 시그니처 전체를 감싸고 focus-metavariable 로 파라미터를 지목해야
+      #     taint 가 실제로 전파된다. bare `@RequestBody $T $X` 는 --validate 는 통과하지만
+      #     파라미터 선언 노드만 매치할 뿐 오염이 흐르지 않아 0건이 된다
+      #     (semgrep 1.169.0 실측). `@X(...)` 는 인자 없는 `@X` 도 함께 매칭한다.
+      - patterns:
+          - pattern-either:
+              - pattern: "class $C { $RT $M(..., @RequestBody(...) $T $X, ...) { ... } }"
+              - pattern: "class $C { $RT $M(..., @RequestParam(...) $T $X, ...) { ... } }"
+              - pattern: "class $C { $RT $M(..., @PathVariable(...) $T $X, ...) { ... } }"
+              - pattern: "class $C { $RT $M(..., @RequestHeader(...) $T $X, ...) { ... } }"
+          - focus-metavariable: $X
     pattern-sinks:
       - patterns:
           - pattern-either:
@@ -230,11 +256,24 @@ rules:
       exclude: ["*Test.java"]
     mode: taint
     pattern-sources:
+      # (a) Servlet 원시 API
       - pattern: $R.getParameter(...)
       - pattern: $R.getParameterValues(...)
       - pattern: $R.getHeader(...)
       - pattern: $R.getQueryString()
       - pattern: $R.getCookies()
+      # (b) Spring MVC 컨트롤러 파라미터 애노테이션 (#29).
+      #     메서드 시그니처 전체를 감싸고 focus-metavariable 로 파라미터를 지목해야
+      #     taint 가 실제로 전파된다. bare `@RequestBody $T $X` 는 --validate 는 통과하지만
+      #     파라미터 선언 노드만 매치할 뿐 오염이 흐르지 않아 0건이 된다
+      #     (semgrep 1.169.0 실측). `@X(...)` 는 인자 없는 `@X` 도 함께 매칭한다.
+      - patterns:
+          - pattern-either:
+              - pattern: "class $C { $RT $M(..., @RequestBody(...) $T $X, ...) { ... } }"
+              - pattern: "class $C { $RT $M(..., @RequestParam(...) $T $X, ...) { ... } }"
+              - pattern: "class $C { $RT $M(..., @PathVariable(...) $T $X, ...) { ... } }"
+              - pattern: "class $C { $RT $M(..., @RequestHeader(...) $T $X, ...) { ... } }"
+          - focus-metavariable: $X
     pattern-sinks:
       - patterns:
           - pattern-either:
@@ -334,11 +373,24 @@ rules:
       exclude: ["*Test.java"]
     mode: taint
     pattern-sources:
+      # (a) Servlet 원시 API
       - pattern: $R.getParameter(...)
       - pattern: $R.getParameterValues(...)
       - pattern: $R.getHeader(...)
       - pattern: $R.getQueryString()
       - pattern: $R.getCookies()
+      # (b) Spring MVC 컨트롤러 파라미터 애노테이션 (#29).
+      #     메서드 시그니처 전체를 감싸고 focus-metavariable 로 파라미터를 지목해야
+      #     taint 가 실제로 전파된다. bare `@RequestBody $T $X` 는 --validate 는 통과하지만
+      #     파라미터 선언 노드만 매치할 뿐 오염이 흐르지 않아 0건이 된다
+      #     (semgrep 1.169.0 실측). `@X(...)` 는 인자 없는 `@X` 도 함께 매칭한다.
+      - patterns:
+          - pattern-either:
+              - pattern: "class $C { $RT $M(..., @RequestBody(...) $T $X, ...) { ... } }"
+              - pattern: "class $C { $RT $M(..., @RequestParam(...) $T $X, ...) { ... } }"
+              - pattern: "class $C { $RT $M(..., @PathVariable(...) $T $X, ...) { ... } }"
+              - pattern: "class $C { $RT $M(..., @RequestHeader(...) $T $X, ...) { ... } }"
+          - focus-metavariable: $X
     pattern-sinks:
       - patterns:
           - pattern-either:
@@ -357,11 +409,24 @@ rules:
       exclude: ["*Test.java"]
     mode: taint
     pattern-sources:
+      # (a) Servlet 원시 API
       - pattern: $R.getParameter(...)
       - pattern: $R.getParameterValues(...)
       - pattern: $R.getHeader(...)
       - pattern: $R.getQueryString()
       - pattern: $R.getCookies()
+      # (b) Spring MVC 컨트롤러 파라미터 애노테이션 (#29).
+      #     메서드 시그니처 전체를 감싸고 focus-metavariable 로 파라미터를 지목해야
+      #     taint 가 실제로 전파된다. bare `@RequestBody $T $X` 는 --validate 는 통과하지만
+      #     파라미터 선언 노드만 매치할 뿐 오염이 흐르지 않아 0건이 된다
+      #     (semgrep 1.169.0 실측). `@X(...)` 는 인자 없는 `@X` 도 함께 매칭한다.
+      - patterns:
+          - pattern-either:
+              - pattern: "class $C { $RT $M(..., @RequestBody(...) $T $X, ...) { ... } }"
+              - pattern: "class $C { $RT $M(..., @RequestParam(...) $T $X, ...) { ... } }"
+              - pattern: "class $C { $RT $M(..., @PathVariable(...) $T $X, ...) { ... } }"
+              - pattern: "class $C { $RT $M(..., @RequestHeader(...) $T $X, ...) { ... } }"
+          - focus-metavariable: $X
     pattern-sinks:
       - pattern: new File(...)
       - pattern: new FileInputStream(...)
@@ -420,11 +485,24 @@ rules:
       exclude: ["*Test.java"]
     mode: taint
     pattern-sources:
+      # (a) Servlet 원시 API
       - pattern: $R.getParameter(...)
       - pattern: $R.getParameterValues(...)
       - pattern: $R.getHeader(...)
       - pattern: $R.getQueryString()
       - pattern: $R.getCookies()
+      # (b) Spring MVC 컨트롤러 파라미터 애노테이션 (#29).
+      #     메서드 시그니처 전체를 감싸고 focus-metavariable 로 파라미터를 지목해야
+      #     taint 가 실제로 전파된다. bare `@RequestBody $T $X` 는 --validate 는 통과하지만
+      #     파라미터 선언 노드만 매치할 뿐 오염이 흐르지 않아 0건이 된다
+      #     (semgrep 1.169.0 실측). `@X(...)` 는 인자 없는 `@X` 도 함께 매칭한다.
+      - patterns:
+          - pattern-either:
+              - pattern: "class $C { $RT $M(..., @RequestBody(...) $T $X, ...) { ... } }"
+              - pattern: "class $C { $RT $M(..., @RequestParam(...) $T $X, ...) { ... } }"
+              - pattern: "class $C { $RT $M(..., @PathVariable(...) $T $X, ...) { ... } }"
+              - pattern: "class $C { $RT $M(..., @RequestHeader(...) $T $X, ...) { ... } }"
+          - focus-metavariable: $X
     pattern-sinks:
       - patterns:
           - pattern-either:
@@ -448,11 +526,24 @@ rules:
       exclude: ["*Test.java"]
     mode: taint
     pattern-sources:
+      # (a) Servlet 원시 API
       - pattern: $R.getParameter(...)
       - pattern: $R.getParameterValues(...)
       - pattern: $R.getHeader(...)
       - pattern: $R.getQueryString()
       - pattern: $R.getCookies()
+      # (b) Spring MVC 컨트롤러 파라미터 애노테이션 (#29).
+      #     메서드 시그니처 전체를 감싸고 focus-metavariable 로 파라미터를 지목해야
+      #     taint 가 실제로 전파된다. bare `@RequestBody $T $X` 는 --validate 는 통과하지만
+      #     파라미터 선언 노드만 매치할 뿐 오염이 흐르지 않아 0건이 된다
+      #     (semgrep 1.169.0 실측). `@X(...)` 는 인자 없는 `@X` 도 함께 매칭한다.
+      - patterns:
+          - pattern-either:
+              - pattern: "class $C { $RT $M(..., @RequestBody(...) $T $X, ...) { ... } }"
+              - pattern: "class $C { $RT $M(..., @RequestParam(...) $T $X, ...) { ... } }"
+              - pattern: "class $C { $RT $M(..., @PathVariable(...) $T $X, ...) { ... } }"
+              - pattern: "class $C { $RT $M(..., @RequestHeader(...) $T $X, ...) { ... } }"
+          - focus-metavariable: $X
     pattern-sinks:
       - patterns:
           - pattern-either:

--- a/rules/typescript.yaml
+++ b/rules/typescript.yaml
@@ -60,11 +60,32 @@ rules:
       category: security
     mode: taint
     pattern-sources:
+      # (a) Express 스타일 요청 객체
       - pattern-either:
           - pattern: $REQ.query
           - pattern: $REQ.body
           - pattern: $REQ.params
           - pattern: $REQ.headers
+      # (b) NestJS·nestia 컨트롤러 파라미터 데코레이터 (#29).
+      #     메서드 시그니처 전체를 감싸고 focus-metavariable 로 파라미터를 지목해야
+      #     taint 가 실제로 전파된다. bare `@Body() $X` 는 --validate 는 통과하지만
+      #     파라미터 선언 노드만 매치할 뿐 오염이 후속 사용처로 흐르지 않아 0건이 된다
+      #     (semgrep 1.169.0 실측). `@X(...)` 는 인자 없는 `@X()` 도 함께 매칭한다.
+      - patterns:
+          - pattern-either:
+              - pattern: "class $C { $M(..., @Body(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @Query(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @Param(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @Headers(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @TypedBody(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @TypedQuery(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @TypedParam(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @EncryptedBody(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @core.TypedBody(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @core.TypedQuery(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @core.TypedParam(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @core.EncryptedBody(...) $X, ...) { ... } }"
+          - focus-metavariable: $X
     pattern-sinks:
       - patterns:
           - pattern-either:
@@ -86,11 +107,32 @@ rules:
       category: security
     mode: taint
     pattern-sources:
+      # (a) Express 스타일 요청 객체
       - pattern-either:
           - pattern: $REQ.query
           - pattern: $REQ.body
           - pattern: $REQ.params
           - pattern: $REQ.headers
+      # (b) NestJS·nestia 컨트롤러 파라미터 데코레이터 (#29).
+      #     메서드 시그니처 전체를 감싸고 focus-metavariable 로 파라미터를 지목해야
+      #     taint 가 실제로 전파된다. bare `@Body() $X` 는 --validate 는 통과하지만
+      #     파라미터 선언 노드만 매치할 뿐 오염이 후속 사용처로 흐르지 않아 0건이 된다
+      #     (semgrep 1.169.0 실측). `@X(...)` 는 인자 없는 `@X()` 도 함께 매칭한다.
+      - patterns:
+          - pattern-either:
+              - pattern: "class $C { $M(..., @Body(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @Query(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @Param(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @Headers(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @TypedBody(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @TypedQuery(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @TypedParam(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @EncryptedBody(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @core.TypedBody(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @core.TypedQuery(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @core.TypedParam(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @core.EncryptedBody(...) $X, ...) { ... } }"
+          - focus-metavariable: $X
     pattern-sinks:
       - patterns:
           - pattern-either:
@@ -107,11 +149,32 @@ rules:
       category: security
     mode: taint
     pattern-sources:
+      # (a) Express 스타일 요청 객체
       - pattern-either:
           - pattern: $REQ.query
           - pattern: $REQ.body
           - pattern: $REQ.params
           - pattern: $REQ.headers
+      # (b) NestJS·nestia 컨트롤러 파라미터 데코레이터 (#29).
+      #     메서드 시그니처 전체를 감싸고 focus-metavariable 로 파라미터를 지목해야
+      #     taint 가 실제로 전파된다. bare `@Body() $X` 는 --validate 는 통과하지만
+      #     파라미터 선언 노드만 매치할 뿐 오염이 후속 사용처로 흐르지 않아 0건이 된다
+      #     (semgrep 1.169.0 실측). `@X(...)` 는 인자 없는 `@X()` 도 함께 매칭한다.
+      - patterns:
+          - pattern-either:
+              - pattern: "class $C { $M(..., @Body(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @Query(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @Param(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @Headers(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @TypedBody(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @TypedQuery(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @TypedParam(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @EncryptedBody(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @core.TypedBody(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @core.TypedQuery(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @core.TypedParam(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @core.EncryptedBody(...) $X, ...) { ... } }"
+          - focus-metavariable: $X
     pattern-sinks:
       - patterns:
           - pattern-either:
@@ -125,6 +188,29 @@ rules:
               - pattern: https.get($U, ...)
               - pattern: https.request($U, ...)
           - focus-metavariable: $U
+
+  # 2차(stored) SSRF — 외부에서 지정한 콜백/웹훅 URL 이 DB 를 경유해 저장된 뒤 서버가 호출하는 경로 (#29).
+  # ts.ssrf 의 taint 로는 못 잡는다. 이유가 두 가지고 둘 다 실측했다:
+  #   (1) 값이 Prisma/ORM 을 거쳐 저장·재조회되므로 taint 체인이 끊긴다.
+  #   (2) semgrep 1.169.0 의 TS 파서는 `export namespace X { ... }` 블록 안의 문장을
+  #       AST 패턴으로 매칭하지 못한다(같은 코드가 top-level 이면 매칭됨 — 실측).
+  #       provider 를 export namespace 로 감싸는 코드베이스에서는 sink 자체가 무음이라
+  #       source 를 아무리 넓혀도 소용이 없다. 그래서 이 룰만 languages: [regex] 로 둔다.
+  # 오탐 억제: 임의의 비리터럴 URL 이 아니라 "webhook/callback/postback/notify/redirect/forward"
+  # 어휘 + url/uri/endpoint 로 끝나는 **프로퍼티 접근**(엔티티 필드 읽기)일 때만 발화한다.
+  # SCREAMING_CASE 필드(`Config.WEBHOOK_URL` 같은 설정 상수)는 대소문자 구분으로 제외한다.
+  # 확정 취약점이 아니라 "출처 확인 필요" 신호이므로 severity 는 WARNING 으로 둔다.
+  - id: finguard.ts.stored-ssrf
+    languages: [regex]
+    severity: WARNING
+    message: 외부에서 지정한 콜백/웹훅 URL 필드가 서버 측 HTTP 요청 대상으로 사용되고 있습니다(2차 SSRF). 저장 시점에 호스트 허용 목록·사설 IP 대역 차단으로 검증했는지 확인해야 합니다.
+    metadata:
+      cwe: "CWE-918"
+      category: security
+    paths:
+      include: ["*.ts", "*.tsx", "*.js", "*.jsx"]
+      exclude: ["*.test.ts", "*.spec.ts", "*.test.js", "*.spec.js"]
+    pattern-regex: '(?m)^(?![ \t]*(?://|\*|/\*)).*\b(?:fetch|axios(?:\.(?:get|post|put|patch|delete|head|request))?|https?\.(?:get|request))\s*\(\s*(?:await\s+)?[A-Za-z_$][\w$]*(?:\s*\??\.\s*[\w$]+)*\s*\??\.\s*[\w$]*(?:webhook|Webhook|callback|Callback|postback|Postback|notify|Notify|redirect|Redirect|forward|Forward)[\w$]*(?:url|Url|URL|uri|Uri|URI|endpoint|Endpoint)[\w$]*\s*!?\s*[,)]'
 
   - id: finguard.ts.xss-innerhtml
     languages: [ts, js]
@@ -156,11 +242,32 @@ rules:
       category: security
     mode: taint
     pattern-sources:
+      # (a) Express 스타일 요청 객체
       - pattern-either:
           - pattern: $REQ.query
           - pattern: $REQ.body
           - pattern: $REQ.params
           - pattern: $REQ.headers
+      # (b) NestJS·nestia 컨트롤러 파라미터 데코레이터 (#29).
+      #     메서드 시그니처 전체를 감싸고 focus-metavariable 로 파라미터를 지목해야
+      #     taint 가 실제로 전파된다. bare `@Body() $X` 는 --validate 는 통과하지만
+      #     파라미터 선언 노드만 매치할 뿐 오염이 후속 사용처로 흐르지 않아 0건이 된다
+      #     (semgrep 1.169.0 실측). `@X(...)` 는 인자 없는 `@X()` 도 함께 매칭한다.
+      - patterns:
+          - pattern-either:
+              - pattern: "class $C { $M(..., @Body(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @Query(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @Param(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @Headers(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @TypedBody(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @TypedQuery(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @TypedParam(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @EncryptedBody(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @core.TypedBody(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @core.TypedQuery(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @core.TypedParam(...) $X, ...) { ... } }"
+              - pattern: "class $C { $M(..., @core.EncryptedBody(...) $X, ...) { ... } }"
+          - focus-metavariable: $X
     pattern-sanitizers:
       - pattern: path.basename(...)
     pattern-sinks:

--- a/testdata/rule-fixtures/java_spring_taint_sources.java
+++ b/testdata/rule-fixtures/java_spring_taint_sources.java
@@ -1,0 +1,73 @@
+// Spring MVC 컨트롤러 파라미터 애노테이션을 taint source 로 인식하는지 확인하는 정탐 픽스처 (#29).
+// 확장 전에는 pattern-sources 가 Servlet 원시 API 5개뿐이라 아래가 전부 미검출이었다.
+// 대조군은 safe_java_spring_taint.java.
+package finguard.fixtures;
+
+import java.io.File;
+import java.net.URL;
+import java.sql.Connection;
+import java.sql.Statement;
+import javax.naming.directory.DirContext;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class SpringTaintController {
+
+    private Connection conn;
+    private DirContext ctx;
+    private ExpressionParser parser;
+    private HttpServletResponse response;
+
+    @PostMapping("/webhooks")
+    public String registerWebhook(@RequestBody WebhookForm form) throws Exception {
+        // EXPECT: finguard.java.ssrf
+        return new URL(form.getCallbackUrl()).getHost();
+    }
+
+    @GetMapping("/receipts")
+    public String receipt(@RequestParam("name") String name) throws Exception {
+        // EXPECT: finguard.java.path-traversal
+        File f = new File(name);
+        return f.getPath();
+    }
+
+    @GetMapping("/go/{to}")
+    public void go(@PathVariable("to") String to) throws Exception {
+        // EXPECT: finguard.java.open-redirect
+        response.sendRedirect(to);
+    }
+
+    @GetMapping("/reports")
+    public void report(@RequestHeader("X-Report-Cmd") String cmd) throws Exception {
+        // EXPECT: finguard.java.os-command-injection
+        Runtime.getRuntime().exec(cmd);
+    }
+
+    // 같은 source 블록을 공유하는 나머지 taint 룰도 함께 확장된다.
+    @GetMapping("/accounts")
+    public void find(@RequestParam("q") String q) throws Exception {
+        Statement st = conn.createStatement();
+        // EXPECT: finguard.java.jdbc-sqli
+        st.executeQuery(q);
+    }
+
+    @GetMapping("/directory")
+    public void directory(@RequestParam("filter") String filter) throws Exception {
+        // EXPECT: finguard.java.ldap-injection
+        ctx.search("ou=users,dc=example,dc=com", filter, null);
+    }
+
+    @PostMapping("/expressions")
+    public void evaluate(@RequestBody String expression) throws Exception {
+        // EXPECT: finguard.java.ssti
+        parser.parseExpression(expression);
+    }
+}

--- a/testdata/rule-fixtures/safe_java_spring_taint.java
+++ b/testdata/rule-fixtures/safe_java_spring_taint.java
@@ -1,0 +1,36 @@
+// java_spring_taint_sources.java 의 대조군 — 어떤 룰에도 걸리면 안 된다.
+// safe_ 접두 파일은 EXPECT 마커를 가질 수 없다.
+package finguard.fixtures;
+
+import java.net.URL;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class SafeSpringController {
+
+    private Connection conn;
+    private List<String> allowedHosts;
+
+    // 애노테이션 파라미터를 받되 허용 목록으로 검증하고, 호출 대상은 고정 상수다.
+    @GetMapping("/safe/webhooks")
+    public String registerWebhook(@RequestParam("target") String target) throws Exception {
+        URL candidate = new URL("https://api.internal.example.com/webhooks/register");
+        if (!allowedHosts.contains(target)) {
+            throw new IllegalArgumentException("허용되지 않은 호스트");
+        }
+        return candidate.getHost();
+    }
+
+    // 바인딩 파라미터 — 조립이 없다.
+    @GetMapping("/safe/accounts")
+    public void find(@RequestParam("q") String q) throws Exception {
+        PreparedStatement ps = conn.prepareStatement("SELECT * FROM ACCT WHERE NAME = ?");
+        ps.setString(1, q);
+        ps.executeQuery();
+    }
+}

--- a/testdata/rule-fixtures/safe_ts_framework_taint.ts
+++ b/testdata/rule-fixtures/safe_ts_framework_taint.ts
@@ -1,0 +1,23 @@
+// ts_framework_taint_sources.ts 의 대조군 — 어떤 룰에도 걸리면 안 된다.
+// safe_ 접두 파일은 EXPECT 마커를 가질 수 없다.
+import { Body, Controller, Post } from "@nestjs/common";
+
+declare const ALLOW_HOSTS: string[];
+
+@Controller("safe-payments")
+export class SafePaymentController {
+  // 데코레이터 파라미터를 받되 허용 목록으로 검증하고, 호출 대상은 고정 상수다.
+  @Post("webhook")
+  async register(@Body() input: { url: string }): Promise<unknown> {
+    const u = new URL(input.url);
+    if (!ALLOW_HOSTS.includes(u.hostname)) {
+      throw new Error("허용되지 않은 호스트");
+    }
+    return fetch("https://api.internal.example.com/webhooks/register");
+  }
+}
+
+// 설정 상수(SCREAMING_CASE)에서 온 URL 은 이용자가 지정한 값이 아니므로 stored-ssrf 대상이 아니다.
+export async function ping(config: { WEBHOOK_URL: string }): Promise<void> {
+  await fetch(config.WEBHOOK_URL, { method: "POST" });
+}

--- a/testdata/rule-fixtures/ts_framework_taint_sources.ts
+++ b/testdata/rule-fixtures/ts_framework_taint_sources.ts
@@ -1,0 +1,56 @@
+// NestJS·nestia 컨트롤러 파라미터 데코레이터를 taint source 로 인식하는지 확인하는 정탐 픽스처 (#29).
+// 확장 전에는 pattern-sources 가 $REQ.query/body/params/headers 뿐이라 아래가 전부 미검출이었다.
+// 대조군은 safe_ts_framework_taint.ts.
+import { Body, Controller, Get, Headers, Param, Post, Query } from "@nestjs/common";
+import core from "@nestia/core";
+import { exec } from "child_process";
+import fs from "fs";
+
+declare const res: any;
+
+@Controller("payments")
+export class PaymentController {
+  @Post("webhook")
+  async register(@Body() input: { url: string }): Promise<unknown> {
+    // EXPECT: finguard.ts.ssrf
+    return fetch(input.url);
+  }
+
+  @Get("receipt")
+  receipt(@Query() q: { name: string }): Buffer {
+    // EXPECT: finguard.ts.path-traversal
+    return fs.readFileSync(q.name);
+  }
+
+  @Get("go/:to")
+  go(@Param() p: { to: string }): void {
+    // EXPECT: finguard.ts.open-redirect
+    res.redirect(p.to);
+  }
+
+  @Post("report")
+  report(@Headers() h: Record<string, string>): void {
+    // EXPECT: finguard.ts.os-command-injection
+    exec(h["x-report-cmd"]);
+  }
+
+  // nestia 의 암호화 본문 — samchon/payments 가 실제로 쓰는 형태
+  @Post("encrypted")
+  async encrypted(@core.EncryptedBody() body: { target: string }): Promise<unknown> {
+    // EXPECT: finguard.ts.ssrf
+    return fetch(body.target);
+  }
+
+  @Post("typed")
+  async typed(@core.TypedBody() body: { target: string }): Promise<unknown> {
+    // EXPECT: finguard.ts.ssrf
+    return fetch(body.target);
+  }
+}
+
+// 2차(stored) SSRF — 저장된 콜백 URL 을 그대로 호출한다.
+// taint 로는 잡히지 않아 별도 regex 룰이 담당한다.
+export async function sendWebhook(history: { webhook_url: string }): Promise<void> {
+  // EXPECT: finguard.ts.stored-ssrf
+  await fetch(history.webhook_url, { method: "POST" });
+}


### PR DESCRIPTION
Closes #29

TS taint 룰 4종의 `pattern-sources` 가 `$REQ.query/body/params/headers` 뿐이고, Java taint 룰이 Servlet 원시 API 5개뿐이라 NestJS·nestia·Spring MVC 컨트롤러를 쓰는 코드에서 taint 룰이 통째로 무음이던 문제를 고친다.

## 1. 검증에서 나온 반박·반영 내역

| 반박 | 판정 | 반영 |
| :--- | :--- | :--- |
| **구현가능성**: bare `(@Body() $X)` 는 TS 파서에서 파싱 에러, 괄호 없는 `@Body() $X` 는 `--validate` 는 통과하나 taint 전파 0건. `class $C { $M(..., @Body() $X, ...) { ... } }` + `focus-metavariable: $X` 로 써야 동작 | 채택 | 모든 source 를 메서드 시그니처를 감싸는 형태 + `focus-metavariable` 로 작성. 실증은 아래 2절 |
| **재현율 수호자 / 규제심사**: `finguard.ts.ssrf-dynamic-url`(fetch 인자가 리터럴도 `process.env` 도 아니면 WARNING)은 정상 코드 대부분에 발화 → 폐기 | 채택 | **원안 (2) 는 구현하지 않았다.** 코드에 흔적 없음 |
| **재현율 수호자 / 규제심사 수정본**: 대신 "엔티티 프로퍼티 / 콜백·웹훅 URL 필드명" 으로 한정한 stored-SSRF 룰(WARNING) 로 재설계 | 채택 | `finguard.ts.stored-ssrf` 신설. sink 는 fetch/axios/http(s) 로 한정하고, 인자가 `webhook/callback/postback/notify/redirect/forward` 어휘 + `url/uri/endpoint` 로 끝나는 **프로퍼티 접근**일 때만 발화. SCREAMING_CASE 필드(설정 상수)는 제외. severity 는 WARNING 고정 |
| **규제심사**: source 확장은 순수 개선, 규정상 손실 없음 | 채택 | 아래 3절에서 손실 0건 실측 |
| **재현율 수호자**: TS 데코레이터 소스 문법은 검증된 형태가 아니므로 실픽스처 확인 필요 | 채택 | 회귀 픽스처 4종 + 변이 시험(5절) |

## 2. source 가 실제로 발화함을 보인 최소 재현

`semgrep 1.169.0`(`/opt/homebrew/bin/semgrep`).

**TypeScript** — NestJS/nestia 컨트롤러 6개 파라미터, sink 는 `fetch($U, ...)`:

```
t.ts  8  @Body()               → fetch(input.url)
t.ts 14  @Query()              → fetch(q.target)
t.ts 15  @Param()              → fetch(p.target)
t.ts 20  @core.TypedBody()     → fetch(body.webhook_url)
t.ts 25  @core.EncryptedBody() → fetch(body.callback_url)
t.ts 26  @Headers()            → fetch(h["x-target"])
```

`@Body("url")` 처럼 인자가 있는 형태도 `@Body(...)` 로 함께 매칭되고, 데코레이터 없는 순수 파라미터는 매칭되지 않음을 별도 픽스처로 확인했다.

**Java** — Spring MVC 애노테이션, sink 는 `new URL($U, ...)` / `new File($U, ...)`:

```
T.java  12  @RequestBody PayReq req                        → new URL(req.getCallbackUrl())
T.java  19  @RequestParam String name                      → new File(name)
T.java  20  @PathVariable("id") String id                  → new URL(id)
T.java  21  @RequestHeader("X-Target") String target       → new URL(target)
T.java  27  @RequestParam(value="q", required=false) String q → new URL(q)
T2.java 13  반환형 ResponseEntity<String>                   → 매칭
T2.java 19  반환형 void                                     → 매칭
T2.java 24  private static 메서드                           → 매칭
```

- `@X(...)` 는 인자 없는 bare `@X` 도 함께 매칭한다(실측) → 애노테이션당 패턴 1개로 충분.
- bare `@RequestBody $T $X` 단독은 `@RequestBody(...)` 형태를 못 잡는다 → 괄호 형태만 채택.

**실코드에서의 source 바인딩** — samchon/payments 컨트롤러에 새 source 패턴만 적용한 probe 룰을 돌리면 **52건**의 데코레이터 파라미터가 실제로 바인딩된다(확장 전에는 0건). 패턴이 죽어 있는 게 아니라, 아래 3절대로 같은 파일 안에 sink 가 없을 뿐이다.

## 3. 실코드 전/후 검출 비교 (코퍼스 10개 레포)

`semgrep --config rules/` 전체 룰셋을 각 레포 `src` 에 돌린 결과.

| 레포 | 언어 | before | after | 신규 | 손실 |
| :--- | :--- | ---: | ---: | ---: | ---: |
| r0 한국투자증권 OpenAPI | Python | 54 | 54 | 0 | 0 |
| **r1 samchon/payments** | TS·NestJS | 8 | **10** | **+2** | 0 |
| r2 CoinNow | Swift | 1 | 1 | 0 | 0 |
| r3 DuDoong-Backend | Kotlin | 12 | 12 | 0 | 0 |
| r4 iamport-python | Python | 0 | 0 | 0 | 0 |
| r5 AXSnapshot | Swift | 0 | 0 | 0 | 0 |
| r6 reactive-crypto | Kotlin | 2 | 2 | 0 | 0 |
| r7 pybithumb | Python | 0 | 0 | 0 | 0 |
| r8 iamport-rest-client-java | Java | 0 | 0 | 0 | 0 |
| r9 upbitBar | Swift | 2 | 2 | 0 | 0 |
| 합계 | | 79 | 81 | +2 | 0 |

### 신규 2건 전수 확인 — 둘 다 정탐

이슈 「근거」 절이 지목한 바로 그 두 건이다.

1. `packages/payment-backend/src/providers/payments/PaymentWebhookProvider.ts:84`
   `await fetch(history.webhook_url!, { method: "POST", ... })` — 가맹점이 등록한 webhook URL 을 allowlist 검증 없이 호출.
2. `packages/payment-backend/src/providers/payments/PaymentHistoryProvider.ts:92`
   `await fetch(history.webhook_url, { method: "GET", ... })` — `null` 검사만 있고 호스트 검증 없음.

프로토타입 단계에서 잡히던 3번째 건(`fake-toss-payments-server/.../FakeTossWebhookProvider.ts:7`, `fetch(FakeTossConfiguration.WEBHOOK_URL, ...)`)은 설정 상수라 오탐이므로, 최종 정규식에서 SCREAMING_CASE 필드를 대소문자 구분으로 제외해 떨어뜨렸다.

### source 확장 자체는 왜 신규 0건인가 (규명)

코퍼스에는 nestia 데코레이터를 쓰는 컨트롤러가 **17개 파일**(위 probe 기준 52개 파라미터) 있는데도 taint 확장분만으로는 신규 검출이 0이다. 이유를 끝까지 확인했다.

1. **컨트롤러 → 프로바이더 파일 분리.** semgrep OSS 의 taint 는 파일 단위다. 컨트롤러가 받은 본문을 다른 파일의 Provider 에 넘기는 순간 체인이 끊긴다.
2. **DB 왕복.** `webhook_url` 은 Prisma 로 저장됐다가 나중에 다시 조회돼 호출된다. 저장/조회는 taint propagator 가 아니다.
3. **(새로 밝혀낸 것) semgrep 1.169.0 TS 파서는 `export namespace X { ... }` 블록 안의 문장을 AST 패턴으로 매칭하지 못한다.** 최소 재현:

   ```ts
   export namespace A { export async function f(h: any) { await fetch(h.u); } }  // 미검출
   export namespace B { async function g(h: any) { await fetch(h.u); } }         // 미검출
   namespace C { export async function h2(h: any) { await fetch(h.u); } }        // 검출
   export const D = { async i(h: any) { await fetch(h.u); } };                    // 검출
   ```

   `fetch($U, ...)` 라는 sink 패턴만으로도 `export namespace` 안에서는 0건이다. samchon/payments 의 provider 는 전부 `export namespace` 로 감싸여 있어, **source 를 아무리 넓혀도 sink 쪽이 먼저 무음**이었다.

3번은 이 PR 의 taint 확장으로는 해결할 수 없는 semgrep 자체의 한계다. 그래서 stored-SSRF 보조 룰만 `languages: [regex]` 로 두어 파서 갭을 우회했고, 그 결과 위 2건이 실제로 잡힌다. 이 한계는 finguard 의 다른 TS AST 룰에도 동일하게 적용되므로 별도 이슈로 다룰 가치가 있다(이 PR 범위 밖).

## 4. 변이 시험 (픽스처가 실제로 게이트로 동작하는지)

`go test -count=1 -tags semgrep_integration ./internal/scanner/ -run TestFixtureExpectationsMatchScan`

| 변이 | 결과 |
| :--- | :--- |
| `ts_framework_taint_sources.ts` 의 `// EXPECT: finguard.ts.stored-ssrf` 마커 제거 | **rc=1** — `오탐 회귀 — 마커가 없는데 검출됐다: ts_framework_taint_sources.ts:54 finguard.ts.stored-ssrf` |
| 검출되지 않는 줄(`export async function sendWebhook`)에 `// EXPECT: finguard.ts.ssrf` 추가 | **rc=1** — `미탐 회귀 — 마커가 있는데 검출되지 않았다: ts_framework_taint_sources.ts:54 finguard.ts.ssrf` |
| 원복 | **rc=0** |

첫 시도에서 `-count=1` 없이 돌려 Go 테스트 캐시 때문에 rc=0 이 나왔던 점을 함께 기록한다.

## 5. 일부러 넣지 않은 것과 이유

- **`finguard.ts.ssrf-dynamic-url`(이슈 원안 (2))** — 3개 렌즈 중 2개가 명시 반대. `baseUrl + path` 조립·설정 객체 경유·내부 서비스 디스커버리까지 전부 발화해 MR 코멘트를 도배한다. 폐기하고 stored-SSRF 로 대체.
- **Kotlin(`rules/kotlin.yaml`) Spring 애노테이션 확장** — 코퍼스에 `@RequestBody` 등을 쓰는 Kotlin 파일이 30개 있어 가치는 있지만, 같은 시각 다른 작업이 그 파일을 점유 중이라 이 PR 범위에서 제외했다. Kotlin 은 `$RT $M(...)` 형태의 Java 관용구가 그대로 통하지 않으므로 별도 실측이 필요하다(#28 에서 같은 함정이 확인됐다).
- **Java `@ModelAttribute` / `@CookieValue` / `@RequestPart`** — 이슈가 지목한 4종 밖이고, 특히 `@ModelAttribute` 는 커맨드 객체 바인딩이라 검증 로직까지 광범위하게 물 수 있어 실코드 근거 없이는 넣지 않았다.
- **Java stored-SSRF 대응 룰** — 코퍼스의 Java 165개 파일 중 Spring 컨트롤러가 0개라 오탐률을 실측할 근거가 없다. TS 쪽 실측 후 필요하면 별도 이슈로.
- **`languages: [regex]` 를 taint 룰 본체에 적용** — stored-SSRF 보조 룰에만 한정했다. 기존 taint 룰을 regex 로 바꾸면 sanitizer·경로 추적을 전부 잃는다.

## 6. 범위 메모 — 확장한 룰 목록

이슈는 8종을 지목했지만, Java 쪽은 동일한 Servlet-only source 블록을 3개 룰이 더 공유하고 있었다. 그대로 두면 같은 무음 문제가 남으므로 함께 확장했다.

- TS(4): `finguard.ts.ssrf` · `finguard.ts.open-redirect` · `finguard.ts.path-traversal` · `finguard.ts.os-command-injection`
- Java(7): `finguard.java.ssrf` · `finguard.java.open-redirect` · `finguard.java.path-traversal` · `finguard.java.os-command-injection` · `finguard.java.jdbc-sqli` · `finguard.java.ldap-injection` · `finguard.java.ssti`
- 신설(1): `finguard.ts.stored-ssrf` (WARNING, `FIN-SSRF-005`)

`finguard.java.zip-slip` / `finguard.ts.zip-slip` 은 source 가 ZIP 엔트리명이라 대상이 아니다.

## 7. 검증 결과

| 명령 | 결과 |
| :--- | :--- |
| `semgrep --validate --config rules/` | `Configuration is valid - found 0 configuration error(s), and 116 rule(s).` |
| 룰 수 ↔ 매핑 수 대조 | 룰 116 · 매핑 116 · 매핑 누락 0 · 고아 0 |
| `go build -mod=vendor ./...` | 통과 |
| `go vet -mod=vendor ./...` | 통과 |
| `go test -race -mod=vendor ./...` | 전 패키지 ok |
| `go test -race -mod=vendor -tags semgrep_integration ./internal/scanner/ -v` | `TestFixtureExpectationsMatchScan: 기대 123건 · 검출 123건 · 전부 일치`, 전체 PASS |

## 8. 픽스처

- `testdata/rule-fixtures/ts_framework_taint_sources.ts` — NestJS/nestia 데코레이터 → ssrf·path-traversal·open-redirect·os-command-injection + stored-ssrf (마커 7개)
- `testdata/rule-fixtures/safe_ts_framework_taint.ts` — 대조군(allowlist 검증 후 고정 URL 호출, SCREAMING_CASE 설정 상수)
- `testdata/rule-fixtures/java_spring_taint_sources.java` — Spring 애노테이션 → ssrf·path-traversal·open-redirect·os-command-injection·jdbc-sqli·ldap-injection·ssti (마커 7개)
- `testdata/rule-fixtures/safe_java_spring_taint.java` — 대조군(allowlist 검증, PreparedStatement 바인딩)

모두 `testdata/rule-fixtures/` 최상위 평면 배치. `internal/scanner/integration_test.go` 는 수정하지 않았다.
