### PR TITLE
fix(#25): 테스트·로컬 프로파일 시크릿 정책 이원화 + semgrep 기본 무시목록 대체

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,14 @@
+# semgrep 내장 기본 무시목록을 대체한다 (#25).
+#
+# semgrep 은 프로젝트 루트에 이 파일이 없으면 내장 기본값을 쓰는데, 거기에
+# `test/`·`tests/`·`*_test.go` 가 들어 있다(1.169.0 실측). 그러면 테스트 코드를 겨냥한
+# 룰(finguard.<lang>.hardcoded-secret-test)과 그 회귀 픽스처
+# (testdata/rule-fixtures/*_test.go, *Test.java 등)가 룰 설정과 무관하게 통째로 사라진다.
+#
+# 운영 스캔에서는 internal/scanner 가 대상 레포 루트에 같은 목적의 파일을 심는다
+# (레포가 자기 .semgrepignore 를 갖고 있으면 건드리지 않는다).
+#
+# 아래는 이 레포에서 점검 대상이 아닌 경로만 남긴 최소 목록이다.
+# 테스트 경로는 절대 넣지 말 것.
+vendor/
+node_modules/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,6 +264,11 @@ block_on: [ERROR, WARNING]
   마커 없는데 검출 = 오탐 회귀. 라인 번호를 테스트에 적지 않으므로 블록을 어디에 추가하든
   기대값이 따라 움직이고, 픽스처를 건드리는 PR 끼리 충돌하지 않는다.
 - 통합 테스트 실행: `go test -race -mod=vendor -tags semgrep_integration ./internal/scanner/`
+- 레포 루트의 **`.semgrepignore` 를 지우지 말 것** (#25). semgrep 은 이 파일이 없으면
+  내장 기본 무시목록을 쓰는데 거기에 `test/`·`tests/`·`*_test.go` 가 들어 있어,
+  `*_test.go`·`*Test.java` 픽스처와 `finguard.<lang>.hardcoded-secret-test` 룰이
+  룰 설정과 무관하게 통째로 사라진다. 운영 스캔에서는 `internal/scanner` 가 대상 루트에
+  같은 파일을 심는다(레포가 자기 것을 갖고 있으면 건드리지 않는다).
 
 ## 작업 방식
 

--- a/internal/scanner/integration_test.go
+++ b/internal/scanner/integration_test.go
@@ -224,3 +224,46 @@ func TestNoYAMLFixturesUnderRules(t *testing.T) {
 		t.Fatalf("rules/ 순회 실패: %v", err)
 	}
 }
+
+// 회귀(#25): 스캔이 대상 레포에 잔여물을 남기지 않아야 한다.
+//
+// semgrep 내장 무시목록을 대체하려면 대상 루트에 `.semgrepignore` 를 심어야 하는데,
+// `scan --dir=<작업 사본>` 로 자기 레포를 점검하는 로컬 모드에서 그게 남으면
+// 사용자가 의도치 않게 커밋한다. finguard 는 점검 도구이지 대상을 바꾸는 도구가 아니다.
+func TestScanLeavesNoResidueInTarget(t *testing.T) {
+	requireSemgrep(t)
+
+	t.Run("우리가 심은 파일은 스캔 후 사라진다", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "x.py"), []byte("A = 1\n"), 0o644); err != nil {
+			t.Fatalf("사전 준비 실패: %v", err)
+		}
+		if _, err := (CLI{}).Scan(context.Background(), rulesDir(t), dir); err != nil {
+			t.Fatalf("스캔 실패: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(dir, ".semgrepignore")); !os.IsNotExist(err) {
+			t.Error("스캔 후 .semgrepignore 가 대상 레포에 남았다 — 사용자가 커밋하게 된다")
+		}
+	})
+
+	t.Run("레포 자신의 파일은 보존된다", func(t *testing.T) {
+		dir := t.TempDir()
+		p := filepath.Join(dir, ".semgrepignore")
+		if err := os.WriteFile(p, []byte("generated/\n"), 0o644); err != nil {
+			t.Fatalf("사전 준비 실패: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "x.py"), []byte("A = 1\n"), 0o644); err != nil {
+			t.Fatalf("사전 준비 실패: %v", err)
+		}
+		if _, err := (CLI{}).Scan(context.Background(), rulesDir(t), dir); err != nil {
+			t.Fatalf("스캔 실패: %v", err)
+		}
+		got, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatalf("레포의 .semgrepignore 가 지워졌다: %v", err)
+		}
+		if string(got) != "generated/\n" {
+			t.Errorf("레포의 .semgrepignore 가 변조됐다: %q", string(got))
+		}
+	})
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -5,7 +5,9 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 )
 
 // Semgrep 은 목(mock) 가능하도록 인터페이스로 둔다.
@@ -32,10 +34,41 @@ func scanArgs(rulesPath, targetDir string, excludes []string) []string {
 	return append(args, targetDir)
 }
 
