### PR TITLE
fix(#66): export namespace AST 사각지대 전수조사 + 무음 가시화 룰·회귀 픽스처

### DIFF
--- a/mapping/rules.yaml
+++ b/mapping/rules.yaml
@@ -1815,3 +1815,29 @@
     toss:
       secret-key: ${TOSS_SECRET_KEY}
     ```
+
+- rule_id: finguard.ts.namespace-analysis-gap
+  code: FIN-COV-001
+  cwe: CWE 해당 없음
+  title: AST 분석 미적용 구간 (export namespace, TS)
+  severity: INFO
+  basis: finguard 도구 한계 고지 — semgrep 1.169.0 TypeScript 파서 (#66)
+  kisa_item: ""
+  explain: |
+    semgrep 1.169.0 의 TypeScript 파서는 `export namespace X { ... }` 블록 본문을 AST 패턴으로
+    매칭하지 못합니다(같은 코드가 top-level 이거나 `export` 없는 `namespace` 면 정상 매칭됩니다).
+    이 블록 안에서는 AST 기반 룰 — 명령 실행(FIN-CMDI), SSRF(FIN-SSRF), 경로 조작(FIN-PATH),
+    XSS(FIN-XSS), zip-slip, SQL 삽입의 조립 탐지 갈래 — 이 발화하지 않습니다.
+    블록 안에 해당 룰의 위험 API 호출이 실제로 존재하여 고지합니다.
+    자동 점검 결과가 "이상 없음"이더라도 이 구간은 점검되지 않은 것이므로 수동 검토가 필요합니다.
+  fix_example: |
+    코드 결함이 아니라 도구 커버리지 고지이므로 수정 대상이 아닙니다. 아래 중 하나로 대응합니다.
+
+    1. 이 블록 안의 외부 입력 → 위험 API 경로를 수동 검토한다.
+    2. 점검 커버리지가 중요한 모듈이라면 `export namespace` 대신 모듈 export 로 구조를 바꾼다.
+
+    ```ts
+    // export namespace Provider { export async function call(url: string) { ... } }
+    // ↓ 동일 기능, AST 점검 대상이 된다
+    export async function call(url: string) { ... }
+    ```

--- a/rules/typescript.yaml
+++ b/rules/typescript.yaml
@@ -439,3 +439,44 @@ rules:
     paths:
       include: ["*.ts", "*.tsx", "*.js", "*.jsx"]
     pattern-regex: '(?im)^(?![ \t]*(?://|\*|/\*)).*(?:rejectUnauthorized\s*:\s*false|strictSSL\s*:\s*false|insecureSkipTLSVerify\s*:\s*true|NODE_TLS_REJECT_UNAUTHORIZED["'']?\]?\s*=\s*["'']?0|checkServerIdentity\s*:\s*(?:\([^)]*\)|\w+)\s*=>\s*(?:undefined|null|\{\s*\}))'
+
+  # ── AST 분석 사각지대 고지 (#66) ────────────────────────────────────────
+  #
+  # semgrep 1.169.0 의 TypeScript 파서는 `export namespace X { ... }` **블록 본문**의
+  # 문장을 AST 패턴으로 매칭하지 못한다. 2026-08-22 실측(semgrep 1.169.0, 프로브 3종):
+  #
+  #   형태                                   AST 룰 발화
+  #   top-level                              O
+  #   namespace X { ... }                    O
+  #   export namespace X { ... }             X  ← 갭
+  #   namespace Outer { export namespace ... }  X  (중첩도 동일)
+  #
+  # 갭은 블록 단위다 — 같은 파일의 export namespace 바깥 코드는 정상 분석된다.
+  # 정규식 모드(`languages: [regex]`) 룰은 파일 텍스트를 보므로 영향이 없다.
+  # 이 파일에서 영향받는 룰: os-command-injection · open-redirect · ssrf ·
+  # xss-innerhtml · path-traversal · zip-slip (전부 AST) + sql-injection 의 (B) 갈래.
+  # sql-injection 의 (A) 갈래는 pattern-regex 라 블록 안에서도 발화한다.
+  #
+  # 문제의 본질은 미탐 자체가 아니라 **무음이 clean 과 구분되지 않는 것**이다.
+  # 영향 룰을 통째로 정규식으로 바꾸는 대응은 택하지 않았다 — 여섯 중 다섯이 taint
+  # 모드라 데이터흐름 없이는 재현할 수 없고, 정규식으로 근사하면 오탐이 폭증한다.
+  # 대신 사각지대를 **보이게** 만든다: export namespace 블록 안에 AST 룰의 싱크가
+  # 실제로 존재할 때만 INFO 로 고지해 수동 검토를 요청한다.
+  #
+  # 조건부인 이유(실측): samchon/payments 230 파일에 export namespace 는 118 개지만
+  # 그중 싱크를 품은 블록은 10 개뿐이다. 무조건 고지하면 12 배의 소음이 되고
+  # 그 소음이 곧 무시로 이어진다.
+  #
+  # 한계: (1) 블록 경계는 열 0 의 `}` 로 근사한다 — 들여쓴 중첩 export namespace
+  # (실측 118 중 4)는 대상이 아니다. (2) 싱크 어휘는 이 파일의 AST 룰 싱크 목록에서
+  # 뽑았으므로 AST 룰을 추가하면 여기도 같이 늘려야 한다.
+  # semgrep 업그레이드로 갭이 해소되면 이 룰과 회귀 픽스처를 함께 제거한다.
+  - id: finguard.ts.namespace-analysis-gap
+    languages: [regex]
+    severity: INFO
+    message: 이 export namespace 블록은 semgrep 1.169.0 TypeScript 파서의 한계로 AST 기반 룰(명령 실행·SSRF·경로 조작·XSS·SQL 삽입 (B) 갈래)이 적용되지 않습니다. 블록 안에 해당 룰의 위험 API 호출이 있으므로 자동 점검 결과를 "이상 없음"으로 해석하면 안 되며 수동 검토가 필요합니다.
+    metadata:
+      category: security
+    paths:
+      include: ["*.ts", "*.tsx"]
+    pattern-regex: '(?m)^export[ \t]+namespace[ \t]+[\w$.]+[^\n{]*\{(?:(?!^\}[ \t]*;?[ \t]*$)[\s\S])*?(?:\b(?:fetch|exec|execSync|spawn|spawnSync|readFile|readFileSync|writeFile|writeFileSync|createReadStream|createWriteStream|sendFile|mkdir|mkdirSync)[ \t]*\(|\.(?:innerHTML|outerHTML)[ \t]*=|\binsertAdjacentHTML[ \t]*\(|\bdocument\.write(?:ln)?[ \t]*\(|\.(?:query|execute|raw)[ \t]*\()'

--- a/testdata/rule-fixtures/ts_export_namespace_gap.ts
+++ b/testdata/rule-fixtures/ts_export_namespace_gap.ts
@@ -1,0 +1,93 @@
+// #66 회귀 픽스처 — semgrep TypeScript 파서의 `export namespace` AST 갭을 고정한다.
+//
+// (A) export namespace 블록과 (B) top-level 블록은 **같은 미끼 코드**다.
+//   - (B) 는 AST 룰이 발화하므로 EXPECT 마커가 붙어 있다. 미끼가 실제로 탐지
+//     가능하다는 대조군(control)이다 — 대조군 없이 (A) 의 "0건" 을 해석하면
+//     미끼가 원래 안 잡히는 것인지 갭 때문인지 구분할 수 없다.
+//   - (A) 는 semgrep 1.169.0 에서 무음이라 마커가 없다.
+//
+// **마커 부재가 곧 기대값이다.** TestFixtureExpectationsMatchScan 은 양방향
+// (마커 있는데 미검출 = 미탐 회귀 / 마커 없는데 검출 = 오탐 회귀)이므로,
+// semgrep 업그레이드로 갭이 해소되면 (A) 의 검출이 "마커 없는데 검출됐다" 로
+// 테스트를 실패시킨다. 갭 해소가 조용히 지나가지 않고 드러난다.
+//
+// 그때 할 일: (A) 에 마커를 달고, finguard.ts.namespace-analysis-gap 룰과
+// #27·#29 가 넣은 정규식 우회(sql-injection (A) 갈래 · stored-ssrf)를 재검토한다.
+//
+// 정규식 모드 룰은 이 갭의 영향을 받지 않는다 — (A) 안의 $executeRawUnsafe 가
+// sql-injection (A) 갈래로 잡히는 것이 그 증거다.
+
+// EXPECT: finguard.ts.namespace-analysis-gap
+export namespace GapDemo {
+  // AST 룰 미끼 — semgrep 1.169.0 에서는 아래 전부 무음이다(마커 없음).
+  export function osCmd(req: any, cp: any) {
+    cp.exec(req.query.cmd);
+  }
+
+  export function openRedirect(req: any, res: any) {
+    res.redirect(req.query.next);
+  }
+
+  export function ssrfCall(req: any) {
+    return fetch(req.query.url);
+  }
+
+  export function xssSink(el: any, req: any) {
+    el.innerHTML = req.body.html;
+  }
+
+  export function pathTrav(req: any, fs: any) {
+    return fs.readFileSync(req.query.p);
+  }
+
+  export function zipSlip(entry: any, fs: any) {
+    fs.writeFileSync(entry.entryName, "x");
+  }
+
+  export function sqlAstBranch(db: any, id: string) {
+    return db.query(`SELECT * FROM payments WHERE id = ${id}`);
+  }
+
+  // 정규식 갈래는 블록 안에서도 발화한다.
+  export function sqlRegexBranch(prisma: any, script: string) {
+    // EXPECT: finguard.ts.sql-injection
+    return prisma.$executeRawUnsafe(script);
+  }
+}
+
+// (B) 대조군 — 같은 코드가 top-level 이면 AST 룰이 정상 발화한다.
+
+export function osCmdTop(req: any, cp: any) {
+  // EXPECT: finguard.ts.os-command-injection
+  cp.exec(req.query.cmd);
+}
+
+export function openRedirectTop(req: any, res: any) {
+  // EXPECT: finguard.ts.open-redirect
+  res.redirect(req.query.next);
+}
+
+export function ssrfCallTop(req: any) {
+  // EXPECT: finguard.ts.ssrf
+  return fetch(req.query.url);
+}
+
+export function xssSinkTop(el: any, req: any) {
+  // EXPECT: finguard.ts.xss-innerhtml
+  el.innerHTML = req.body.html;
+}
+
+export function pathTravTop(req: any, fs: any) {
+  // EXPECT: finguard.ts.path-traversal
+  return fs.readFileSync(req.query.p);
+}
+
+export function zipSlipTop(entry: any, fs: any) {
+  // EXPECT: finguard.ts.zip-slip
+  fs.writeFileSync(entry.entryName, "x");
+}
+
+export function sqlAstBranchTop(db: any, id: string) {
+  // EXPECT: finguard.ts.sql-injection
+  return db.query(`SELECT * FROM payments WHERE id = ${id}`);
+}


### PR DESCRIPTION
Closes #66

## 1. 갭 확정 — 재현됨

`semgrep 1.169.0` (`/opt/homebrew/bin/semgrep`, 2026-08-22 실측). 동일한 본문을 세 형태로
감싼 프로브 파일 3개를 만들어 `rules/typescript.yaml` 로 스캔했다.

| 감싼 형태 | AST 룰 발화 |
| :--- | :--- |
| top-level | O (6개 룰 + sql-injection (B)) |
| `namespace X { ... }` | O (동일) |
| `export namespace X { ... }` | **X (전부 무음)** |

추가로 확인한 두 가지:

- **갭은 블록 단위다.** 같은 파일에서 `export namespace` 블록 안의 `fetch(req.query.url)` 은
  무음이지만 블록 바깥 top-level 의 동일 코드는 정상 발화했다. 파일 전체가 죽는 것이 아니다.
- **중첩도 동일하다.** `namespace Outer { export namespace Nested { ... } }` 의 안쪽도 무음이고,
  같은 `Outer` 안의 비-export 위치는 발화했다.

이슈 본문의 주장이 그대로 재현된다. 닫을 근거가 아니라 진행할 근거다.

## 2. 영향 룰 전수조사

`rules/typescript.yaml` 의 18개 룰 전부에 대해 `export namespace` 블록 안에서 발화하는지
실측했다(정규식 룰 11개는 별도 프로브 `expns_regex.tsx` 로, AST 룰은 위 3형태 프로브로).

| 룰ID | 모드 | `export namespace` 안 발화 | 대응 |
| :--- | :--- | :--- | :--- |
| `finguard.ts.dangerously-set-inner-html` | regex | O | 조치 불필요 |
| `finguard.ts.eval` | regex | O | 조치 불필요 |
| `finguard.ts.hardcoded-secret` | regex | O | 조치 불필요 |
| `finguard.ts.http-url` | regex | O | 조치 불필요 |
| `finguard.ts.cleartext-websocket` | regex | O | 조치 불필요 |
| `finguard.ts.stored-ssrf` | regex | O | 조치 불필요 (#29 가 이미 이 갭 때문에 regex 로 만든 룰) |
| `finguard.ts.hardcoded-crypto-material` | regex | O | 조치 불필요 |
| `finguard.ts.weak-crypto` | regex | O | 조치 불필요 |
| `finguard.ts.insecure-random` | regex | O | 조치 불필요 |
| `finguard.ts.tls-verify-disabled` | regex | O | 조치 불필요 |
| `finguard.ts.os-command-injection` | **AST (taint)** | **X** | 현행 유지 + 갭 고지 룰로 가시화 |
| `finguard.ts.open-redirect` | **AST (taint)** | **X** | 현행 유지 + 갭 고지 룰로 가시화 |
| `finguard.ts.ssrf` | **AST (taint)** | **X** | 현행 유지 + 갭 고지 룰로 가시화 (2차 SSRF 는 `stored-ssrf` 가 부분 보완) |
| `finguard.ts.path-traversal` | **AST (taint)** | **X** | 현행 유지 + 갭 고지 룰로 가시화 |
| `finguard.ts.zip-slip` | **AST (taint)** | **X** | 현행 유지 + 갭 고지 룰로 가시화 |
| `finguard.ts.xss-innerhtml` | **AST (patterns)** | **X** | 현행 유지 + 갭 고지 룰로 가시화 |
| `finguard.ts.sql-injection` | 혼합 | **부분** — (A) 정규식 갈래 O / (B) AST 갈래 X | 현행 유지 (#27 의 (A) 갈래가 raw 실행 API 를 이미 덮는다) |
| `finguard.ts.namespace-analysis-gap` | regex | O (신규) | 이 PR 에서 추가 |

## 3. 대응 방침 — 정규식 전환은 하지 않는다

세 선택지 중 **"한계를 문서화한다"를 택하되, 문서가 아니라 룰로 구현**했다.

**정규식 전환을 택하지 않은 이유 (룰별 판단):**

- 영향받는 6개 중 **5개가 taint 모드**다(`os-command-injection`·`open-redirect`·`ssrf`·
  `path-traversal`·`zip-slip`). 이 룰들의 정탐 근거는 "외부 입력이 싱크까지 흘렀다"는 데이터흐름
  자체다. 정규식으로는 흐름을 볼 수 없으니 "싱크 호출이 있다"로 근사할 수밖에 없고, 그러면
  `fetch(...)`·`readFileSync(...)`·`exec(...)` 를 쓰는 모든 줄이 ERROR 가 된다. 은행 반입 심사
  도구에서 그 오탐률은 도구를 폐기시킨다. #29 가 `stored-ssrf` 를 정규식으로 만든 것은
  "전환"이 아니라 webhook/callback 어휘 + 프로퍼티 접근으로 좁힌 **별도 좁은 룰 신설**이었고,
  그 방식은 taint 룰 일반에 확장되지 않는다.
- `xss-innerhtml` 은 유일하게 taint 가 아니라 정규식 근사가 가능하다. 그럼에도 전환하지 않았다.
  `export namespace` 는 nestia/typia 계열 **백엔드** 관용구이고 `innerHTML` 은 DOM 코드라
  교집합이 사실상 비어 있어, 정밀도(리터럴 대입·템플릿 리터럴 판별)를 정규식으로 다시 짜는
  비용에 비해 얻는 커버리지가 없다. 실제로 코퍼스 118개 블록 중 innerHTML 계열 싱크를 가진
  블록은 0개였다.
- `sql-injection` 은 이미 (A) 갈래가 정규식이라 `$executeRawUnsafe`·`Prisma.raw` 는 블록 안에서도
  잡힌다. (B) 갈래(범용 싱크 + 조립 흔적 + SQL 키워드)까지 정규식으로 내리면 `.query(`/`.execute(`
  가 있는 모든 줄로 번지므로 그대로 둔다.

**대신 추가한 것 — `finguard.ts.namespace-analysis-gap` (INFO, regex):**

이슈가 지적한 진짜 위험은 미탐 자체가 아니라 **"무음이 clean 과 구분되지 않는 것"** 이다.
이 룰은 그 구분을 복원한다. `export namespace` 블록 안에 **AST 룰의 싱크가 실제로 존재할 때만**
INFO 로 "이 구간은 자동 점검되지 않았다"고 고지한다.

조건부로 만든 근거(실측): `samchon/payments` 230 파일에 `export namespace` 는 118개지만,
그중 AST 룰 싱크를 품은 블록은 **10개뿐**이다. 무조건 고지하면 12배 소음이 되고 소음은 곧
무시로 이어진다. 룰은 그 10개를 정확히 집어냈다 — 중괄호 매칭으로 블록을 잘라 판정한 독립
스크립트의 결과와 **완전히 일치**(오탐 0 / 미탐 0).

기록해 둔 한계 2가지(룰 주석에도 명시):
1. 블록 경계를 열 0 의 `}` 로 근사한다 → 들여쓴 중첩 `export namespace`(코퍼스 118 중 4)는 대상 밖.
2. 싱크 어휘는 이 파일의 AST 룰 싱크 목록에서 뽑았다 → AST 룰을 추가하면 이 목록도 같이 늘려야 한다.

INFO 라 기본 게이트(`FINGUARD_BLOCK_ON=ERROR`)를 막지 않는다. 매핑 엔트리 `FIN-COV-001` 은
취약점이 아니라 커버리지 고지이므로 `kisa_item` 을 비웠다 — 없는 금보원 항목을 지어내지 않는다.

## 4. 회귀 방어 — 마커 부재를 기대값으로 고정

`testdata/rule-fixtures/ts_export_namespace_gap.ts` 는 **같은 미끼 코드**를 두 벌 담는다.

- **(A) `export namespace` 안** — 마커 없음. 지금 무음인 것이 현재 정상 상태다.
- **(B) top-level** — 마커 있음. **대조군**이다. 대조군이 없으면 (A) 의 "0건"이 갭 때문인지
  미끼가 원래 안 잡히는 것인지 구분할 수 없다(`.claude/memory/project_adversarial-verify-recheck.md`).

마커는 "검출되어야 한다"는 뜻이므로 (A) 에는 쓸 수 없다. 대신 **`TestFixtureExpectationsMatchScan`
이 양방향**(마커 있는데 미검출 = 미탐 회귀 / 마커 없는데 검출 = 오탐 회귀)이라는 성질을 이용해,
**마커 부재 자체를 "검출되면 안 된다"는 기대값으로** 쓴다. semgrep 업그레이드로 갭이 해소되면
(A) 의 검출이 "마커 없는데 검출됐다"로 테스트를 실패시켜 갭 해소가 조용히 지나가지 않는다.
그때 할 일(마커 추가 + 고지 룰·우회 정규식 재검토)은 픽스처 헤더 주석에 적어 두었다.

**변이 시험**: `export namespace GapDemo` → `namespace GapDemo` 로 한 글자 바꾸자
미탐 1건(`namespace-analysis-gap`) + 오탐 7건(블록 안 AST 룰 전부)으로 테스트가 실패했다.
원복 후 green 확인.

## 5. 실코드 검증 — samchon/payments

`find <dir> -name '*.ts' | wc -l` = **230** (코퍼스 존재 확인).

| | 수정 전 | 수정 후 |
| :--- | ---: | ---: |
| 합계 | 6 | 16 |
| `insecure-random` | 1 | 1 |
| `sql-injection` | 2 | 2 |
| `stored-ssrf` | 2 | 2 |
| `hardcoded-crypto-material` | 1 | 1 |
| `namespace-analysis-gap` (신규) | – | **10** |

증가분 10건 전수 확인 — 전부 정탐(각 블록 안에 실제 싱크 존재):

| 파일 | 블록 시작 줄 | 블록 안 싱크 |
| :--- | ---: | :--- |
| `payment-backend/src/PaymentSetupWizard.ts` | 6 | `$executeRawUnsafe` (#27 의 증거 파일) |
| `payment-backend/src/providers/payments/PaymentWebhookProvider.ts` | 13 | `fetch(history.webhook_url!, ...)` (#29 의 증거 파일) |
| `payment-backend/src/providers/payments/PaymentHistoryProvider.ts` | 19 | `fetch(history.webhook_url, ...)` |
| `payment-backend/src/utils/Terminal.ts` | 4 | `cp.exec(...)` |
| `payment-backend/src/utils/ErrorUtil.ts` | 7 | `fs.promises.writeFile(...)` |
| `fake-toss-payments-server/src/providers/FakeTossWebhookProvider.ts` | 5 | `fetch(...)` |
| `fake-toss-payments-server/src/utils/Terminal.ts` | 4 | `cp.exec(...)` |
| `fake-toss-payments-server/src/utils/ErrorUtil.ts` | 7 | `fs.promises.writeFile(...)` |
| `fake-iamport-server/src/providers/FakeIamportPaymentProvider.ts` | 9 | `fetch(payment.notice_url \|\| ...)` |
| `fake-iamport-server/src/utils/Terminal.ts` | 4 | `cp.exec(...)` |

기존 4개 룰의 검출 수는 변동 없음(회귀 없음).

## 6. 검증

| 명령 | 결과 |
| :--- | :--- |
| `semgrep --validate --config rules/` | `Configuration is valid — 0 error(s), 123 rule(s)` |
| 룰 수 = 매핑 수 | 123 = 123 (`TestEveryRuleMapped` 통과) |
| `go build -mod=vendor ./...` | 통과 |
| `go vet -mod=vendor ./...` | 통과 |
| `go test -race -count=1 -mod=vendor ./...` | 전 패키지 ok |
| `go test -race -count=1 -mod=vendor -tags semgrep_integration ./internal/scanner/` | ok (기대 175건 · 검출 175건 일치) |

## 파일

- `rules/typescript.yaml` — 룰 1개 추가 + 갭 전수조사 결과 주석
- `mapping/rules.yaml` — `FIN-COV-001` 엔트리 **추가만** (기존 엔트리 무수정)
- `testdata/rule-fixtures/ts_export_namespace_gap.ts` — 신규 회귀 픽스처

`internal/scanner/*.go`(#60·#61 소유)와 다른 언어 룰 파일은 건드리지 않았다.
