### PR TITLE
test(#60,#61): 마커 파서 재귀 순회 + XML/plist 주석 지원, 정규식 복제 제거

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,11 +258,36 @@ block_on: [ERROR, WARNING]
   REALTIME_FEED_URL = "ws://ops.example-broker.co.kr:21000"
   ```
 
-  마커 뒤에 설명을 덧붙이면 매칭되지 않는다(룰ID 만 온다). `//` 주석도 같은 문법.
+  마커 뒤에 설명을 덧붙이면 매칭되지 않는다(룰ID 만 온다).
+- **주석 형태 3종** — 파일 문법에 맞는 것을 쓴다.
+
+  | 형태 | 대상 |
+  | :--- | :--- |
+  | `# EXPECT: <룰ID>` | 파이썬·셸·YAML·properties |
+  | `// EXPECT: <룰ID>` | Go·Java·Kotlin·Swift·TS |
+  | `<!-- EXPECT: <룰ID> -->` | XML·plist (#61) |
+
+  XML 은 한 줄로 여닫는다. 주석을 다음 줄에서 닫거나 `<!--` / `# EXPECT:` / `-->` 로
+  쪼개던 우회책은 폐기했다 (#61). 닫기(`-->`) 앞뒤에 설명을 붙이면 다른 형태와 똑같이
+  매칭되지 않는다.
+- **하위 디렉터리도 순회한다** (#60). 마커 파서(`walkFixtures`)와 스캔(`CLI.Scan`)의 순회
+  범위가 같으므로, `paths.include` 로 경로 구조 자체를 판정 기준으로 삼는 룰
+  (`finguard.swift.insecure-trust-vendor` 등)도 벤더 경로 하위에 픽스처를 두고 검증한다.
+  기대값 키는 픽스처 루트 기준 **상대경로**라 다른 디렉터리의 동명 파일이 섞이지 않는다.
+  - 단 `DefaultExcludes`(`internal/scanner/exclude.go`)에 걸리는 경로는 스캔 자체에서
+    빠진다 — `Pods/` 하위 픽스처는 `--exclude Pods` 때문에 검출되지 않으므로
+    `Carthage/` 를 쓴다.
+  - 바이너리(NUL 바이트 포함 파일)는 마커 순회에서 건너뛴다.
 - **`safe_` 접두 파일은 대조군**이라 마커를 가질 수 없다 — 어떤 룰에도 걸리지 않아야 한다.
+  하위 디렉터리의 `safe_*` 도 같은 기준으로 검사한다.
 - `TestFixtureExpectationsMatchScan` 이 양방향으로 검사한다. 마커 있는데 미검출 = 미탐 회귀,
   마커 없는데 검출 = 오탐 회귀. 라인 번호를 테스트에 적지 않으므로 블록을 어디에 추가하든
   기대값이 따라 움직이고, 픽스처를 건드리는 PR 끼리 충돌하지 않는다.
+- 마커 문법·순회 구현은 **`internal/scanner/expect_marker_test.go` 한 곳**에만 있다.
+  이 파일에는 빌드 태그가 없어 기본 `go test` 와 `-tags semgrep_integration` 양쪽에서
+  컴파일되고, 태그 뒤의 `integration_test.go` 가 그 정의를 그대로 쓴다. 예전처럼 문법을
+  양쪽에 복제하면 어긋난 순간 마커가 조용히 무시되고 통합 테스트가 "기대 0건 · 검출 0건"
+  으로 통과한다 — 복제하지 말 것 (#60·#61).
 - 통합 테스트 실행: `go test -race -mod=vendor -tags semgrep_integration ./internal/scanner/`
 - 레포 루트의 **`.semgrepignore` 를 지우지 말 것** (#25). semgrep 은 이 파일이 없으면
   내장 기본 무시목록을 쓰는데 거기에 `test/`·`tests/`·`*_test.go` 가 들어 있어,

--- a/internal/scanner/expect_marker_test.go
+++ b/internal/scanner/expect_marker_test.go
@@ -1,27 +1,71 @@
+// 룰 회귀 픽스처의 기대값 마커 — 문법 정의와 픽스처 트리 순회.
+//
+// **이 파일에는 빌드 태그가 없다.** 기본 `go test` 와 `-tags semgrep_integration`
+// 양쪽에서 컴파일되므로, 태그 뒤에 있는 integration_test.go 도 여기 정의를 그대로 쓴다.
+// semgrep 바이너리가 필요 없는 검사(마커 문법·순회·대조군)는 전부 여기 둔다.
 package scanner
 
 import (
+	"bytes"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 )
 
-// expectMarkerPattern 은 integration_test.go 의 expectMarker 와 같은 문법이다.
-// 그쪽은 semgrep_integration 빌드 태그 뒤에 있어 기본 `go test` 에서 컴파일되지 않으므로,
-// 마커 문법 자체의 회귀는 태그 없는 이 테스트가 지킨다 (#44).
+// ── 기대값 마커 — 단일 정의 ──
 //
-// 두 정규식이 어긋나면 픽스처 마커가 조용히 무시되고, 그 순간 통합 테스트는
-// "기대 0건 · 검출 0건" 으로 통과해버린다 — 그래서 문법을 여기에 고정한다.
-const expectMarkerPattern = `(?:#|//)\s*EXPECT:\s*(\S+)\s*$`
+// 픽스처는 검출이 기대되는 줄 **바로 위**에 마커 주석을 단다 (#44):
+//
+//	# EXPECT: finguard.python.cleartext-websocket
+//	REALTIME_FEED_URL = "ws://ops.example-broker.co.kr:21000"
+//
+// 기대값이 테스트가 아니라 픽스처 안에 있으므로 블록을 어디에 추가하든 따라 움직인다.
+// 라인 번호를 테스트에 하드코딩하던 구조는 픽스처를 건드리는 모든 PR 을 서로
+// 충돌시켰고, 병합 후 조용히 어긋나기까지 했다.
+//
+// 예전에는 같은 문법을 integration_test.go 에도 복제해 두었다. 둘이 어긋나면 픽스처
+// 마커가 조용히 무시되고 통합 테스트가 "기대 0건 · 검출 0건" 으로 통과해버렸다
+// (#60·#61). 정의를 하나로 합쳐 그 어긋남 자체를 구조적으로 없앤다.
+//
+// 지원하는 주석 형태:
+//
+//	# EXPECT: <룰ID>                  파이썬·셸·YAML·properties
+//	// EXPECT: <룰ID>                  Go·Java·Kotlin·Swift·TS
+//	<!-- EXPECT: <룰ID> -->            XML·plist (#61)
+//
+// 룰ID 문자는 `[A-Za-z0-9_.-]` 로 제한한다. XML 닫기(`-->`)가 룰ID 에 섞여 들어가는
+// 것을 막고, 마커 뒤에 설명을 덧붙이면 매칭 자체가 실패하게 하는 것이 목적이다.
+// 조용히 무시되는 대신 통합 테스트가 "마커 없는데 검출됨(오탐 회귀)" 으로 즉시
+// 실패해야 작성자가 알아챈다.
+var expectMarker = regexp.MustCompile(
+	`(?:(?:#|//)\s*EXPECT:\s*([\w.-]+)|<!--\s*EXPECT:\s*([\w.-]+)\s*-->)\s*$`)
+
+// expectMarkerRuleID 는 한 줄에서 마커의 룰ID 를 뽑는다. 마커가 아니면 "" 를 준다.
+//
+// 정규식이 주석 형태별로 캡처 그룹을 따로 갖기 때문에 호출부가 그룹 번호를 알 필요가
+// 없도록 여기서 흡수한다.
+func expectMarkerRuleID(line string) string {
+	m := expectMarker.FindStringSubmatch(line)
+	if m == nil {
+		return ""
+	}
+	if m[1] != "" {
+		return m[1]
+	}
+	return m[2]
+}
 
 func TestExpectMarkerSyntax(t *testing.T) {
-	re := regexp.MustCompile(expectMarkerPattern)
-
 	tests := []struct {
 		name string
 		line string
 		want string // 빈 문자열이면 매칭되지 않아야 한다
 	}{
-		// 매칭돼야 하는 형태
+		// 매칭돼야 하는 형태 — 줄 주석
 		{"파이썬/셸 주석", "# EXPECT: finguard.python.weak-hash", "finguard.python.weak-hash"},
 		{"TS/Java 주석", "// EXPECT: finguard.ts.eval", "finguard.ts.eval"},
 		{"들여쓰기", "    # EXPECT: finguard.python.eval-exec", "finguard.python.eval-exec"},
@@ -29,7 +73,15 @@ func TestExpectMarkerSyntax(t *testing.T) {
 		{"주석기호 뒤 공백 없음", "#EXPECT: finguard.swift.http-url", "finguard.swift.http-url"},
 		{"줄 끝 공백", "# EXPECT: finguard.java.xxe   ", "finguard.java.xxe"},
 
-		// 매칭되면 안 되는 형태
+		// 매칭돼야 하는 형태 — XML/plist 주석 (#61)
+		{"XML 한 줄 주석", "<!-- EXPECT: finguard.plist.ats-arbitrary-loads -->", "finguard.plist.ats-arbitrary-loads"},
+		{"XML 들여쓰기", "\t\t<!-- EXPECT: finguard.config.plist-secret -->", "finguard.config.plist-secret"},
+		{"XML 닫기 앞 공백 없음", "<!-- EXPECT: finguard.config.debug-logging-->", "finguard.config.debug-logging"},
+		{"XML 여는 태그 뒤 공백 없음", "<!--EXPECT: finguard.plist.ats-partial-exception-->", "finguard.plist.ats-partial-exception"},
+		{"XML 줄 끝 공백", "<!-- EXPECT: finguard.java.xxe -->  ", "finguard.java.xxe"},
+		{"XML 요소 뒤에 붙은 마커", "<key>X</key> <!-- EXPECT: finguard.config.plist-secret -->", "finguard.config.plist-secret"},
+
+		// 매칭되면 안 되는 형태 — 줄 주석
 		{"평범한 주석", "# 이 줄은 API 키를 담는다", ""},
 		{"EXPECT 언급만", "# 이 룰은 EXPECT 마커로 검증한다", ""},
 		{"콜론 없음", "# EXPECT finguard.python.weak-hash", ""},
@@ -37,22 +89,21 @@ func TestExpectMarkerSyntax(t *testing.T) {
 		{"룰ID 자리가 공백뿐", "# EXPECT:    ", ""},
 		{"주석 아닌 코드", `EXPECT = "finguard.python.weak-hash"`, ""},
 		{"뒤에 다른 내용이 붙음", "# EXPECT: finguard.python.weak-hash 이유: 테스트", ""},
+
+		// 매칭되면 안 되는 형태 — XML/plist (#61)
+		{"XML 마커 뒤 설명", "<!-- EXPECT: finguard.plist.ats-arbitrary-loads 이유: ATS -->", ""},
+		{"XML 닫기 뒤 내용", "<!-- EXPECT: finguard.plist.ats-arbitrary-loads --><key>X</key>", ""},
+		{"XML 주석 미종료", "<!-- EXPECT: finguard.plist.ats-arbitrary-loads", ""},
+		{"XML 평범한 주석", "<!-- 대조군 — INFO 는 대상이 아니다 -->", ""},
+		{"XML 룰ID 없음", "<!-- EXPECT: -->", ""},
+		{"XML 여는 기호 앞에 설명", "<!-- 참고 EXPECT: finguard.plist.ats-arbitrary-loads -->", ""},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := re.FindStringSubmatch(tc.line)
-			if tc.want == "" {
-				if m != nil {
-					t.Errorf("매칭되면 안 되는데 %q 로 매칭됐다: %q", m[1], tc.line)
-				}
-				return
-			}
-			if m == nil {
-				t.Fatalf("매칭돼야 하는데 안 됐다: %q", tc.line)
-			}
-			if m[1] != tc.want {
-				t.Errorf("룰ID 추출 결과 %q, 기대 %q (입력 %q)", m[1], tc.want, tc.line)
+			got := expectMarkerRuleID(tc.line)
+			if got != tc.want {
+				t.Errorf("룰ID 추출 결과 %q, 기대 %q (입력 %q)", got, tc.want, tc.line)
 			}
 		})
 	}
@@ -62,9 +113,205 @@ func TestExpectMarkerSyntax(t *testing.T) {
 //
 // 마커 줄에 설명을 덧붙이면 조용히 무시되는 대신 아예 매칭되지 않아야 한다.
 // 그래야 통합 테스트가 "마커 없는데 검출됨(오탐 회귀)" 으로 즉시 실패해 작성자가 알아챈다.
+// XML 주석도 같은 규칙을 따른다 — 닫기(`-->`) 앞이든 뒤든 설명이 붙으면 거부된다 (#61).
 func TestExpectMarkerRejectsTrailingText(t *testing.T) {
-	re := regexp.MustCompile(expectMarkerPattern)
-	if re.MatchString("# EXPECT: finguard.python.weak-hash — MD5 사용") {
-		t.Error("마커 뒤 설명을 허용하면 룰ID 에 설명이 섞여 들어간다 — 거부돼야 한다")
+	lines := []string{
+		"# EXPECT: finguard.python.weak-hash — MD5 사용",
+		"// EXPECT: finguard.python.weak-hash — MD5 사용",
+		"<!-- EXPECT: finguard.python.weak-hash — MD5 사용 -->",
+		"<!-- EXPECT: finguard.python.weak-hash --> MD5 사용",
+	}
+	for _, l := range lines {
+		if got := expectMarkerRuleID(l); got != "" {
+			t.Errorf("마커 뒤 설명을 허용하면 룰ID 에 설명이 섞여 들어간다 — 거부돼야 한다: %q → %q", l, got)
+		}
+	}
+}
+
+// TestExpectMarkerXMLCloserNotInRuleID 는 트레일링 `-->` 가 룰ID 에 섞이지 않음을 못박는다 (#61).
+//
+// 예전 문법(`(\S+)\s*$`)을 그대로 두고 `<!--` 만 주석 기호에 추가하면 `\S+` 가 `-->` 까지
+// 삼켜 룰ID 가 "finguard.plist.ats-arbitrary-loads-->" 가 된다. 그러면 마커는 매칭되지만
+// 어떤 검출과도 일치하지 않아 미탐 회귀로 오인된다.
+func TestExpectMarkerXMLCloserNotInRuleID(t *testing.T) {
+	const want = "finguard.plist.ats-arbitrary-loads"
+	for _, l := range []string{
+		"<!-- EXPECT: " + want + " -->",
+		"<!-- EXPECT: " + want + "-->",
+	} {
+		if got := expectMarkerRuleID(l); got != want {
+			t.Errorf("룰ID 추출 결과 %q, 기대 %q (입력 %q)", got, want, l)
+		}
+	}
+}
+
+// fixturesDir 는 룰 회귀 픽스처 디렉터리다.
+//
+// rules/ 바깥에 두는 것이 필수다 (#43) — semgrep 은 `--config <디렉터리>` 하위의 모든
+// .yml/.yaml 을 룰 파일로 재귀 파싱하므로, rules/ 안에 yaml 픽스처가 하나라도 있으면
+// 룰셋 전체가 "0 rule(s)" 로 로드 실패한다.
+func fixturesDir(t *testing.T) string {
+	t.Helper()
+	p, err := filepath.Abs("../../testdata/rule-fixtures")
+	if err != nil {
+		t.Fatalf("픽스처 경로 확인 실패: %v", err)
+	}
+	return p
+}
+
+// expectation 은 픽스처 한 줄에 기대되는 검출이다.
+type expectation struct {
+	file   string // 픽스처 루트 기준 상대경로 (슬래시 구분)
+	line   int    // 검출이 기대되는 줄 (마커 다음 줄)
+	ruleID string // 기대 룰 ID (semgrep 접두어 없는 suffix)
+}
+
+func (e expectation) String() string {
+	return e.file + ":" + itoa(e.line) + " " + e.ruleID
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}
+
+// walkFixtures 는 픽스처 트리를 **재귀로** 훑어 텍스트 파일마다 fn 을 부른다.
+//
+// 재귀가 핵심이다 (#60). 스캔(`CLI.Scan` → semgrep)은 대상 디렉터리를 재귀로 훑는데
+// 마커 파서만 `os.ReadDir` 로 최상위 파일을 보고 있었다. 그래서 하위 디렉터리 픽스처는
+// 검출은 되는데 기대값이 안 읽혀 정상 픽스처가 "오탐 회귀" 로 실패했고, 경로 구조 자체를
+// 판정 기준으로 삼는 룰(`paths.include` 를 쓰는 벤더 경로 룰 등)은 회귀 픽스처를
+// 아예 만들 수 없었다. 순회 범위를 스캔과 일치시킨다.
+//
+// rel 은 픽스처 루트 기준 상대경로다. 베이스명을 쓰면 서로 다른 디렉터리의 동명 파일이
+// 같은 키로 뭉개져 기대값이 섞인다.
+//
+// 확장자 화이트리스트 대신 NUL 바이트 유무로 바이너리를 거른다. 목록 방식은 새 형식의
+// 픽스처가 들어올 때 마커를 **조용히** 누락시키는데, 그건 이 인프라에서 가장 위험한
+// 실패 양상이다(기대값이 사라져도 테스트는 통과한다).
+func walkFixtures(t *testing.T, dir string, fn func(rel string, lines []string)) {
+	t.Helper()
+	err := filepath.WalkDir(dir, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		raw, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		if bytes.IndexByte(raw, 0) >= 0 {
+			return nil // 바이너리 — 마커가 있을 수 없다
+		}
+		rel, err := filepath.Rel(dir, p)
+		if err != nil {
+			return err
+		}
+		fn(filepath.ToSlash(rel), strings.Split(string(raw), "\n"))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("픽스처 순회 실패: %v", err)
+	}
+}
+
+// parseExpectations 는 픽스처 트리를 훑어 마커에서 기대 집합을 만든다.
+func parseExpectations(t *testing.T, dir string) map[expectation]bool {
+	t.Helper()
+	want := map[expectation]bool{}
+
+	walkFixtures(t, dir, func(rel string, lines []string) {
+		for i, l := range lines {
+			id := expectMarkerRuleID(l)
+			if id == "" {
+				continue
+			}
+			if i+1 >= len(lines) {
+				t.Errorf("%s:%d 마커가 파일 마지막 줄에 있어 대상 줄이 없다", rel, i+1)
+				continue
+			}
+			// lines 는 0-based, 파일 라인은 1-based → 마커 다음 줄 = i+2
+			want[expectation{file: rel, line: i + 2, ruleID: id}] = true
+		}
+	})
+	if len(want) == 0 {
+		t.Fatal("픽스처에서 EXPECT 마커를 하나도 찾지 못했다 — 마커 문법이 깨졌거나 경로가 틀렸다")
+	}
+	return want
+}
+
+// TestSafeFixturesHaveNoExpectations 는 safe_ 접두 픽스처가 마커를 갖지 않음을 강제한다.
+//
+// safe_* 는 "어떤 룰에도 걸리면 안 되는" 대조군이다. 여기에 마커가 생기면
+// TestFixtureExpectationsMatchScan 이 그 검출을 정당한 것으로 받아들여 대조군의 의미가
+// 사라진다.
+// 하위 디렉터리도 같은 기준으로 본다 (#60) — 대조군이 중첩 경로에 있다고 해서
+// 검사를 빠져나가면 안 된다. 판정은 상대경로의 베이스명 접두로 한다.
+func TestSafeFixturesHaveNoExpectations(t *testing.T) {
+	dir := fixturesDir(t)
+	walkFixtures(t, dir, func(rel string, lines []string) {
+		if !strings.HasPrefix(path.Base(rel), "safe_") {
+			return
+		}
+		for i, l := range lines {
+			if expectMarkerRuleID(l) != "" {
+				t.Errorf("%s:%d 대조군 픽스처에 EXPECT 마커가 있다 — safe_* 는 검출 0건이어야 한다", rel, i+1)
+			}
+		}
+	})
+}
+
+// TestParseExpectationsWalksSubdirectories 는 #60 의 핵심을 합성 트리로 못박는다.
+//
+// 실제 픽스처 트리는 semgrep 이 있어야 검증되지만, 순회 자체는 바이너리 없이 고정할 수
+// 있다. 확인하는 것은 셋이다.
+//   - 하위 디렉터리의 마커가 읽힌다 (예전 os.ReadDir 구현이 통째로 버리던 지점)
+//   - 서로 다른 디렉터리의 **동명 파일**이 상대경로로 구분돼 기대값이 섞이지 않는다
+//   - NUL 바이트가 있는 바이너리는 건너뛴다
+func TestParseExpectationsWalksSubdirectories(t *testing.T) {
+	root := t.TempDir()
+	write := func(rel, body string) {
+		t.Helper()
+		p := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatalf("사전 준비 실패: %v", err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatalf("사전 준비 실패: %v", err)
+		}
+	}
+
+	write("Trust.swift",
+		"// EXPECT: finguard.swift.insecure-trust\nSecTrustSetExceptions(t, b)\n")
+	write("Carthage/Checkouts/SDK/Trust.swift",
+		"// 벤더 사본 — 최상위와 베이스명이 같다\n// EXPECT: finguard.swift.insecure-trust-vendor\nSecTrustSetExceptions(t, b)\n")
+	write("Nested/Info.plist",
+		"<!-- EXPECT: finguard.plist.ats-arbitrary-loads -->\n<key>NSAllowsArbitraryLoads</key>\n")
+	write("blob.bin", "\x00# EXPECT: finguard.python.weak-hash\nx\n")
+
+	got := parseExpectations(t, root)
+	want := map[expectation]bool{
+		{file: "Trust.swift", line: 2, ruleID: "finguard.swift.insecure-trust"}:                               true,
+		{file: "Carthage/Checkouts/SDK/Trust.swift", line: 3, ruleID: "finguard.swift.insecure-trust-vendor"}: true,
+		{file: "Nested/Info.plist", line: 2, ruleID: "finguard.plist.ats-arbitrary-loads"}:                    true,
+	}
+	for e := range want {
+		if !got[e] {
+			t.Errorf("기대값이 읽히지 않았다: %s", e)
+		}
+	}
+	for e := range got {
+		if !want[e] {
+			t.Errorf("읽히면 안 되는 기대값이 나왔다: %s", e)
+		}
 	}
 }

--- a/internal/scanner/integration_test.go
+++ b/internal/scanner/integration_test.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 	"testing"
@@ -29,20 +28,6 @@ func rulesDir(t *testing.T) string {
 	return p
 }
 
-// fixturesDir 는 룰 회귀 픽스처 디렉터리다.
-//
-// rules/ 바깥에 두는 것이 필수다 (#43) — semgrep 은 `--config <디렉터리>` 하위의 모든
-// .yml/.yaml 을 룰 파일로 재귀 파싱하므로, rules/ 안에 yaml 픽스처가 하나라도 있으면
-// 룰셋 전체가 "0 rule(s)" 로 로드 실패한다.
-func fixturesDir(t *testing.T) string {
-	t.Helper()
-	p, err := filepath.Abs("../../testdata/rule-fixtures")
-	if err != nil {
-		t.Fatalf("픽스처 경로 확인 실패: %v", err)
-	}
-	return p
-}
-
 func requireSemgrep(t *testing.T) {
 	t.Helper()
 	if _, err := exec.LookPath("semgrep"); err != nil {
@@ -50,77 +35,12 @@ func requireSemgrep(t *testing.T) {
 	}
 }
 
-// ── 기대값 마커 ──
-//
-// 픽스처는 검출이 기대되는 줄 **바로 위**에 마커 주석을 단다 (#44):
-//
-//	# EXPECT: finguard.python.cleartext-websocket
-//	REALTIME_FEED_URL = "ws://ops.example-broker.co.kr:21000"
-//
-// 기대값이 테스트가 아니라 픽스처 안에 있으므로 블록을 어디에 추가하든 따라 움직인다.
-// 라인 번호를 테스트에 하드코딩하던 구조는 픽스처를 건드리는 모든 PR 을 서로
-// 충돌시켰고, 병합 후 조용히 어긋나기까지 했다.
-var expectMarker = regexp.MustCompile(`(?:#|//)\s*EXPECT:\s*(\S+)\s*$`)
-
-// expectation 은 픽스처 한 줄에 기대되는 검출이다.
-type expectation struct {
-	file   string // 픽스처 파일의 베이스명
-	line   int    // 검출이 기대되는 줄 (마커 다음 줄)
-	ruleID string // 기대 룰 ID (semgrep 접두어 없는 suffix)
-}
-
-func (e expectation) String() string {
-	return e.file + ":" + itoa(e.line) + " " + e.ruleID
-}
-
-func itoa(n int) string {
-	if n == 0 {
-		return "0"
-	}
-	var b []byte
-	for n > 0 {
-		b = append([]byte{byte('0' + n%10)}, b...)
-		n /= 10
-	}
-	return string(b)
-}
-
-// parseExpectations 는 픽스처 디렉터리를 훑어 마커에서 기대 집합을 만든다.
-func parseExpectations(t *testing.T, dir string) map[expectation]bool {
-	t.Helper()
-	want := map[expectation]bool{}
-
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		t.Fatalf("픽스처 디렉터리 읽기 실패: %v", err)
-	}
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
-		}
-		raw, err := os.ReadFile(filepath.Join(dir, e.Name()))
-		if err != nil {
-			t.Fatalf("픽스처 읽기 실패 %s: %v", e.Name(), err)
-		}
-		lines := strings.Split(string(raw), "\n")
-		for i, l := range lines {
-			m := expectMarker.FindStringSubmatch(l)
-			if m == nil {
-				continue
-			}
-			if i+1 >= len(lines) {
-				t.Errorf("%s:%d 마커가 파일 마지막 줄에 있어 대상 줄이 없다", e.Name(), i+1)
-				continue
-			}
-			// lines 는 0-based, 파일 라인은 1-based → 마커 다음 줄 = i+2
-			want[expectation{file: e.Name(), line: i + 2, ruleID: m[1]}] = true
-		}
-	}
-	if len(want) == 0 {
-		t.Fatal("픽스처에서 EXPECT 마커를 하나도 찾지 못했다 — 마커 문법이 깨졌거나 경로가 틀렸다")
-	}
-	return want
-}
+// 마커 문법(`expectMarkerRuleID`)과 픽스처 순회(`walkFixtures`·`parseExpectations`),
+// 그리고 대조군 검사(`TestSafeFixturesHaveNoExpectations`)는 빌드 태그가 없는
+// expect_marker_test.go 에 있다. 이 파일은 semgrep_integration 태그 뒤에 있어
+// 기본 `go test` 에서 컴파일되지 않으므로, 마커 문법을 여기 복제하면 양쪽이 어긋나도
+// 아무도 모른다 — 그 순간 이 테스트는 "기대 0건 · 검출 0건" 으로 조용히 통과한다
+// (#60·#61). 정의는 한 곳에만 두고, semgrep 이 필요한 검사만 여기 남긴다.
 
 // TestFixtureExpectationsMatchScan 은 픽스처 마커와 실제 스캔 결과가 정확히 일치하는지 본다.
 //
@@ -145,7 +65,8 @@ func TestFixtureExpectationsMatchScan(t *testing.T) {
 		if i := strings.LastIndex(id, "finguard."); i >= 0 {
 			id = id[i:]
 		}
-		got[expectation{file: filepath.Base(f.Path), line: f.StartLine, ruleID: id}] = true
+		// f.Path 는 ParseSARIF 가 스캔 루트(= 픽스처 루트) 기준 상대경로로 만들어 준다.
+		got[expectation{file: filepath.ToSlash(f.Path), line: f.StartLine, ruleID: id}] = true
 	}
 
 	var missing, unexpected []string
@@ -170,32 +91,6 @@ func TestFixtureExpectationsMatchScan(t *testing.T) {
 	}
 
 	t.Logf("기대 %d건 · 검출 %d건 · 전부 일치", len(want), len(got))
-}
-
-// TestSafeFixturesHaveNoExpectations 는 safe_ 접두 픽스처가 마커를 갖지 않음을 강제한다.
-//
-// safe_* 는 "어떤 룰에도 걸리면 안 되는" 대조군이다. 여기에 마커가 생기면 위 테스트가
-// 그 검출을 정당한 것으로 받아들여 대조군의 의미가 사라진다.
-func TestSafeFixturesHaveNoExpectations(t *testing.T) {
-	dir := fixturesDir(t)
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		t.Fatalf("픽스처 디렉터리 읽기 실패: %v", err)
-	}
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasPrefix(e.Name(), "safe_") {
-			continue
-		}
-		raw, err := os.ReadFile(filepath.Join(dir, e.Name()))
-		if err != nil {
-			t.Fatalf("픽스처 읽기 실패 %s: %v", e.Name(), err)
-		}
-		for i, l := range strings.Split(string(raw), "\n") {
-			if expectMarker.MatchString(l) {
-				t.Errorf("%s:%d 대조군 픽스처에 EXPECT 마커가 있다 — safe_* 는 검출 0건이어야 한다", e.Name(), i+1)
-			}
-		}
-	}
 }
 
 // TestNoYAMLFixturesUnderRules 는 #43 회귀 방어다.

--- a/testdata/rule-fixtures/Ats-Info.plist
+++ b/testdata/rule-fixtures/Ats-Info.plist
@@ -2,43 +2,39 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <!-- 룰 회귀 픽스처 — finguard.plist.ats-arbitrary-loads / finguard.plist.ats-partial-exception (#33)
      semgrep 은 매치 시작 줄(<key> 가 있는 줄)을 보고하므로 마커는 그 줄 바로 위에 둔다.
-     plist 는 주석 문법이 XML 이라 마커를 <!-- --> 안에 넣는다 (Secrets-Info.plist 선례). -->
+     마커는 XML 한 줄 주석 형태를 쓴다 (#61). -->
 <plist version="1.0">
 <dict>
 	<key>CFBundleIdentifier</key>
 	<string>com.example.trading</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<!-- <true></true> 표기형 — 기존 정규식('<true\s*/>')이 놓치던 자리다
-		# EXPECT: finguard.plist.ats-arbitrary-loads
-		--><key>NSAllowsArbitraryLoads</key>
+		<!-- 아래는 <true></true> 표기형 — 기존 정규식이 놓치던 자리다 -->
+		<!-- EXPECT: finguard.plist.ats-arbitrary-loads -->
+		<key>NSAllowsArbitraryLoads</key>
 		<true></true>
-		<!--
-		# EXPECT: finguard.plist.ats-partial-exception
-		--><key>NSAllowsArbitraryLoadsInWebContent</key>
+		<!-- EXPECT: finguard.plist.ats-partial-exception -->
+		<key>NSAllowsArbitraryLoadsInWebContent</key>
 		<true/>
-		<!--
-		# EXPECT: finguard.plist.ats-partial-exception
-		--><key>NSAllowsArbitraryLoadsForMedia</key>
+		<!-- EXPECT: finguard.plist.ats-partial-exception -->
+		<key>NSAllowsArbitraryLoadsForMedia</key>
 		<true></true>
 		<key>NSExceptionDomains</key>
 		<dict>
 			<key>pay.example-bank.co.kr</key>
 			<dict>
-				<!-- 결제 도메인을 예외에 넣고 '좁혔으니 안전' 이라 종결하는 실제 다수 형태
-				# EXPECT: finguard.plist.ats-partial-exception
-				--><key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<!-- 결제 도메인을 예외에 넣고 '좁혔으니 안전' 이라 종결하는 실제 다수 형태 -->
+				<!-- EXPECT: finguard.plist.ats-partial-exception -->
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
 				<true/>
-				<!--
-				# EXPECT: finguard.plist.ats-partial-exception
-				--><key>NSExceptionMinimumTLSVersion</key>
+				<!-- EXPECT: finguard.plist.ats-partial-exception -->
+				<key>NSExceptionMinimumTLSVersion</key>
 				<string>TLSv1.0</string>
 			</dict>
 			<key>cdn.example-vendor.com</key>
 			<dict>
-				<!--
-				# EXPECT: finguard.plist.ats-partial-exception
-				--><key>NSThirdPartyExceptionMinimumTLSVersion</key>
+				<!-- EXPECT: finguard.plist.ats-partial-exception -->
+				<key>NSThirdPartyExceptionMinimumTLSVersion</key>
 				<string>TLSv1.1</string>
 			</dict>
 		</dict>

--- a/testdata/rule-fixtures/Carthage/Checkouts/ExampleNetworkKit/ExampleTrustBypass.swift
+++ b/testdata/rule-fixtures/Carthage/Checkouts/ExampleNetworkKit/ExampleTrustBypass.swift
@@ -1,0 +1,38 @@
+//
+//  룰 회귀 픽스처 — finguard.swift.insecure-trust-vendor (#33, 픽스처는 #60)
+//
+//  이 룰은 `paths.include` 로 **경로 구조 자체**를 판정 기준으로 삼는다
+//  (Pods/**, Carthage/**, *.xcframework/**). 그래서 최상위에 파일을 두는 것으로는
+//  검증할 수 없고, 반드시 벤더 경로 하위에 픽스처가 있어야 한다.
+//  마커 파서가 하위 디렉터리를 순회하지 않던 동안에는 그게 불가능해서 이 룰만
+//  회귀 픽스처 없이 머지됐다 (#60).
+//
+//  경로가 Pods/ 가 아니라 Carthage/ 인 이유: finguard 의 DefaultExcludes 에
+//  "Pods" 가 들어 있어 `CLI.Scan` 이 semgrep 에 `--exclude Pods` 를 넘긴다.
+//  즉 Pods/ 하위는 룰의 include 와 무관하게 스캔 자체에서 빠진다. Carthage/ 는
+//  DefaultExcludes 에 없어 실제 운영 스캔에서도 이 룰이 발화하는 경로다.
+//
+//  합성 코드이며 실제 라이브러리 코드가 아니다.
+//
+
+import Foundation
+
+final class VendorSessionDelegate {
+
+    // 표준 API — 벤더 소스라도 최종 바이너리에서 그대로 실행된다.
+    func credential(for trust: SecTrust) -> URLCredential {
+        // EXPECT: finguard.swift.insecure-trust-vendor
+        return URLCredential(trust: trust)
+    }
+
+    // Alamofire 5 관용구.
+    func evaluators() -> Any {
+        // EXPECT: finguard.swift.insecure-trust-vendor
+        return ["api.example-bank.co.kr": DisabledTrustEvaluator()]
+    }
+
+    // 대조군 — 정상 평가기는 대상이 아니다.
+    func pinnedEvaluators() -> Any {
+        return ["api.example-bank.co.kr": PublicKeysTrustEvaluator()]
+    }
+}

--- a/testdata/rule-fixtures/Secrets-Info.plist
+++ b/testdata/rule-fixtures/Secrets-Info.plist
@@ -2,18 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <!-- 룰 회귀 픽스처 — finguard.config.plist-secret (#24)
      key 와 값이 두 줄로 나뉘어 key=value 정규식이 닿지 않는 형태다. 값은 합성 더미다.
-     semgrep 은 매치 시작 줄(<key> 가 있는 줄)을 보고하므로 마커는 그 줄 바로 위에 둔다. -->
+     semgrep 은 매치 시작 줄(<key> 가 있는 줄)을 보고하므로 마커는 그 줄 바로 위에 둔다.
+     마커는 XML 한 줄 주석 형태를 쓴다 (#61). -->
 <plist version="1.0">
 <dict>
 	<key>BUNDLE_ID</key>
 	<string>com.example.trading</string>
-	<!--
-	# EXPECT: finguard.config.plist-secret
-	--><key>API_KEY</key>
+	<!-- EXPECT: finguard.config.plist-secret -->
+	<key>API_KEY</key>
 	<string>AIzaSyA1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q</string>
-	<!--
-	# EXPECT: finguard.config.plist-secret
-	--><key>CLIENT_SECRET</key>
+	<!-- EXPECT: finguard.config.plist-secret -->
+	<key>CLIENT_SECRET</key>
 	<string>0d1f2a3b4c5d6e7f8091a2b3c4d5e6f7</string>
 	<key>IS_ADS_ENABLED</key>
 	<false/>

--- a/testdata/rule-fixtures/logback-payment.xml
+++ b/testdata/rule-fixtures/logback-payment.xml
@@ -2,13 +2,12 @@
 <!--
   finguard.config.debug-logging (#32) 정탐 픽스처 — logback 문법.
 
-  XML 에는 줄 주석이 없어 EXPECT 마커(`#|// EXPECT: <룰ID>` 로 줄이 끝나야 한다)를
-  한 줄짜리 <!-- ... --> 안에 넣을 수 없다. 주석을 다음 줄에서 닫고 대상 요소를 이어 쓴다.
+  EXPECT 마커는 XML 한 줄 주석 형태를 그대로 쓴다 (#61).
   마커 없는 줄은 오탐 방지 대조군이다.
 -->
 <configuration>
-  <!-- # EXPECT: finguard.config.debug-logging
-  --><logger name="com.example.outer.api.tossPayments" level="DEBUG"/>
+  <!-- EXPECT: finguard.config.debug-logging -->
+  <logger name="com.example.outer.api.tossPayments" level="DEBUG"/>
 
   <!-- 대조군 — INFO 는 대상이 아니다 -->
   <logger name="com.example.outer.api.kftc" level="INFO"/>


### PR DESCRIPTION
Closes #60
Closes #61

마커 인프라 두 건은 같은 파일(`internal/scanner/integration_test.go`,
`internal/scanner/expect_marker_test.go`)을 건드리고 서로 얽혀 있어 한 PR 로 처리한다.

## #60 — 하위 디렉터리 미순회

`parseExpectations` 가 `os.ReadDir` 로 최상위 파일만 읽고 하위 디렉터리를 버렸다.
스캔(`CLI.Scan` → semgrep)은 재귀라서 중첩 픽스처는 검출은 되는데 기대값이 안 읽혀
정상 픽스처가 "오탐 회귀" 로 실패했다.

- 순회를 `filepath.WalkDir` 로 바꿔 스캔과 범위를 일치시켰다.
- 기대값 키를 베이스명 → **픽스처 루트 기준 상대경로**로 바꿨다. 검출 쪽도
  `filepath.Base(f.Path)` 대신 `f.Path`(`ParseSARIF` 가 이미 스캔 루트 기준
  상대경로로 만들어 준다)를 쓴다. 다른 디렉터리의 동명 파일이 섞이지 않는다.
- `TestSafeFixturesHaveNoExpectations` 도 같은 기준으로 재귀 검사한다.
- 확장자 화이트리스트 대신 **NUL 바이트 유무**로 바이너리를 거른다. 목록 방식은 새
  형식의 픽스처가 들어올 때 마커를 *조용히* 누락시키는데, 기대값이 사라져도 테스트가
  통과하는 그 실패 양상이 이 인프라에서 가장 위험하다.

## #61 — XML/plist 주석 지원

`<!-- EXPECT: <룰ID> -->` 한 줄 형태를 1급으로 지원한다.

```xml
<!-- EXPECT: finguard.plist.ats-arbitrary-loads -->
<key>NSAllowsArbitraryLoads</key><true/>
```

- 룰ID 문자를 `[\w.-]` 로 제한해 트레일링 `-->` 가 룰ID 에 섞이지 않게 분리했다.
  기존 `(\S+)` 를 두고 `<!--` 만 추가하면 룰ID 가 `...loads-->` 가 되어 마커는
  매칭되지만 어떤 검출과도 일치하지 않아 미탐 회귀로 오인된다
  (`TestExpectMarkerXMLCloserNotInRuleID` 가 이걸 못박는다).
- **"마커 뒤 설명 금지" 규칙은 XML 에서도 동일하다** — 닫기(`-->`) 앞이든 뒤든 설명이
  붙으면 매칭되지 않는다. 조용히 무시되는 대신 통합 테스트가 오탐 회귀로 즉시 실패해야
  작성자가 알아챈다.
- 기존 `#`·`//` 케이스 전부 회귀 없음.
- `Ats-Info.plist`·`Secrets-Info.plist`·`logback-payment.xml` 의 우회 주석
  (주석을 다음 줄에서 닫기 / 3줄로 쪼개기)을 표준 형태로 정리했다.

## 정규식 복제 제거

`integration_test.go` 의 `expectMarker` 는 `semgrep_integration` 빌드 태그 뒤에 있어
기본 `go test` 에서 컴파일되지 않았고, 그래서 `expect_marker_test.go` 가 같은 문법을
태그 없이 복제해 고정하고 있었다. 둘이 어긋나면 마커가 조용히 무시되고 통합 테스트가
"기대 0건 · 검출 0건" 으로 통과한다.

빌드 태그는 파일을 **제외**할 뿐 추가하지는 않으므로 태그 없는 파일은 양쪽 모드에서
모두 컴파일된다. 이를 이용해 마커 문법·픽스처 순회·대조군 검사를 태그 없는
`expect_marker_test.go` 한 곳으로 모으고, 태그 뒤에는 semgrep 바이너리가 실제로 필요한
검사만 남겼다. **복제가 사라져 어긋남 자체가 구조적으로 불가능하다.**

부수 효과로 `TestSafeFixturesHaveNoExpectations` 가 기본 `go test` 에서도 돌게 됐다.
semgrep 을 부르지 않는 검사인데 태그에 가려 폐쇄망 CI 에서 실행되지 않고 있었다.

## 벤더 경로 룰의 회귀 픽스처가 성립한다

`finguard.swift.insecure-trust-vendor` 는 `paths.include` 로 **경로 구조 자체**를 판정
기준으로 삼아 회귀 픽스처를 만들 수 없었고, #33 에서 픽스처 없이 머지됐다. 이제
성립한다.

신규 픽스처: `testdata/rule-fixtures/Carthage/Checkouts/ExampleNetworkKit/ExampleTrustBypass.swift`
(마커 2건 + 대조군 1건). 픽스처 기대·검출 건수가 **166 → 168** 로 늘었고 전부 일치한다.

변이 시험 2번(아래)이 증거다 — 이 중첩 파일의 마커를 지우면 오탐 회귀로 실패한다.
즉 마커가 실제로 읽히고 있다. 수정 전 코드에서는 마커가 **있는 채로** 실패했다.

### 경로가 `Pods/` 가 아니라 `Carthage/` 인 이유 (실측)

이슈 #60 은 `Pods/` 하위 픽스처를 완료 조건으로 적었지만, 실측 결과 `Pods/` 는
성립하지 않는다. `DefaultExcludes`(`internal/scanner/exclude.go`)에 `"Pods"` 가 있어
`CLI.Scan` 이 semgrep 에 `--exclude Pods` 를 넘기기 때문이다.

동일 내용의 파일을 `Pods/ExampleSDK/A.swift` 와
`Carthage/Checkouts/ExampleSDK/A.swift` 에 두고 운영과 같은 인자로 돌린 결과:

```
rules.finguard.swift.insecure-trust-vendor  .../Carthage/Checkouts/ExampleSDK/A.swift  4
(Pods 경로는 결과 없음)
```

`Pods/` 하위는 룰의 `paths.include` 와 무관하게 **스캔 자체에서 빠진다.** 따라서
픽스처를 `Pods/` 에 두면 마커만 있고 검출이 없어 미탐 회귀로 실패한다 — 파서 문제가
아니라 제외 정책 문제다. `Carthage/` 는 `DefaultExcludes` 에 없어 운영 스캔에서도 이
룰이 실제로 발화하는 경로이므로 그쪽을 썼다.

> 별건 관찰: 이 룰의 `Pods/**` include 브랜치는 현재 운영 스캔에서 도달 불가다
> (`--exclude Pods` 가 항상 먼저 걸린다). 룰 파일은 이 PR 의 소유 범위 밖이라
> 건드리지 않았고, 판단이 필요하면 별도 이슈로 다루는 편이 맞다.

## 변이 시험

인프라를 고치는 PR 이라 "테스트가 실제로 물어뜯는지" 를 6종으로 확인하고 전부
원복했다.

| # | 변이 | 결과 |
| :-- | :--- | :--- |
| 1 | 최상위 픽스처(`swift_insecure_trust.swift`)의 마커 제거 | FAIL — `오탐 회귀 — 마커가 없는데 검출됐다: swift_insecure_trust.swift:16 finguard.swift.insecure-trust` |
| 2 | **중첩 픽스처**(`Carthage/.../ExampleTrustBypass.swift`)의 마커 제거 | FAIL — `오탐 회귀 ...: Carthage/Checkouts/ExampleNetworkKit/ExampleTrustBypass.swift:24 finguard.swift.insecure-trust-vendor` — 상대경로 키까지 확인된다 (**#60 수정 증거**) |
| 3 | 검출 안 되는 줄(`import Foundation`)에 마커 추가 | FAIL — `미탐 회귀 — 마커가 있는데 검출되지 않았다: swift_insecure_trust.swift:10 finguard.swift.insecure-trust` |
| 4 | `safe_swift_trust.swift` 에 마커 추가 | FAIL — 기본 `go test` 에서 `대조군 픽스처에 EXPECT 마커가 있다`, 태그 실행에서는 추가로 미탐 회귀까지 |
| 5 | XML 마커를 망가뜨림 (`<!-- EXPECT: ... 이유: ATS -->`) | FAIL — `오탐 회귀 ...: Ats-Info.plist:14 finguard.plist.ats-arbitrary-loads` (**#61 수정 증거** — 마커가 실제로 파싱되고 있으며, 설명을 붙이면 XML 에서도 거부된다) |
| 6 | 마커 정규식을 예전 문법(`(?:#|//)\s*EXPECT:\s*(\S+)\s*$`)으로 되돌림 | FAIL — 태그 **없는** `go test` 의 `TestExpectMarkerSyntax` 가 XML 케이스 6건을 즉시 잡는다. 두 정규식을 서로 다르게 만드는 변이 자체는 이제 불가능하다(정의가 하나뿐). 대신 semgrep 없이도 문법 회귀가 잡힌다는 점을 확인했다 |

## AGENTS.md 갱신

「테스트 → 룰 회귀 픽스처」 절에 반영했다.

- 주석 형태 3종 표(`#` / `//` / `<!-- ... -->`)와 XML 우회책 폐기 명시
- 하위 디렉터리 순회 규약, 기대값 키가 상대경로라는 점
- `DefaultExcludes` 에 걸리는 경로(`Pods/`)는 스캔에서 빠지므로 벤더 픽스처는
  `Carthage/` 를 쓴다는 함정
- 바이너리(NUL 바이트) 건너뜀
- 하위 디렉터리의 `safe_*` 도 같은 기준으로 검사
- **마커 문법·순회 구현은 `expect_marker_test.go` 한 곳뿐 — 복제 금지**

## 검증

| 명령 | 결과 |
| :--- | :--- |
| `go build -mod=vendor ./...` | 통과 |
| `go vet -mod=vendor ./...` | 통과 |
| `go vet -mod=vendor -tags semgrep_integration ./internal/scanner/` | 통과 |
| `go test -race -count=1 -mod=vendor ./...` | 전 패키지 ok |
| `go test -race -count=1 -mod=vendor -tags semgrep_integration ./internal/scanner/` | ok — `기대 168건 · 검출 168건 · 전부 일치` |
| `semgrep --validate --config rules/` | `0 configuration error(s), 122 rule(s)` |

`rules/*.yaml` 과 `mapping/rules.yaml` 은 건드리지 않았다.