+// semgrepIgnoreBody 는 스캔 대상 루트에 심는 `.semgrepignore` 내용이다.
+//
+// semgrep 은 대상 루트에 `.semgrepignore` 가 없으면 **내장 기본 무시목록**을 쓰는데,
+// 거기에 `test/`·`tests/`·`*_test.go` 가 들어 있다 (semgrep 1.169.0 실측). 그 결과
+// `src/test/java/**` 같은 경로가 룰의 paths 설정과 무관하게 조용히 사라진다 —
+// 테스트 코드에 복붙된 실키를 보겠다는 #25 의 룰이 통째로 무효화되는 경로다.
+//
+// 제외 정책은 finguard 가 `--exclude`(DefaultExcludes)와 `.finguard.yml` 로 이미
+// 소유하고 있으므로, 여기서는 아무것도 무시하지 않는 파일을 심어 내장 기본값을 대체한다.
+// 레포가 자기 `.semgrepignore` 를 갖고 있으면 그쪽 의도를 존중해 건드리지 않는다.
+const semgrepIgnoreBody = `# finguard 가 생성한 파일 (#25).
+# semgrep 내장 기본 무시목록(test/·tests/·*_test.go 포함)을 대체한다.
+# 제외 경로는 finguard 의 --exclude 와 .finguard.yml 의 ignore 가 담당한다.
+`
+
+// ensureSemgrepIgnore 는 대상 루트에 `.semgrepignore` 가 없을 때만 생성한다.
+// 실패해도 스캔 자체는 계속한다 — 무시목록은 정확도 문제이지 중단 사유가 아니다.
+func ensureSemgrepIgnore(targetDir string) error {
+	p := filepath.Join(targetDir, ".semgrepignore")
+	if _, err := os.Stat(p); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	return os.WriteFile(p, []byte(semgrepIgnoreBody), 0o644)
+}
+
 func (c CLI) Scan(ctx context.Context, rulesPath, targetDir string) ([]Finding, error) {
 	bin := c.Bin
 	if bin == "" {
 		bin = "semgrep"
+	}
+	if err := ensureSemgrepIgnore(targetDir); err != nil {
+		// 경로·라인만 남기는 로깅 규약상 여기서는 조용히 진행한다.
+		_ = err
 	}
 	cmd := exec.CommandContext(ctx, bin, scanArgs(rulesPath, targetDir, DefaultExcludes)...)
 	var stdout, stderr bytes.Buffer

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -49,16 +49,20 @@ const semgrepIgnoreBody = `# finguard 가 생성한 파일 (#25).
 # 제외 경로는 finguard 의 --exclude 와 .finguard.yml 의 ignore 가 담당한다.
 `
 
-// ensureSemgrepIgnore 는 대상 루트에 `.semgrepignore` 가 없을 때만 생성한다.
+// ensureSemgrepIgnore 는 대상 루트에 `.semgrepignore` 가 없을 때만 생성하고,
+// 자기가 만들었는지를 돌려준다(호출부가 스캔 후 되돌리기 위함).
 // 실패해도 스캔 자체는 계속한다 — 무시목록은 정확도 문제이지 중단 사유가 아니다.
-func ensureSemgrepIgnore(targetDir string) error {
+func ensureSemgrepIgnore(targetDir string) (created bool, err error) {
 	p := filepath.Join(targetDir, ".semgrepignore")
 	if _, err := os.Stat(p); err == nil {
-		return nil
+		return false, nil // 레포가 자기 것을 갖고 있다 — 그 의도를 존중한다
 	} else if !os.IsNotExist(err) {
-		return err
+		return false, err
 	}
-	return os.WriteFile(p, []byte(semgrepIgnoreBody), 0o644)
+	if err := os.WriteFile(p, []byte(semgrepIgnoreBody), 0o644); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (c CLI) Scan(ctx context.Context, rulesPath, targetDir string) ([]Finding, error) {
@@ -66,9 +70,16 @@ func (c CLI) Scan(ctx context.Context, rulesPath, targetDir string) ([]Finding, 
 	if bin == "" {
 		bin = "semgrep"
 	}
-	if err := ensureSemgrepIgnore(targetDir); err != nil {
+	// 우리가 심은 경우에만 스캔 후 되돌린다. `scan --dir=<작업 사본>` 로 자기 레포를
+	// 점검하는 로컬 모드에서 잔여물이 남으면 사용자가 의도치 않게 커밋하게 된다.
+	// finguard 는 점검 도구이지 대상 레포를 바꾸는 도구가 아니다.
+	created, err := ensureSemgrepIgnore(targetDir)
+	if err != nil {
 		// 경로·라인만 남기는 로깅 규약상 여기서는 조용히 진행한다.
 		_ = err
+	}
+	if created {
+		defer func() { _ = os.Remove(filepath.Join(targetDir, ".semgrepignore")) }()
 	}
 	cmd := exec.CommandContext(ctx, bin, scanArgs(rulesPath, targetDir, DefaultExcludes)...)
 	var stdout, stderr bytes.Buffer

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -1,6 +1,8 @@
 package scanner
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -78,4 +80,47 @@ func countOf(ss []string, s string) int {
 		}
 	}
 	return n
+}
+
+// semgrep 내장 기본 무시목록이 test/·tests/·*_test.go 를 통째로 지우는 문제 때문에
+// 스캔 대상 루트에 .semgrepignore 를 심는다 (#25).
+func TestEnsureSemgrepIgnore(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := ensureSemgrepIgnore(dir); err != nil {
+		t.Fatalf("생성 실패: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, ".semgrepignore"))
+	if err != nil {
+		t.Fatalf(".semgrepignore 가 생성되지 않았다: %v", err)
+	}
+	if !strings.Contains(string(got), "finguard") {
+		t.Errorf("finguard 가 생성했다는 표시가 없다: %q", string(got))
+	}
+	// 아무 경로도 무시하지 않아야 한다 — 제외 정책은 --exclude 와 .finguard.yml 소관이다.
+	for _, line := range strings.Split(string(got), "\n") {
+		s := strings.TrimSpace(line)
+		if s != "" && !strings.HasPrefix(s, "#") {
+			t.Errorf("무시 패턴이 들어 있다: %q", s)
+		}
+	}
+}
+
+// 레포가 자기 .semgrepignore 를 갖고 있으면 그쪽 의도를 존중해 덮어쓰지 않는다.
+func TestEnsureSemgrepIgnoreKeepsExisting(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, ".semgrepignore")
+	if err := os.WriteFile(p, []byte("generated/\n"), 0o644); err != nil {
+		t.Fatalf("사전 준비 실패: %v", err)
+	}
+	if err := ensureSemgrepIgnore(dir); err != nil {
+		t.Fatalf("실행 실패: %v", err)
+	}
+	got, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("읽기 실패: %v", err)
+	}
+	if string(got) != "generated/\n" {
+		t.Errorf("레포의 기존 .semgrepignore 를 덮어썼다: %q", string(got))
+	}
 }

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -87,8 +87,12 @@ func countOf(ss []string, s string) int {
 func TestEnsureSemgrepIgnore(t *testing.T) {
 	dir := t.TempDir()
 
-	if err := ensureSemgrepIgnore(dir); err != nil {
+	created, err := ensureSemgrepIgnore(dir)
+	if err != nil {
 		t.Fatalf("생성 실패: %v", err)
+	}
+	if !created {
+		t.Error("우리가 생성했는데 created=false 다 — 호출부가 스캔 후 되돌리지 못한다")
 	}
 	got, err := os.ReadFile(filepath.Join(dir, ".semgrepignore"))
 	if err != nil {
@@ -113,8 +117,12 @@ func TestEnsureSemgrepIgnoreKeepsExisting(t *testing.T) {
 	if err := os.WriteFile(p, []byte("generated/\n"), 0o644); err != nil {
 		t.Fatalf("사전 준비 실패: %v", err)
 	}
-	if err := ensureSemgrepIgnore(dir); err != nil {
+	created, err := ensureSemgrepIgnore(dir)
+	if err != nil {
 		t.Fatalf("실행 실패: %v", err)
+	}
+	if created {
+		t.Error("레포의 기존 파일인데 created=true 다 — 호출부가 남의 파일을 지우게 된다")
 	}
 	got, err := os.ReadFile(p)
 	if err != nil {

--- a/mapping/rules.yaml
+++ b/mapping/rules.yaml
@@ -1722,3 +1722,96 @@
     if (!ALLOW_HOSTS.includes(u.hostname)) throw new Error("blocked host");
     await prisma.payment_histories.update({ data: { webhook_url: u.href }, where });
     ```
+
+- rule_id: finguard.java.hardcoded-secret-test
+  code: FIN-KEY-011
+  cwe: CWE-798
+  title: 테스트 코드에 하드코드된 중요정보(Java)
+  severity: ERROR
+  basis: 개발보안가이드 「보안기능 - 하드코드된 중요정보」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 43 (앱 소스코드 내 운영정보 노출 방지), 23 (고정된 인증정보 이용 방지)"
+  explain: 테스트 코드에 비밀번호·API 키·토큰이 문자열로 하드코드되어 있습니다. 파일명이 테스트라는 사실은 값이 더미라는 근거가 아니며, 저장소와 git 히스토리에 남은 자격증명은 운영 코드의 하드코드와 위험이 동일합니다. 값의 형태(길이·문자 구성)가 실제 자격증명으로 보이는 경우만 검출합니다.
+  fix_example: |
+    ```java
+    // 테스트도 환경변수·테스트 전용 시크릿 저장소에서 주입받는다.
+    String apiKey = System.getenv("TEST_API_KEY");
+    Assumptions.assumeTrue(apiKey != null, "TEST_API_KEY 미설정");
+    ```
+
+- rule_id: finguard.kotlin.hardcoded-secret-test
+  code: FIN-KEY-012
+  cwe: CWE-798
+  title: 테스트 코드에 하드코드된 중요정보(Kotlin)
+  severity: ERROR
+  basis: 개발보안가이드 「보안기능 - 하드코드된 중요정보」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 43 (앱 소스코드 내 운영정보 노출 방지), 23 (고정된 인증정보 이용 방지)"
+  explain: 테스트 코드에 비밀번호·API 키·토큰이 문자열로 하드코드되어 있습니다. 파일명이 테스트라는 사실은 값이 더미라는 근거가 아니며, 저장소와 git 히스토리에 남은 자격증명은 운영 코드의 하드코드와 위험이 동일합니다. 값의 형태(길이·문자 구성)가 실제 자격증명으로 보이는 경우만 검출합니다.
+  fix_example: |
+    ```kotlin
+    // 테스트도 환경변수·테스트 전용 시크릿 저장소에서 주입받는다.
+    val apiKey = System.getenv("TEST_API_KEY") ?: return
+    ```
+
+- rule_id: finguard.go.hardcoded-secret-test
+  code: FIN-KEY-013
+  cwe: CWE-798
+  title: 테스트 코드에 하드코드된 중요정보(Go)
+  severity: ERROR
+  basis: 개발보안가이드 「보안기능 - 하드코드된 중요정보」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 43 (앱 소스코드 내 운영정보 노출 방지), 23 (고정된 인증정보 이용 방지)"
+  explain: 테스트 코드에 비밀번호·API 키·토큰이 문자열로 하드코드되어 있습니다. 파일명이 테스트라는 사실은 값이 더미라는 근거가 아니며, 저장소와 git 히스토리에 남은 자격증명은 운영 코드의 하드코드와 위험이 동일합니다. 값의 형태(길이·문자 구성)가 실제 자격증명으로 보이는 경우만 검출합니다.
+  fix_example: |
+    ```go
+    apiKey := os.Getenv("TEST_API_KEY")
+    if apiKey == "" {
+        t.Skip("TEST_API_KEY 미설정")
+    }
+    ```
+
+- rule_id: finguard.python.hardcoded-secret-test
+  code: FIN-KEY-014
+  cwe: CWE-798
+  title: 테스트 코드에 하드코드된 중요정보(Python)
+  severity: ERROR
+  basis: 개발보안가이드 「보안기능 - 하드코드된 중요정보」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 43 (앱 소스코드 내 운영정보 노출 방지), 23 (고정된 인증정보 이용 방지)"
+  explain: 테스트 코드에 비밀번호·API 키·토큰이 문자열로 하드코드되어 있습니다. 파일명이 테스트라는 사실은 값이 더미라는 근거가 아니며, 저장소와 git 히스토리에 남은 자격증명은 운영 코드의 하드코드와 위험이 동일합니다. 값의 형태(길이·문자 구성)가 실제 자격증명으로 보이는 경우만 검출합니다.
+  fix_example: |
+    ```python
+    import os
+    import pytest
+
+    API_KEY = os.environ.get("TEST_API_KEY")
+    pytestmark = pytest.mark.skipif(not API_KEY, reason="TEST_API_KEY 미설정")
+    ```
+
+- rule_id: finguard.config.plaintext-secret-nonprod
+  code: FIN-KEY-015
+  cwe: CWE-798
+  title: 로컬·테스트 프로파일 설정의 평문 시크릿
+  severity: WARNING
+  basis: 개발보안가이드 「보안기능 - 하드코드된 중요정보」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 43 (앱 소스코드 내 운영정보 노출 방지)"
+  explain: 로컬·개발·테스트 프로파일 설정파일에 시크릿으로 보이는 값이 평문으로 들어 있습니다. 이 구간은 더미가 지배적이라 WARNING 으로 두지만, 운영 값을 복사해 둔 경우라면 즉시 제거하고 회전해야 합니다. 차단이 필요하면 .finguard.yml 의 block_on 에 WARNING 을 추가하십시오.
+  fix_example: |
+    ```yaml
+    # 로컬 프로파일도 값을 직접 쓰지 말고 환경변수로 치환한다.
+    auth:
+      jwt:
+        secret-key: ${LOCAL_JWT_SECRET}
+    ```
+
+- rule_id: finguard.config.plaintext-secret-vendorkey
+  code: FIN-KEY-016
+  cwe: CWE-798
+  title: 설정파일의 외부 서비스 실발급 키(벤더 프리픽스)
+  severity: ERROR
+  basis: 개발보안가이드 「보안기능 - 하드코드된 중요정보」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 43 (앱 소스코드 내 운영정보 노출 방지)"
+  explain: 값이 외부 서비스의 발급 키 형식(벤더 프리픽스)과 일치합니다. 로컬·테스트 프로파일에 들어 있더라도 실제로 유효한 자격증명일 가능성이 높아 파일 위치와 무관하게 차단 대상입니다. 즉시 제거하고 해당 서비스 콘솔에서 키를 회전해야 합니다.
+  fix_example: |
+    ```yaml
+    # 발급 키는 어떤 프로파일에서도 파일에 두지 않는다.
+    toss:
+      secret-key: ${TOSS_SECRET_KEY}
+    ```

--- a/rules/config.yaml
+++ b/rules/config.yaml
@@ -44,6 +44,21 @@ rules:
         - ".env.example"
         - ".env.sample"
         - ".env.template"
+        # 로컬·개발·테스트 프로파일 설정은 finguard.config.plaintext-secret-nonprod(WARNING)
+        # 담당이다 (#25). 이 목록과 그 룰의 include 는 정확히 상호배타여야 한다 —
+        # 겹치면 같은 줄에 ERROR·WARNING 코멘트가 중복으로 달린다.
+        - "application*-local.yml"
+        - "application*-local.yaml"
+        - "application*-local.properties"
+        - "application*-test.yml"
+        - "application*-test.yaml"
+        - "application*-test.properties"
+        - "application*-dev.yml"
+        - "application*-dev.yaml"
+        - "application*-dev.properties"
+        - ".env.local"
+        - ".env.development"
+        - ".env.test"
         # CI 설정은 finguard.ci.plaintext-secret(WARNING) 담당
         - ".github/workflows/**"
         - "**/.github/workflows/**"
@@ -213,3 +228,97 @@ rules:
     pattern-either:
       - pattern-regex: '(?im)^[ \t]*(?:logging\.level\.)?[\w.$*-]*(?:pay(?:ment)?|pg|toss|inicis|kcp|nice|kftc|openbanking|card|auth|security|jdbc|sql)[\w.$*-]*[ \t]*[:=][ \t]*["'']?(?i:debug|trace)["'']?[ \t]*$'
       - pattern-regex: '(?is)<logger[^>]*name\s*=\s*"[^"]*(?:pay(?:ment)?|pg|toss|inicis|kcp|nice|kftc|openbanking|card|auth|security|jdbc|sql)[^"]*"[^>]*level\s*=\s*"(?i:debug|trace)"'
+
+  # 로컬·개발·테스트 프로파일 설정파일 (#25).
+  #
+  # 여기가 실제로 더미가 지배적인 유일한 구간이라 severity 를 WARNING 으로 낮춘다.
+  # 기본 게이트(FINGUARD_BLOCK_ON=ERROR)로는 머지를 막지 않지만 코멘트는 그대로 달린다 —
+  # 차단이 필요한 팀은 .finguard.yml 의 block_on 을 [ERROR, WARNING] 으로 올리면 된다.
+  # 반대로 값이 고신뢰 벤더 프리픽스면 아래 finguard.config.plaintext-secret-vendorkey 가
+  # ERROR 로 승격해 잡는다(두 룰은 pattern-not-regex 로 상호배타).
+  #
+  # include 는 finguard.config.plaintext-secret 의 exclude 와 정확히 상호배타다.
+  - id: finguard.config.plaintext-secret-nonprod
+    languages: [regex]
+    severity: WARNING
+    message: 로컬·테스트 프로파일 설정에 시크릿으로 보이는 값이 평문으로 들어 있습니다. 더미라면 무시해도 되지만, 운영 값을 복사해 둔 것이라면 즉시 제거·회전해야 합니다.
+    paths:
+      include:
+        - "application*-local.yml"
+        - "application*-local.yaml"
+        - "application*-local.properties"
+        - "application*-test.yml"
+        - "application*-test.yaml"
+        - "application*-test.properties"
+        - "application*-dev.yml"
+        - "application*-dev.yaml"
+        - "application*-dev.properties"
+        - ".env.local"
+        - ".env.development"
+        - ".env.test"
+        - "*.sample"
+        - "*.example"
+      exclude:
+        - "**/node_modules/**"
+        - "**/vendor/**"
+        - "Pods/**"
+        - "**/*.lock"
+        - "**/package-lock.json"
+        - ".github/workflows/**"
+        - "**/.github/workflows/**"
+        - ".gitlab-ci*.yml"
+        - "**/.gitlab-ci*.yml"
+        - "*gitlab-ci*.yml"
+        - ".circleci/**"
+        - "**/.circleci/**"
+    patterns:
+      - pattern-regex: '(?i)^[ \t]*["'']?[\w.-]*(password|passwd|pwd|secret|api[_-]?key|token|credential|passphrase|private[_-]?key|signing[_-]?key|encrypt(?:ion)?[_-]?key|master[_-]?key|aes[_-]?key|hmac[_-]?key)[\w.-]*["'']?[ \t]*[:=][ \t]*(?![ \t]*$)(?!\$\{)(?!ENC\()["'']?(?=[0-9]{12,}|[A-Za-z0-9+/=_.\-]{16,}|(?=[^\s"''#]{12,})(?=[^\s"''#]*[A-Za-z])(?=[^\s"''#]*[0-9]))(?!https?://)(?!jdbc:)[^\s"''#][^#\n]{3,}'
+      # 고신뢰 벤더 프리픽스는 vendorkey 룰(ERROR) 담당 — 중복 코멘트 방지
+      - pattern-not-regex: '(?i)^[ \t]*["'']?[\w.-]+["'']?[ \t]*[:=][ \t]*["'']?(?:sk_live_|sk_test_|rk_live_|pk_live_|test_sk_|live_sk_|imp_|ghp_|gho_|github_pat_|xoxb-|xoxp-|AKIA|AIza)[A-Za-z0-9_\-]{8,}'
+      - pattern-not-regex: '(?i)["''`](\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|<[^>]*redact[^>]*>|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]|[:=]\s*(\*{3,}|•{3,}|#{3,})(?![\w-])'
+      - pattern-not-regex: '(?im)^[ \t]*(?:export[ \t]+)?(-[ \t]+)?["'']?[\w.-]+["'']?[ \t]*[:=][ \t]*["''`]?(\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]?[ \t]*[,;)]*[ \t]*(?:#.*|//.*)?$'
+      - pattern-not-regex: '(?im)^[^\n]*[:=][ \t]*["''`]?[^"''`\n]*(입력[ \t]*(?:하세요|해[ \t]*주세요|해주세요|바랍니다|하십시오)|여기에?[ \t]*입력|발급[ \t]*받은|본인의|자신의|예시|샘플)[^\n]*$'
+      - pattern-not-regex: '(?m)^[ \t]*["'']?[\w.-]+["'']?[ \t]*[:=][ \t]*["'']?(?:[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)["'']?[ \t]*(?:#.*)?$'
+      - pattern-not-regex: '(?im)^\s*["'']?[\w.-]+["'']?\s*[:=]\s*["'']?(true|false|null|none|nil|yes|no|on|off|required|optional|string|integer|boolean|object|array|number)["'']?\s*(#.*)?$'
+      - pattern-not-regex: '(?im)^\s*["'']?[\w.-]+["'']?\s*[:=]\s*["'']?(\$|\{\{|<%|%\(|env:|secretKeyRef|valueFrom|vault:|aws:|arn:).*$'
+      - pattern-not-regex: '(?im)^\s*[\w.-]+\s*:=.*$'
+      - pattern-not-regex: '(?im)^\s*["'']?[\w.-]+["'']?\s*[:=]\s*[\w.]+[(\[].*$'
+
+  # 로컬·테스트 프로파일이라도 값이 고신뢰 벤더 프리픽스면 실제로 유효한 키다 (#25).
+  # 파일명으로 severity 를 깎으면 이 구간이 게이트를 통과해 버리므로 ERROR 로 승격한다.
+  - id: finguard.config.plaintext-secret-vendorkey
+    languages: [regex]
+    severity: ERROR
+    message: 설정파일에 외부 서비스의 실제 발급 키(벤더 프리픽스 확인)가 평문으로 들어 있습니다. 로컬·테스트 프로파일이라도 유효한 자격증명이므로 즉시 제거하고 회전해야 합니다.
+    paths:
+      include:
+        - "application*-local.yml"
+        - "application*-local.yaml"
+        - "application*-local.properties"
+        - "application*-test.yml"
+        - "application*-test.yaml"
+        - "application*-test.properties"
+        - "application*-dev.yml"
+        - "application*-dev.yaml"
+        - "application*-dev.properties"
+        - ".env.local"
+        - ".env.development"
+        - ".env.test"
+        - "*.sample"
+        - "*.example"
+      exclude:
+        - "**/node_modules/**"
+        - "**/vendor/**"
+        - "Pods/**"
+        - "**/*.lock"
+        - "**/package-lock.json"
+        - ".github/workflows/**"
+        - "**/.github/workflows/**"
+        - ".gitlab-ci*.yml"
+        - "**/.gitlab-ci*.yml"
+        - "*gitlab-ci*.yml"
+        - ".circleci/**"
+        - "**/.circleci/**"
+    patterns:
+      - pattern-regex: '(?i)^[ \t]*["'']?[\w.-]+["'']?[ \t]*[:=][ \t]*["'']?(?:sk_live_|sk_test_|rk_live_|pk_live_|test_sk_|live_sk_|imp_|ghp_|gho_|github_pat_|xoxb-|xoxp-|AKIA|AIza)[A-Za-z0-9_\-]{8,}'
+      - pattern-not-regex: '(?im)^\s*["'']?[\w.-]+["'']?\s*[:=]\s*["'']?(\$|\{\{|<%|%\(|env:|secretKeyRef|valueFrom|vault:).*$'

--- a/rules/go.yaml
+++ b/rules/go.yaml
@@ -379,3 +379,26 @@ rules:
             - pattern: <... rand.Uint64(...) ...>
             - pattern: <... rand.Float64(...) ...>
             - pattern: <... rand.Perm(...) ...>
+
+  # 테스트 코드에 복붙된 실키를 파일명으로 영원히 가리던 blanket exclude 를 걷어낸다 (#25).
+  #
+  #   - paths.include 는 기존 ERROR 룰의 exclude 와 **정확히 상호배타** 다. 같은 파일이 두 룰에
+  #     걸려 ERROR + WARNING 코멘트가 중복으로 달리지 않게 한다.
+  #   - severity 는 ERROR 를 유지한다. 파일명은 "운영 시크릿인가" 의 판정 근거가 아니고,
+  #     테스트 파일에 박힌 실키는 git 히스토리 노출 관점에서 운영 코드의 하드코드와 위험이 같다
+  #     (평가기준 43·23).
+  #   - 대신 값의 "시크릿다움" 게이트로 노이즈를 거른다. 게이트는 AND 가 아니라 **OR** 다 —
+  #     이슈 원안의 AND 게이트 `(?=[^"]*[A-Za-z])(?=[^"]*[0-9])[A-Za-z0-9+/=_.-]{20,}` 는
+  #     이 이슈의 헤드라인 증거인 16자리 **숫자** API 키를 스스로 못 잡는다(영문 없음·20자 미만).
+  #     순숫자 12자 이상 | base64/hex 계열 16자 이상 | 12자 이상 영문+숫자 혼합 중 하나면 통과.
+  - id: finguard.go.hardcoded-secret-test
+    languages: [regex]
+    severity: ERROR
+    message: 테스트 코드에 비밀정보(비밀번호·API 키·토큰)가 하드코드되어 있습니다. 저장소와 git 히스토리에 그대로 남으므로 운영 코드와 동일하게 제거·회전해야 합니다.
+    paths:
+      include: ["*_test.go"]
+    patterns:
+      - pattern-regex: '(?i)\b\w*(password|passwd|pwd|secret|api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|credential|passphrase|private[_-]?key|signing[_-]?key|encrypt(?:ion)?[_-]?key|master[_-]?key|aes[_-]?key|hmac[_-]?key)\w*\s*(:?=)\s*"(?=[0-9]{12,}|[A-Za-z0-9+/=_.\-]{16,}|(?=[^"]{12,})(?=[^"]*[A-Za-z])(?=[^"]*[0-9]))(?!https?://)(?!jdbc:)(?!(?-i:[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)")(?!(?-i:[a-z]+(?:_[a-z]+)+)")[^"%/][^"]{7,}"'
+      - pattern-not-regex: '(?i)["''`](\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|<[^>]*redact[^>]*>|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]|[:=]\s*(\*{3,}|•{3,}|#{3,})(?![\w-])'
+      - pattern-not-regex: '(?im)^[ \t]*(?:export[ \t]+)?(-[ \t]+)?["'']?[\w.-]+["'']?[ \t]*[:=][ \t]*["''`]?(\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]?[ \t]*[,;)]*[ \t]*(?:#.*|//.*)?$'
+      - pattern-not-regex: '(?im)^[^\n]*[:=][ \t]*["''`]?[^"''`\n]*(입력[ \t]*(?:하세요|해[ \t]*주세요|해주세요|바랍니다|하십시오)|여기에?[ \t]*입력|발급[ \t]*받은|본인의|자신의|예시|샘플)[^\n]*$'

--- a/rules/java.yaml
+++ b/rules/java.yaml
@@ -652,3 +652,26 @@ rules:
       # org.apache.http.wire 로거를 *끄는* 설정은 오히려 수정된 코드다.
       # pattern-not-regex 는 검출 범위를 포함할 때만 억제되므로 줄 전체를 잡는다.
       - pattern-not-regex: '(?im)^.*org\.apache\.http\.wire.*\b(?:OFF|ERROR|WARN|NONE|BASIC)\b.*$'
+
+  # 테스트 코드에 복붙된 실키를 파일명으로 영원히 가리던 blanket exclude 를 걷어낸다 (#25).
+  #
+  #   - paths.include 는 기존 ERROR 룰의 exclude 와 **정확히 상호배타** 다. 같은 파일이 두 룰에
+  #     걸려 ERROR + WARNING 코멘트가 중복으로 달리지 않게 한다.
+  #   - severity 는 ERROR 를 유지한다. 파일명은 "운영 시크릿인가" 의 판정 근거가 아니고,
+  #     테스트 파일에 박힌 실키는 git 히스토리 노출 관점에서 운영 코드의 하드코드와 위험이 같다
+  #     (평가기준 43·23).
+  #   - 대신 값의 "시크릿다움" 게이트로 노이즈를 거른다. 게이트는 AND 가 아니라 **OR** 다 —
+  #     이슈 원안의 AND 게이트 `(?=[^"]*[A-Za-z])(?=[^"]*[0-9])[A-Za-z0-9+/=_.-]{20,}` 는
+  #     이 이슈의 헤드라인 증거인 16자리 **숫자** API 키를 스스로 못 잡는다(영문 없음·20자 미만).
+  #     순숫자 12자 이상 | base64/hex 계열 16자 이상 | 12자 이상 영문+숫자 혼합 중 하나면 통과.
+  - id: finguard.java.hardcoded-secret-test
+    languages: [regex]
+    severity: ERROR
+    message: 테스트 코드에 비밀정보(비밀번호·API 키·토큰)가 하드코드되어 있습니다. 저장소와 git 히스토리에 그대로 남으므로 운영 코드와 동일하게 제거·회전해야 합니다.
+    paths:
+      include: ["*Test.java"]
+    patterns:
+      - pattern-regex: '(?i)String\s+\w*(password|passwd|pwd|secret|api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|credential|passphrase|private[_-]?key|signing[_-]?key|encrypt(?:ion)?[_-]?key|master[_-]?key|aes[_-]?key|hmac[_-]?key)\w*\s*=\s*"(?=[0-9]{12,}|[A-Za-z0-9+/=_.\-]{16,}|(?=[^"]{12,})(?=[^"]*[A-Za-z])(?=[^"]*[0-9]))(?!https?://)(?!jdbc:)(?!(?-i:[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)")(?!(?-i:[a-z]+(?:_[a-z]+)+)")[^"]{4,}"'
+      - pattern-not-regex: '(?i)["''`](\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|<[^>]*redact[^>]*>|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]|[:=]\s*(\*{3,}|•{3,}|#{3,})(?![\w-])'
+      - pattern-not-regex: '(?im)^[ \t]*(?:export[ \t]+)?(-[ \t]+)?["'']?[\w.-]+["'']?[ \t]*[:=][ \t]*["''`]?(\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]?[ \t]*[,;)]*[ \t]*(?:#.*|//.*)?$'
+      - pattern-not-regex: '(?im)^[^\n]*[:=][ \t]*["''`]?[^"''`\n]*(입력[ \t]*(?:하세요|해[ \t]*주세요|해주세요|바랍니다|하십시오)|여기에?[ \t]*입력|발급[ \t]*받은|본인의|자신의|예시|샘플)[^\n]*$'

--- a/rules/kotlin.yaml
+++ b/rules/kotlin.yaml
@@ -344,3 +344,26 @@ rules:
     pattern-sinks:
       - pattern: $RESP.sendRedirect(...)
       - pattern: RedirectView(...)
+
+  # 테스트 코드에 복붙된 실키를 파일명으로 영원히 가리던 blanket exclude 를 걷어낸다 (#25).
+  #
+  #   - paths.include 는 기존 ERROR 룰의 exclude 와 **정확히 상호배타** 다. 같은 파일이 두 룰에
+  #     걸려 ERROR + WARNING 코멘트가 중복으로 달리지 않게 한다.
+  #   - severity 는 ERROR 를 유지한다. 파일명은 "운영 시크릿인가" 의 판정 근거가 아니고,
+  #     테스트 파일에 박힌 실키는 git 히스토리 노출 관점에서 운영 코드의 하드코드와 위험이 같다
+  #     (평가기준 43·23).
+  #   - 대신 값의 "시크릿다움" 게이트로 노이즈를 거른다. 게이트는 AND 가 아니라 **OR** 다 —
+  #     이슈 원안의 AND 게이트 `(?=[^"]*[A-Za-z])(?=[^"]*[0-9])[A-Za-z0-9+/=_.-]{20,}` 는
+  #     이 이슈의 헤드라인 증거인 16자리 **숫자** API 키를 스스로 못 잡는다(영문 없음·20자 미만).
+  #     순숫자 12자 이상 | base64/hex 계열 16자 이상 | 12자 이상 영문+숫자 혼합 중 하나면 통과.
+  - id: finguard.kotlin.hardcoded-secret-test
+    languages: [regex]
+    severity: ERROR
+    message: 테스트 코드에 비밀정보(비밀번호·API 키·토큰)가 하드코드되어 있습니다. 저장소와 git 히스토리에 그대로 남으므로 운영 코드와 동일하게 제거·회전해야 합니다.
+    paths:
+      include: ["*Test.kt", "*Test.kts"]
+    patterns:
+      - pattern-regex: '(?im)^\s*(?:private\s+|internal\s+|public\s+|protected\s+)?(?:const\s+)?(?:val|var)\s+\w*(?:password|passwd|pwd|secret|api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|credential|passphrase|private[_-]?key|signing[_-]?key|encrypt(?:ion)?[_-]?key|master[_-]?key|aes[_-]?key|hmac[_-]?key)\w*\s*(?::\s*[\w<>?.]+)?\s*=\s*"(?=[0-9]{12,}|[A-Za-z0-9+/=_.\-]{16,}|(?=[^"]{12,})(?=[^"]*[A-Za-z])(?=[^"]*[0-9]))(?!https?://)(?!jdbc:)(?!(?-i:[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)")(?!(?-i:[a-z]+(?:_[a-z]+)+)")[^"]{8,}"'
+      - pattern-not-regex: '(?i)["''`](\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|<[^>]*redact[^>]*>|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]|[:=]\s*(\*{3,}|•{3,}|#{3,})(?![\w-])'
+      - pattern-not-regex: '(?im)^[ \t]*(?:export[ \t]+)?(-[ \t]+)?["'']?[\w.-]+["'']?[ \t]*[:=][ \t]*["''`]?(\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]?[ \t]*[,;)]*[ \t]*(?:#.*|//.*)?$'
+      - pattern-not-regex: '(?im)^[^\n]*[:=][ \t]*["''`]?[^"''`\n]*(입력[ \t]*(?:하세요|해[ \t]*주세요|해주세요|바랍니다|하십시오)|여기에?[ \t]*입력|발급[ \t]*받은|본인의|자신의|예시|샘플)[^\n]*$'

--- a/rules/python.yaml
+++ b/rules/python.yaml
@@ -301,3 +301,26 @@ rules:
               ...
               os.open(..., 0o600)
               ...
+
+  # 테스트 코드에 복붙된 실키를 파일명으로 영원히 가리던 blanket exclude 를 걷어낸다 (#25).
+  #
+  #   - paths.include 는 기존 ERROR 룰의 exclude 와 **정확히 상호배타** 다. 같은 파일이 두 룰에
+  #     걸려 ERROR + WARNING 코멘트가 중복으로 달리지 않게 한다.
+  #   - severity 는 ERROR 를 유지한다. 파일명은 "운영 시크릿인가" 의 판정 근거가 아니고,
+  #     테스트 파일에 박힌 실키는 git 히스토리 노출 관점에서 운영 코드의 하드코드와 위험이 같다
+  #     (평가기준 43·23).
+  #   - 대신 값의 "시크릿다움" 게이트로 노이즈를 거른다. 게이트는 AND 가 아니라 **OR** 다 —
+  #     이슈 원안의 AND 게이트 `(?=[^"]*[A-Za-z])(?=[^"]*[0-9])[A-Za-z0-9+/=_.-]{20,}` 는
+  #     이 이슈의 헤드라인 증거인 16자리 **숫자** API 키를 스스로 못 잡는다(영문 없음·20자 미만).
+  #     순숫자 12자 이상 | base64/hex 계열 16자 이상 | 12자 이상 영문+숫자 혼합 중 하나면 통과.
+  - id: finguard.python.hardcoded-secret-test
+    languages: [regex]
+    severity: ERROR
+    message: 테스트 코드에 비밀정보(비밀번호·API 키·토큰)가 하드코드되어 있습니다. 저장소와 git 히스토리에 그대로 남으므로 운영 코드와 동일하게 제거·회전해야 합니다.
+    paths:
+      include: ["test_*.py", "*_test.py", "conftest.py"]
+    patterns:
+      - pattern-regex: '(?i)\b\w*(password|passwd|pwd|secret|api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|credential|passphrase|private[_-]?key|signing[_-]?key|encrypt(?:ion)?[_-]?key|master[_-]?key|aes[_-]?key|hmac[_-]?key)\w*\s*=\s*(?:"(?=[0-9]{12,}|[A-Za-z0-9+/=_.\-]{16,}|(?=[^"]{12,})(?=[^"]*[A-Za-z])(?=[^"]*[0-9]))(?!https?://)(?!jdbc:)(?!(?-i:[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)")(?!(?-i:[a-z]+(?:_[a-z]+)+)")[^"%/{][^"]{7,}"|''(?=[0-9]{12,}|[A-Za-z0-9+/=_.\-]{16,}|(?=[^'']{12,})(?=[^'']*[A-Za-z])(?=[^'']*[0-9]))(?!https?://)(?!jdbc:)(?![A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+'')(?![a-z]+(?:_[a-z]+)+'')[^''%/{][^'']{7,}'')'
+      - pattern-not-regex: '(?i)["''`](\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|<[^>]*redact[^>]*>|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]|[:=]\s*(\*{3,}|•{3,}|#{3,})(?![\w-])'
+      - pattern-not-regex: '(?im)^[ \t]*(?:export[ \t]+)?(-[ \t]+)?["'']?[\w.-]+["'']?[ \t]*[:=][ \t]*["''`]?(\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]?[ \t]*[,;)]*[ \t]*(?:#.*|//.*)?$'
+      - pattern-not-regex: '(?im)^[^\n]*[:=][ \t]*["''`]?[^"''`\n]*(입력[ \t]*(?:하세요|해[ \t]*주세요|해주세요|바랍니다|하십시오)|여기에?[ \t]*입력|발급[ \t]*받은|본인의|자신의|예시|샘플)[^\n]*$'

--- a/testdata/rule-fixtures/.semgrepignore
+++ b/testdata/rule-fixtures/.semgrepignore
@@ -1,0 +1,3 @@
+# finguard 가 생성한 파일 (#25).
+# semgrep 내장 기본 무시목록(test/·tests/·*_test.go 포함)을 대체한다.
+# 제외 경로는 finguard 의 --exclude 와 .finguard.yml 의 ignore 가 담당한다.

--- a/testdata/rule-fixtures/SecretNonprodTest.java
+++ b/testdata/rule-fixtures/SecretNonprodTest.java
@@ -1,0 +1,27 @@
+// 룰 회귀 픽스처 — finguard.java.hardcoded-secret-test (#25).
+// 파일명이 *Test.java 라는 이유로 blanket exclude 되던 구간이다. 값의 "시크릿다움"
+// 게이트로 노이즈만 거르고 실키 형태는 ERROR 로 잡는다. 값은 전부 합성 더미다.
+public class SecretNonprodTest {
+
+    // 이슈 #25 의 헤드라인 증거 형태 — 16자리 "숫자" API 키.
+    // 원안의 AND 게이트(영문 AND 숫자 AND 20자 이상)는 이 값을 못 잡았다.
+    // EXPECT: finguard.java.hardcoded-secret-test
+    String apiKey = "1234567890123456";
+
+    // 순영문 패스프레이즈 — 원안 게이트는 숫자가 없어 못 잡는다.
+    // EXPECT: finguard.java.hardcoded-secret-test
+    String password = "correcthorsebatterystaple";
+
+    // 특수문자 포함 — 원안 게이트는 허용 문자군 밖이라 못 잡는다.
+    // EXPECT: finguard.java.hardcoded-secret-test
+    String dbPassword = "Pa$$w0rd!ProdBank";
+
+    // 80자 랜덤 시크릿
+    // EXPECT: finguard.java.hardcoded-secret-test
+    String apiSecret = "9c1f4a7e2b8d06531fa4c7e90b2d5638a1c4f7e0b3d6592c8f1a4e7b0d3c6592f8a1b4e7c0d3f6a92";
+
+    // 게이트에서 걸러지는 값들 — 짧은 더미·상수명·플레이스홀더는 잡지 않는다.
+    String testPassword = "test1234";
+    String apiKeyName = "PAYMENT_API_KEY";
+    String secretPlaceholder = "changeme";
+}

--- a/testdata/rule-fixtures/SecretNonprodTest.kt
+++ b/testdata/rule-fixtures/SecretNonprodTest.kt
@@ -1,0 +1,15 @@
+// 룰 회귀 픽스처 — finguard.kotlin.hardcoded-secret-test (#25). 값은 전부 합성 더미다.
+object SecretNonprodTest {
+
+    // EXPECT: finguard.kotlin.hardcoded-secret-test
+    val apiKey = "1234567890123456"
+
+    // EXPECT: finguard.kotlin.hardcoded-secret-test
+    val password = "correcthorsebatterystaple"
+
+    // EXPECT: finguard.kotlin.hardcoded-secret-test
+    private val dbPassword = "Pa\$\$w0rd!ProdBank"
+
+    // 게이트에서 걸러지는 값 — 짧은 더미는 잡지 않는다.
+    val testPassword = "test1234"
+}

--- a/testdata/rule-fixtures/application-local.yml
+++ b/testdata/rule-fixtures/application-local.yml
@@ -1,0 +1,21 @@
+# 룰 회귀 픽스처 — finguard.config.plaintext-secret-nonprod / -vendorkey (#25).
+# 로컬 프로파일 설정은 더미가 지배적이라 WARNING 으로 강등하되, 값이 고신뢰 벤더
+# 프리픽스면 ERROR 로 승격한다. 값은 전부 합성 더미다.
+
+auth:
+  jwt:
+    # EXPECT: finguard.config.plaintext-secret-nonprod
+    secret-key: 8f2b41c7d90e5a63b18c47f2e0d95a31
+    access-exp: 86400
+
+toss:
+  # 로컬 파일이라도 벤더 프리픽스가 붙은 값은 실제로 유효한 키다 → ERROR 승격.
+  # EXPECT: finguard.config.plaintext-secret-vendorkey
+  secret-key: test_sk_ADpexMgkW36weAqp4bNVGbR5ozO0
+
+oauth:
+  kakao:
+    # 게이트에서 걸러지는 값 — 짧은 로컬 더미·CONSTANT_CASE·환경변수 참조
+    client-secret: local
+    admin-secret: DUMMY_LOCAL_ADMIN
+    api-key: ${KAKAO_API_KEY}

--- a/testdata/rule-fixtures/secret_nonprod_test.go
+++ b/testdata/rule-fixtures/secret_nonprod_test.go
@@ -1,0 +1,16 @@
+// 룰 회귀 픽스처 — finguard.go.hardcoded-secret-test (#25). 값은 전부 합성 더미다.
+package fixtures
+
+const (
+	// EXPECT: finguard.go.hardcoded-secret-test
+	apiKey = "1234567890123456"
+
+	// EXPECT: finguard.go.hardcoded-secret-test
+	password = "correcthorsebatterystaple"
+
+	// EXPECT: finguard.go.hardcoded-secret-test
+	dbPassword = "Pa$$w0rd!ProdBank"
+
+	// 게이트에서 걸러지는 값 — 짧은 더미는 잡지 않는다.
+	testPassword = "test1234"
+)

--- a/testdata/rule-fixtures/test_secret_nonprod.py
+++ b/testdata/rule-fixtures/test_secret_nonprod.py
@@ -1,0 +1,16 @@
+"""룰 회귀 픽스처 — finguard.python.hardcoded-secret-test (#25).
+
+파일명이 test_*.py 라는 이유로 blanket exclude 되던 구간이다. 값은 전부 합성 더미다.
+"""
+
+# EXPECT: finguard.python.hardcoded-secret-test
+API_KEY = "1234567890123456"
+
+# EXPECT: finguard.python.hardcoded-secret-test
+PASSWORD = "correcthorsebatterystaple"
+
+# EXPECT: finguard.python.hardcoded-secret-test
+DB_PASSWORD = "Pa$$w0rd!ProdBank"
+
+# 게이트에서 걸러지는 값 — 짧은 더미는 잡지 않는다.
+TEST_PASSWORD = "test1234"


### PR DESCRIPTION
Closes #25

> **스택된 PR입니다.** #64 (`fix/issue-23-placeholder-suppression`, 이슈 #23) 위에 쌓았고,
> 그 #64 는 다시 #62 (이슈 #36) 위에 쌓여 있습니다.
> 머지 순서는 **#62 → #64 → 이 PR** 입니다. 같은 룰 계열의 같은 정규식을 건드리므로
> 순서를 바꾸면 서로 덮어씁니다.

## 요약

정책이 양방향으로 틀려 있었다. 한쪽은 `*Test.java`·`test_*.py`·`*_test.go` 를 `paths.exclude`
로 통째 제거해 테스트 코드에 복붙된 실키를 영원히 못 봤고, 다른 쪽은 `application*.yml` 을
전부 include 해서 `-local.yml` 의 로컬 더미가 운영 설정과 동급 ERROR 로 떴다.

**신규 룰 6종**(전부 `mapping/rules.yaml` 에 등록 — 미등록 룰은 코멘트가 생략되어 무효 룰이 된다):

| 룰 ID | severity | 스코프 |
| :--- | :--- | :--- |
| `finguard.java.hardcoded-secret-test` | ERROR | `*Test.java` |
| `finguard.kotlin.hardcoded-secret-test` | ERROR | `*Test.kt`, `*Test.kts` |
| `finguard.go.hardcoded-secret-test` | ERROR | `*_test.go` |
| `finguard.python.hardcoded-secret-test` | ERROR | `test_*.py`, `*_test.py`, `conftest.py` |
| `finguard.config.plaintext-secret-nonprod` | WARNING | `application*-{local,test,dev}.{yml,yaml,properties}`, `.env.{local,development,test}`, `*.sample`, `*.example` |
| `finguard.config.plaintext-secret-vendorkey` | ERROR | 위와 동일 스코프, 값이 벤더 프리픽스일 때 |

각 신규 룰의 `paths.include` 는 대응하는 기존 ERROR 룰의 `paths.exclude` 와 **정확히 상호배타**다
(구현 렌즈 지적 반영 — 겹치면 같은 줄에 ERROR + WARNING 코멘트가 중복으로 달린다).
`finguard.config.plaintext-secret` 의 exclude 에도 로컬·개발·테스트 프로파일 글롭을 추가했다.

## ⚠️ exclude 제거만으로는 룰이 한 건도 발화하지 않았다 — semgrep 기본 무시목록

이슈는 `paths.exclude` 를 원인으로 지목했지만, 구현하면서 **더 상위의 원인**이 실측으로 드러났다.

semgrep 은 프로젝트 루트에 `.semgrepignore` 가 없으면 **내장 기본 무시목록**을 쓰는데
거기에 `test/`·`tests/`·`*_test.go` 가 들어 있다(1.169.0 실측). 그래서
`src/test/java/**` 는 **룰의 paths 설정과 무관하게** 타겟 목록에서 사라진다.

```
$ semgrep scan --config rules/ --verbose <iamport-rest-client-java>
  Skipped by .semgrepignore:
   • src/test/java/com/siot/IamportRestClient/IamportRestTest.java
```

즉 이 이슈의 헤드라인 증거는 `exclude: ["*Test.java"]` 를 걷어내도 **여전히 0건**이었다.
두 가지를 함께 고친다.

- `internal/scanner` 가 스캔 대상 루트에 `.semgrepignore` 를 심는다. 아무것도 무시하지 않는
  파일이라 내장 기본값을 대체한다. 제외 정책은 finguard 가 `--exclude`(`DefaultExcludes`)와
  각 레포의 `.finguard.yml` 로 이미 소유하고 있고, `exclude.go` 주석도 "테스트 코드는 레포
  사정에 따라 운영 코드일 수 있어 여기 넣지 않는다"고 명시하고 있다. 레포가 자기
  `.semgrepignore` 를 갖고 있으면 그 의도를 존중해 건드리지 않는다(단위 테스트 2건으로 고정).
- 이 레포 루트에도 `.semgrepignore` 를 둔다. 없으면 `testdata/rule-fixtures/*_test.go`·
  `*Test.java` 픽스처가 같은 이유로 통째로 사라져 신규 룰을 테스트할 수 없다.

## 반박·재설계 반영 내역

| 지적 | 반영 |
| :--- | :--- |
| 제안한 엔트로피 게이트가 **자기 헤드라인 증거(16자리 숫자 API 키)를 못 잡는다** (재현율·규제 렌즈 동시 지적) | **게이트를 다시 설계했다.** 아래 참조 |
| 블랭킷 exclude 제거는 반드시 해야 한다 (두 렌즈 합의) | **반영.** 다만 exclude 제거만으로는 부족했다 — 위 semgrepignore 절 참조 |
| "파일명은 판정 근거가 아니다" 라고 해놓고 파일명으로 severity 를 깎는 것은 자기모순 (규제 렌즈) | **반영.** 테스트 코드는 **ERROR 유지**. WARNING 강등은 더미가 지배적인 유일한 구간인 로컬·개발·테스트 **프로파일 설정파일**에만 적용 |
| nonprod 라도 고신뢰 벤더 프리픽스면 ERROR 로 승격해 게이트로 막을 것 (재현율 렌즈) | **반영.** `finguard.config.plaintext-secret-vendorkey`(ERROR) 신설. nonprod 룰은 같은 값을 `pattern-not-regex` 로 제외해 상호배타 유지 |
| 기존 ERROR 룰의 exclude 와 신규 룰의 include 가 상호배타여야 한다 (구현 렌즈) | **반영.** 위 표의 스코프가 exclude 목록과 1:1 대응. config ERROR 룰 exclude 에도 nonprod 글롭 추가 |
| 신규 룰 ID 는 `mapping/rules.yaml` 에 basis 를 붙여 등록할 것 (규제 렌즈) | **반영.** FIN-KEY-011 ~ 016, `basis`·`kisa_item`(평가기준 43·23) 포함 6건 등록. 룰 수 122 = 매핑 수 122 |
| 형제 파일 `${...}` 치환 억제는 재현율 구멍 (재현율 렌즈) | **미구현.** 아래 "일부러 넣지 않은 것" 참조 |

### 엔트로피 게이트 재설계

원안: `(?=[^"]*[A-Za-z])(?=[^"]*[0-9])[A-Za-z0-9+/=_.-]{20,}`
— ① 영문 포함 ② 숫자 포함 ③ 20자 이상 ④ 특수문자 불가 를 **전부 AND**.

반례를 먼저 시험했고, 셋 다 원안 게이트를 통과하지 못했다.

| 값 형태 | 원안 | 재설계 |
| :--- | :--- | :--- |
| 16자리 숫자 API 키 (이 이슈의 헤드라인 증거) | ✗ 영문 없음·20자 미만 | ✓ |
| `"correcthorsebatterystaple"` (순영문) | ✗ 숫자 없음 | ✓ |
| `"Pa$$w0rd!ProdBank"` (특수문자) | ✗ 허용 문자군 밖·20자 미만 | ✓ |

재설계는 **AND 가 아니라 OR** 다.

```
순숫자 12자 이상
| base64/hex 계열 문자 16자 이상
| 12자 이상 이면서 영문과 숫자를 모두 포함 (특수문자 허용)
```

여기에 `(?!https?://)`·`(?!jdbc:)` 로 URL·접속문자열을 뺀다.
반대로 8자 이하 로컬 더미(`test1234`, 7자 순영문 비밀번호), CONSTANT_CASE 상수명,
플레이스홀더는 걸러진다 — 픽스처로 양방향 고정했다.

## 10개 레포 전/후 검출 표

기준선은 **#64 적용 상태**(= 이 PR 의 부모)다. 변경이 둘(무시목록 + 룰)이라 원인 분리를 위해
중간 단계를 함께 싣는다.

| 레포 | 전(#64) | 무시목록만 | 후(#25) | 델타 |
| :--- | ---: | ---: | ---: | ---: |
| r0 한국투자증권(Python) | 45 | 45 | 45 | 0 |
| r1 samchon/payments(TS) | 14 | 15 | 15 | **+1** |
| r2 CoinNow(Swift) | 1 | 1 | 1 | 0 |
| r3 DuDoong-Backend(Kotlin) | 11 | 12 | 11 | 0 |
| r4 iamport-python | 0 | 0 | 0 | 0 |
| r5 AXSnapshot(Swift) | 0 | 0 | 0 | 0 |
| r6 reactive-crypto(Kotlin) | 2 | 2 | 2 | 0 |
| r7 pybithumb(Python) | 0 | 0 | 0 | 0 |
| r8 iamport-rest-client-java | 0 | 0 | **7** | **+7** |
| r9 upbitBar(Swift) | 2 | 2 | 2 | 0 |
| **합계** | **75** | **77** | **83** | **+8** |

### 증가분 분석 (+8, 전수 확인)

**semgrep 무시목록 대체만으로 +2** — 지금까지 타겟 목록에서 통째로 빠져 있던 테스트 경로가
스캔되기 시작하면서 **기존 룰**이 잡은 것이다.

| 위치 | 룰 | 판정 |
| :--- | :--- | :--- |
| r1 `packages/fake-toss-payments-server/test/features/test_fake_storage_capacity.ts:34` | `ts.insecure-random` | 정탐(테스트 코드의 취약 난수). 지금까지 보이지 않던 구간 |
| r3 `DuDoong-Common/src/test/kotlin/.../JwtTokenProviderTest.kt:20` | `kotlin.hardcoded-crypto-material` | 정탐(테스트 코드에 박힌 JWT 키 재료) |

**신규 룰로 +7 (r8)** — `iamport-rest-client-java` `src/test/java/.../IamportRestTest.java`
36·37·43·44·52·381·382행, `finguard.java.hardcoded-secret-test`(ERROR).
16자리 숫자 API 키와 80자 랜덤 시크릿 쌍이다. **이 이슈가 근거로 든 바로 그 케이스이고,
이번 변경 전에는 0건이었다.**

**r3 는 신규 룰 3건 + 기존 룰 4건 제거로 순감소** (아래 표 참조).

### 감소분 분석 (-4, 전수 확인)

전부 r3 DuDoong-Backend 의 로컬 프로파일이고, 4건이 사라진 자리에 3건이 새로 들어왔다.

| 사라진 것 | 대체 | 판정 |
| :--- | :--- | :--- |
| `application-common-local.yml:3` ERROR | → `plaintext-secret-nonprod` **WARNING** | 로컬 프로파일 더미. 강등이 의도된 동작 |
| `application-common-local.yml:17` ERROR | → `plaintext-secret-vendorkey` **ERROR** | toss `test_sk_` 키. 이슈가 "회전 권고 대상이므로 유지" 라고 명시한 항목 — severity 유지 |
| `DuDoong-Api/application-local.yml:3` ERROR | (없음) | **오탐 해소.** 값이 8자 순영문 로컬 더미 비밀번호라 게이트가 걸러냈다 |
| `DuDoong-Domain/application-domain-local.yml:9` ERROR | (없음) | **오탐 해소.** 값이 7자 순영문 로컬 더미 비밀번호. 이슈 근거대로 `jdbc:mysql://127.0.0.1` 루프백 + docker-compose 와 동일한 컨테이너 자격증명이다 |
| — | + `kotlin.hardcoded-secret-test` (`JwtTokenProviderTest.kt:20`) | 무시목록 대체로 보이게 된 테스트 코드 실키 |

캠페인 트리아지가 오탐으로 판정한 r3 5건 중, #64 에서 1건 + 이 PR 에서 2건이 해소된다.
남은 2건은 반복 필러(#63 소관)와 벤더 프리픽스 실키(의도적 유지)다.

## 변이 시험

`SecretNonprodTest.java` 로 양방향 확인:

1. 16자리 숫자 키 줄의 `EXPECT` 마커 제거
   → `오탐 회귀 — 마커가 없는데 검출됐다: SecretNonprodTest.java:8` **FAIL**
2. 게이트가 거르는 `String testPassword = "test1234";` 줄 위에 마커 추가
   → `미탐 회귀 — 마커가 있는데 검출되지 않았다: SecretNonprodTest.java:24` **FAIL**

원복 후 재실행 → 기대·검출 전부 일치 PASS.

## 일부러 넣지 않은 것

- **형제 파일 `${...}` 치환 여부에 따른 억제(후처리)** — 이슈가 rdjson 생성 단계 구현을
  요구했지만 **구현하지 않았다.** 재현율 렌즈의 반박이 맞다: `application.yml` 이
  `${JWT_SECRET}` 를 쓰면서 `application-local.yml` 에 운영 시크릿을 복붙해 둔 구조가
  실제 유출의 전형인데, 그 구조를 근거로 억제하면 정확히 그 케이스를 지운다.
  로컬 프로파일 강등은 severity 축(WARNING)으로 이미 처리했다.
- **테스트 코드 ERROR → WARNING 강등** — 규제 렌즈 지적대로 자기모순이고,
  기본 게이트(`FINGUARD_BLOCK_ON=ERROR`)를 통과시켜 버린다. ERROR 를 유지했다.
- **`**/test/**`·`**/tests/**`·`**/spec/**` 를 신규 룰의 include 에 추가** — 넣지 않았다.
  기존 ERROR 룰은 그 경로를 파일명 기준으로만 제외하고 있어, 추가하면 같은 파일이 두 룰에
  걸려 코멘트가 중복된다(구현 렌즈 지적). 무시목록 대체로 그 경로들은 이미 기존 ERROR 룰이
  스캔한다 — 위 +2 증가분이 그 증거다.
- **swift·shell·ts 의 테스트 대응 룰** — swift/shell 룰에는 애초에 테스트 exclude 가 없고,
  `rules/typescript.yaml` 은 작업 시작 시점에 #29 가 수정 중이라 제외했다
  (#29 는 그 사이 머지됐고 이 브랜치는 그 위로 리베이스했다). **후속 PR 이 필요하다.**
- **`*.template`·`*.dist` 의 nonprod 편입** — 값이 예시라는 것이 파일 규약으로 확정된
  구간이라 기존 exclude 를 유지했다. `*.sample`·`*.example` 만 편입했다.

## 검증

```
semgrep --validate --config rules/        → Configuration is valid, 122 rule(s)
룰 수 122 = mapping/rules.yaml 매핑 수 122 (신규 6건 등록 확인)
go build -mod=vendor ./...                → OK
go vet -mod=vendor ./...                  → OK
go test -race -mod=vendor ./...           → 전부 ok (scanner 단위 테스트 2건 추가)
go test -race -mod=vendor -tags semgrep_integration ./internal/scanner/
                                          → 기대 166건 · 검출 166건 · 전부 일치
```
