### PR TITLE
feat(#63): 약한 자격증명(weak-credential) 룰 신설 + 반복 필러 억제 적용

### DIFF
--- a/mapping/rules.yaml
+++ b/mapping/rules.yaml
@@ -1855,4 +1855,22 @@
     const apiKey = process.env.TEST_API_KEY;
     const maybe = apiKey ? describe : describe.skip;
     maybe("결제 연동", () => { /* ... */ });
+
+- rule_id: finguard.config.weak-credential
+  code: FIN-PWD-001
+  cwe: CWE-521
+  title: 약한 자격증명(반복 패턴 값)
+  severity: WARNING
+  basis: 개발보안가이드 「보안기능 - 취약한 비밀번호 허용」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 24 (유추 가능한 인증정보 이용 방지)"
+  explain: 설정파일의 자격증명 값이 같은 토큰의 반복(testkeytestkeytestkey·aaaaaaaa 형태)입니다. 자리표시자로 넣어 둔 더미라면 환경변수 치환으로 바꾸고, 실제 접속에 쓰이는 값이라면 유추 가능한 인증정보이므로 즉시 교체해야 합니다. 반복 패턴은 사전·규칙 기반 대입 공격의 1순위 후보입니다.
+  fix_example: |
+    ```yaml
+    # 값은 파일에 두지 않고 환경변수로 치환한다.
+    auth:
+      jwt:
+        secret-key: ${JWT_SECRET_KEY}
+
+    # 부득이하게 로컬 기본값이 필요하면 반복 패턴이 아닌 난수를 쓴다.
+    #   openssl rand -base64 32
     ```

--- a/rules/config.yaml
+++ b/rules/config.yaml
@@ -96,6 +96,12 @@ rules:
       #   대소문자 무시 플래그를 켜면 안 된다 — (?i) 아래에서는 [A-Z] 가 소문자까지 먹어
       #   `secret-key: test_sk_...` 같은 실키를 CONSTANT_CASE 로 오인해 억제한다(실측).
       - pattern-not-regex: '(?m)^[ \t]*["'']?[\w.-]+["'']?[ \t]*[:=][ \t]*["'']?(?:[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)["'']?[ \t]*(?:#.*)?$'
+      # 값이 같은 토큰의 되풀이로 시작하는 반복 필러는 시크릿이 아니다 (#23 (d), #63).
+      # 억제만 하면 평가기준 24(유추 가능한 인증정보) 대상이 사라지므로,
+      # 같은 값을 finguard.config.weak-credential(WARNING)이 이어받는다 — 두 룰은
+      # 이 정규식을 공유해 정확히 상호배타다. 한쪽만 고치면 중복 코멘트 또는 무검출이 된다.
+      # (semgrep 은 YAML 앵커/별칭을 해석하지 못한다 — 세 룰에 같은 문자열을 그대로 복제한다)
+      - pattern-not-regex: '(?im)^[ \t]*(?:export[ \t]+)?(-[ \t]+)?["'']?[\w.-]+["'']?[ \t]*[:=][ \t]*["''`]?(?=[A-Za-z0-9_-]*[A-Za-z0-9])([A-Za-z0-9_-]{2,12})\2{2,}[A-Za-z0-9_-]*["''`]?[ \t]*[,;)]*[ \t]*(?:#.*|//.*)?$'
       # pattern-not-regex 는 검출 범위를 "포함"할 때만 억제된다(semgrep 1.169.0 실측).
       # 값 부분만 매칭하는 정규식은 필터로 동작하지 않으므로 아래 억제 패턴은 줄 전체를 잡는다.
       #
@@ -167,6 +173,8 @@ rules:
       # 시크릿 저장소 참조는 시크릿이 아니라 올바른 사용법이다
       - pattern-not-regex: '(?im)^\s*["'']?[\w.-]+["'']?\s*[:=]\s*["'']?(\$|\{\{|<%|%\(|env:|secretKeyRef|valueFrom|vault:|aws:|arn:).*$'
       - pattern-not-regex: '(?im)^\s*["'']?[\w.-]+["'']?\s*[:=]\s*["'']?[\w-]{0,6}\.{2,}["'']?\s*$'
+      # 반복 필러 → finguard.config.weak-credential(WARNING) 담당 (#23 (d), #63)
+      - pattern-not-regex: '(?im)^[ \t]*(?:export[ \t]+)?(-[ \t]+)?["'']?[\w.-]+["'']?[ \t]*[:=][ \t]*["''`]?(?=[A-Za-z0-9_-]*[A-Za-z0-9])([A-Za-z0-9_-]{2,12})\2{2,}[A-Za-z0-9_-]*["''`]?[ \t]*[,;)]*[ \t]*(?:#.*|//.*)?$'
 
   # ── 결제·인증 패키지 debug/trace 로깅 (CWE-532) (#32) ────────────────────────
   #
@@ -283,6 +291,8 @@ rules:
       - pattern-not-regex: '(?im)^\s*["'']?[\w.-]+["'']?\s*[:=]\s*["'']?(\$|\{\{|<%|%\(|env:|secretKeyRef|valueFrom|vault:|aws:|arn:).*$'
       - pattern-not-regex: '(?im)^\s*[\w.-]+\s*:=.*$'
       - pattern-not-regex: '(?im)^\s*["'']?[\w.-]+["'']?\s*[:=]\s*[\w.]+[(\[].*$'
+      # 반복 필러 → finguard.config.weak-credential(WARNING) 담당 (#23 (d), #63)
+      - pattern-not-regex: '(?im)^[ \t]*(?:export[ \t]+)?(-[ \t]+)?["'']?[\w.-]+["'']?[ \t]*[:=][ \t]*["''`]?(?=[A-Za-z0-9_-]*[A-Za-z0-9])([A-Za-z0-9_-]{2,12})\2{2,}[A-Za-z0-9_-]*["''`]?[ \t]*[,;)]*[ \t]*(?:#.*|//.*)?$'
 
   # 로컬·테스트 프로파일이라도 값이 고신뢰 벤더 프리픽스면 실제로 유효한 키다 (#25).
   # 파일명으로 severity 를 깎으면 이 구간이 게이트를 통과해 버리므로 ERROR 로 승격한다.
@@ -322,3 +332,80 @@ rules:
     patterns:
       - pattern-regex: '(?i)^[ \t]*["'']?[\w.-]+["'']?[ \t]*[:=][ \t]*["'']?(?:sk_live_|sk_test_|rk_live_|pk_live_|test_sk_|live_sk_|imp_|ghp_|gho_|github_pat_|xoxb-|xoxp-|AKIA|AIza)[A-Za-z0-9_\-]{8,}'
       - pattern-not-regex: '(?im)^\s*["'']?[\w.-]+["'']?\s*[:=]\s*["'']?(\$|\{\{|<%|%\(|env:|secretKeyRef|valueFrom|vault:).*$'
+
+  # 약한 자격증명 — 반복 패턴 값 (#63, #23 (d) 의 보상통제).
+  #
+  # 위 세 시크릿 룰(plaintext-secret · plaintext-secret-nonprod · ci.plaintext-secret)은
+  # `secret-key: testkeytestkeytestkey…` 같은 반복 필러를 억제한다. 억제만 하면 그 값이
+  # 무검출이 되는데, 반복 패턴 값은 "플레이스홀더" 이기 이전에 **유추 가능한 인증정보**라
+  # 전자금융기반시설 평가기준 24 의 점검 대상이다. 억제된 값을 이 룰이 그대로 이어받아
+  # WARNING 으로 남긴다 — 그래야 감사에서 '점검 누락' 이 되지 않는다.
+  #
+  # 상호배타 보장: 세 룰의 억제 정규식과 이 룰의 탐지 정규식은 값 부분이 글자 그대로
+  # 같아야 한다(semgrep 이 YAML 앵커를 해석하지 못해 복제로 유지한다). 한쪽만 고치면
+  # 같은 줄에 ERROR·WARNING 이 중복으로 달리거나 반대로 아무것도 안 달린다.
+  # 회귀 픽스처 testdata/rule-fixtures/config_weak_credential.yml 이 양방향으로 고정한다.
+  #
+  # 의도적으로 좁힌 범위 — 오탐이 터지기 쉬운 룰이라 "확실한 반복" 만 본다.
+  #   - 연속 문자(`12345678`·`qwerty`)·사전어 단독값은 넣지 않았다. 그 값들은 위 시크릿
+  #     룰이 이미 ERROR 로 잡고 있어, 여기서 다시 잡으면 같은 줄에 코멘트가 두 번 달린다.
+  #     WARNING 으로 옮기려면 기존 ERROR 통제를 낮추는 것이라 별도 판단이 필요하다.
+  #   - 값에 영숫자·`_`·`-` 외의 문자가 있으면 보지 않는다(`P@ssw0rd!` 형태 제외) —
+  #     특수문자가 섞인 값은 실제 자격증명일 확률이 높아 시크릿 룰 소관으로 남긴다.
+  #   - 토큰 최소 2자 × 3회 = 최소 6자. 그보다 짧은 값은 판단 근거가 약하다.
+  #   - 언어 룰(python·java·kotlin·go·shell·swift·typescript)에는 억제도 이 룰도 넣지
+  #     않았다. 억제가 없으니 보상통제도 필요 없고(무검출 구간이 생기지 않는다),
+  #     10개 실코드 코퍼스에서 언어 소스의 반복 필러는 테스트 파일 1건뿐이라
+  #     실증 근거 없이 무음 룰만 늘리게 된다.
+  - id: finguard.config.weak-credential
+    languages: [regex]
+    severity: WARNING
+    message: 설정파일의 자격증명 값이 같은 토큰의 반복(testkeytestkeytestkey·aaaaaaaa 형태)입니다. 더미 자리표시자라면 환경변수 치환으로 바꾸고, 실제로 쓰이는 값이라면 유추 가능한 인증정보이므로 즉시 교체해야 합니다.
+    paths:
+      # plaintext-secret · plaintext-secret-nonprod · ci.plaintext-secret 세 룰의
+      # include 합집합 — 셋 중 어디서 억제되든 이 룰이 받아야 구멍이 생기지 않는다.
+      include:
+        - "application*.yml"
+        - "application*.yaml"
+        - "*.properties"
+        - "*.yml"
+        - "*.yaml"
+        - ".env"
+        - ".env.*"
+        - "*.env"
+        - "config*.json"
+        - "appsettings*.json"
+        - "*.tfvars"
+        - "*.xcconfig"
+        - "*.example"
+        - "*.sample"
+        - ".github/workflows/**"
+        - "**/.github/workflows/**"
+        - ".gitlab-ci*.yml"
+        - "**/.gitlab-ci*.yml"
+        - "*gitlab-ci*.yml"
+        - ".circleci/**"
+        - "**/.circleci/**"
+      exclude:
+        - "**/node_modules/**"
+        - "**/vendor/**"
+        - "Pods/**"
+        - "**/*.lock"
+        - "**/package-lock.json"
+        # 어떤 시크릿 룰도 보지 않는 경로 — 억제된 값이 없으므로 이어받을 것도 없다
+        - "*.template"
+        - "*.dist"
+        - ".env.template"
+    patterns:
+      - pattern-regex: '(?i)^[ \t]*(?:export[ \t]+)?(-[ \t]+)?["'']?[\w.-]*(password|passwd|pwd|secret|api[_-]?key|token|credential|passphrase|private[_-]?key|signing[_-]?key|encrypt(?:ion)?[_-]?key|master[_-]?key|aes[_-]?key|hmac[_-]?key)[\w.-]*["'']?[ \t]*[:=][ \t]*["''`]?(?=[A-Za-z0-9_-]*[A-Za-z0-9])([A-Za-z0-9_-]{2,12})\3{2,}[A-Za-z0-9_-]*["''`]?[ \t]*[,;)]*[ \t]*(?:#.*|//.*)?$'
+      # 마스킹 플레이스홀더(xxxxxxxx·********)는 이미 시크릿 룰이 "가리는 코드" 로 보고
+      # 억제하는 값이다. 여기서 다시 잡으면 그 결정을 뒤집는 셈이라 같은 목록으로 억제한다.
+      - pattern-not-regex: '(?im)^[ \t]*(?:export[ \t]+)?(-[ \t]+)?["'']?[\w.-]+["'']?[ \t]*[:=][ \t]*["''`]?(\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]?[ \t]*[,;)]*[ \t]*(?:#.*|//.*)?$'
+      # 한국어 안내문은 시크릿도 자격증명도 아니라 입력 지시문이다 (#23)
+      - pattern-not-regex: '(?im)^[^\n]*[:=][ \t]*["''`]?[^"''`\n]*(입력[ \t]*(?:하세요|해[ \t]*주세요|해주세요|바랍니다|하십시오)|여기에?[ \t]*입력|발급[ \t]*받은|본인의|자신의|예시|샘플)[^\n]*$'
+      # 값 전체가 CONSTANT_CASE 인 스칼라는 상수명·자리표시자다 (#23)
+      - pattern-not-regex: '(?m)^[ \t]*["'']?[\w.-]+["'']?[ \t]*[:=][ \t]*["'']?(?:[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)["'']?[ \t]*(?:#.*)?$'
+      # 컨테이너 부트스트랩 변수는 ci.plaintext-secret 과 같은 이유로 제외한다 —
+      # services:/image: 로 띄우는 일회성 로컬 자격증명이다
+      - pattern-not-regex: '(?im)^\s*["'']?(POSTGRES|POSTGRESQL|MYSQL|MARIADB|MONGO|MONGODB|REDIS|RABBITMQ|ELASTIC|MSSQL|SA)_[\w]*(PASSWORD|PASS)["'']?\s*[:=].*$'
+      - pattern-not-regex: '(?im)^\s*["'']?(MYSQL_ROOT_PASSWORD|MONGO_INITDB_ROOT_PASSWORD|SA_PASSWORD)["'']?\s*[:=].*$'

--- a/testdata/rule-fixtures/application-weakcred-local.yml
+++ b/testdata/rule-fixtures/application-weakcred-local.yml
@@ -1,0 +1,12 @@
+# finguard.config.plaintext-secret-nonprod → weak-credential 인계 픽스처 (#63).
+#
+# 로컬 프로파일은 plaintext-secret 의 exclude 라 nonprod(WARNING) 소관이다.
+# 그쪽에도 반복 필러 억제가 들어갔으므로, 같은 값이 weak-credential 로 넘어오는지
+# (= 무검출 구간이 생기지 않는지) 확인한다.
+auth:
+  jwt:
+    # EXPECT: finguard.config.weak-credential
+    secret-key: testkeytestkeytestkeytestkeytest
+    # 난수 값은 그대로 nonprod 가 잡는다 — 억제가 과하지 않은지 고정
+    # EXPECT: finguard.config.plaintext-secret-nonprod
+    refresh-secret: Zk7Qp3mXv9Lr2Ns8Td4Yb6Hc

--- a/testdata/rule-fixtures/config_weak_credential.yml
+++ b/testdata/rule-fixtures/config_weak_credential.yml
@@ -1,0 +1,41 @@
+# finguard.config.weak-credential 회귀 픽스처 (#63).
+#
+# 반복 필러가 finguard.config.plaintext-secret 에서 빠지고(#23 (d) 억제)
+# finguard.config.weak-credential 로 잡히는지를 양방향으로 고정한다.
+# 한 줄에 두 룰이 함께 걸리면 MR 에 코멘트가 두 번 달린다 — 마커가 정확히
+# 하나씩만 붙는다는 사실 자체가 상호배타 검증이다.
+app:
+  # 같은 토큰의 되풀이 — 이슈 실코드 근거(DuDoong application-common-local.yml)와 같은 형태
+  # EXPECT: finguard.config.weak-credential
+  secret-key: testkeytestkeytestkeytestkeytest
+  # 같은 문자의 되풀이
+  # EXPECT: finguard.config.weak-credential
+  db-password: aaaaaaaaaa
+  # 키보드 패턴의 되풀이
+  # EXPECT: finguard.config.weak-credential
+  api-key: 1q2w3e1q2w3e1q2w3e
+  # 따옴표가 붙어도 값 경계는 같다
+  # EXPECT: finguard.config.weak-credential
+  access-token: "abababababab"
+  # 뒤에 주석이 붙어도 값 경계는 같다
+  # EXPECT: finguard.config.weak-credential
+  refresh-token: bobobobobo # 로컬 전용
+
+  # ── (d) 억제가 과하지 않은지 고정하는 정탐 대조군 ──────────────────────────
+  # 난수 시크릿은 그대로 plaintext-secret(ERROR) 이 잡는다
+  # EXPECT: finguard.config.plaintext-secret
+  jwt-secret: Zk7Qp3mXv9Lr2Ns8Td4Yb6Hc
+  # 한글 혼합 실비밀번호도 그대로 남는다 (#23 (b) 폐기 결정을 테스트로 고정)
+  # EXPECT: finguard.config.plaintext-secret
+  admin-password: 금융보안1234!
+
+  # ── 어느 쪽도 잡으면 안 되는 값 ────────────────────────────────────────────
+  # 마스킹 플레이스홀더는 시크릿도 자격증명도 아니다 — weak-credential 이
+  # 기존 플레이스홀더 억제 결정을 뒤집지 않는지 확인한다
+  masked-password: xxxxxxxxxx
+  redacted-secret: "********"
+  filler-secret: ____________
+  # 토큰 2자 × 3회(6자) 미만은 판단 근거가 약해 보지 않는다
+  short-pwd: aaa
+  # 값에 특수문자가 섞이면 실제 자격증명 쪽에 가까워 반복 판정 대상이 아니다
+  vault-secret: ${VAULT_JWT_SECRET}

--- a/testdata/rule-fixtures/safe_config_weakcred.yml
+++ b/testdata/rule-fixtures/safe_config_weakcred.yml
@@ -1,0 +1,11 @@
+# 대조군 (#63) — 어떤 룰에도 걸리면 안 된다. 마커를 가질 수 없다.
+app:
+  # 환경변수 치환이 정답이다
+  secret-key: ${JWT_SECRET_KEY}
+  db-password: ${DB_PASSWORD}
+  # 마스킹 플레이스홀더
+  masked-api-key: xxxxxxxxxx
+  # 반복이지만 6자 미만
+  short-pwd: aaa
+  # 자격증명 어휘가 아닌 키
+  pool-size: 10

--- a/testdata/rule-fixtures/weakcred-gitlab-ci.yml
+++ b/testdata/rule-fixtures/weakcred-gitlab-ci.yml
@@ -1,0 +1,10 @@
+# finguard.ci.plaintext-secret → weak-credential 인계 픽스처 (#63).
+#
+# CI 설정도 반복 필러를 억제하므로, weak-credential 의 include 에 CI 경로가
+# 빠지면 그 구간만 조용히 무검출이 된다. 그 구멍을 막는 고정이다.
+variables:
+  # EXPECT: finguard.config.weak-credential
+  DEPLOY_TOKEN: zxzxzxzxzxzx
+  # 난수 값은 그대로 ci.plaintext-secret 이 잡는다
+  # EXPECT: finguard.ci.plaintext-secret
+  REGISTRY_PASSWORD: Zk7Qp3mXv9Lr2Ns8


### PR DESCRIPTION
Closes #63

#23 의 (d) 를 그대로 적용하지 않고, 먼저 보상통제(`weak-credential`)를 만든 뒤 억제를 붙였다. 두 검증 렌즈가 지적한 대로 반복 패턴 값은 "플레이스홀더" 이기 이전에 **유추 가능한 인증정보**이고, 그것은 전자금융기반시설 평가기준 24 의 점검 대상이다. 억제만 넣으면 그 항목이 무검출로 남아 감사에서 '점검 누락' 이 된다.

## ① 신설 룰과 대상 언어

| 룰 ID | severity | 매핑 코드 | 대상 |
| :--- | :--- | :--- | :--- |
| `finguard.config.weak-credential` | WARNING | `FIN-PWD-001` (CWE-521) | 설정파일(yml/yaml/properties/.env/json/tfvars/xcconfig/CI 설정) |

**언어 소스(python·java·kotlin·go·shell·swift·typescript)에는 룰을 만들지 않았다.** 근거는 두 가지다.

1. **구멍이 생기지 않는다.** 이 PR 은 언어 룰의 `hardcoded-secret` 에 (d) 억제를 넣지 않았다. 억제가 없으면 기존 ERROR 검출이 그대로 유지되므로 보상통제가 필요한 무검출 구간 자체가 없다.
2. **실증이 없다.** 10개 실코드 코퍼스 전체를 반복 패턴 정규식으로 훑었을 때 언어 소스의 반복 필러는 `DuDoong-Backend` 의 테스트 파일 1건뿐이었고, 그 줄은 이미 `hardcoded-secret-test`(ERROR)·`hardcoded-crypto-key`(ERROR)가 잡고 있다. 여기에 룰을 더 만들면 발화하지 않는 무음 룰만 6개 늘어난다 — #37·#34 에서 코퍼스 검출 0건이라 ERROR 승격을 보류한 것과 같은 판단이다.

`rules/typescript.yaml` 은 이 PR 에서 손대지 않았다(#66·#70 진행 중).

## ② 기존 플레이스홀더 억제와의 중복 조율

세 층으로 조율했다.

1. **시크릿 룰 ↔ weak-credential 은 상호배타.** `finguard.config.plaintext-secret` · `plaintext-secret-nonprod` · `ci.plaintext-secret` 세 룰에 (d) 억제를 넣고, **정확히 같은 값 정규식**을 weak-credential 의 탐지식으로 썼다. 같은 줄에 두 코멘트가 달리는 일이 없다.
2. **weak-credential 도 기존 플레이스홀더 억제를 그대로 상속한다.** `xxxxxxxx`·`********`·`____________`·`changeme`·`dummy` 등은 시크릿 룰이 "가리는 코드" 로 보고 억제하기로 이미 결정한 값이다. weak-credential 이 이를 다시 잡으면 그 결정을 뒤집는 셈이라, 같은 negative 목록(플레이스홀더·한국어 안내문·CONSTANT_CASE·컨테이너 부트스트랩 변수)을 복제해 넣었다.
3. **include 는 세 시크릿 룰의 합집합.** 셋 중 어디서 억제되든 weak-credential 이 받는다. CI 경로가 빠지면 그 구간만 조용히 무검출이 되므로, 그 구멍을 픽스처(`weakcred-gitlab-ci.yml`)로 막았다.

⚠️ semgrep 1.169.0 은 **YAML 앵커/별칭을 해석하지 못한다**(`Expected a string value for pattern-not-regex`). DRY 하게 묶을 수 없어 네 곳에 같은 문자열을 복제했고, 그 동기화가 깨지면 픽스처가 즉시 실패하도록 고정했다.

`hardcoded-secret-test` 계열·`plist-secret`·`plaintext-secret-vendorkey` 는 건드리지 않았다. 억제를 넣지 않았으므로 대응하는 보상통제도 필요 없다.

## ③ #23 (d) 억제 적용 여부

**적용했다** — 단 config 계열 3개 룰에만. 보상통제 룰이 실제로 그 값을 받는 것을 픽스처와 실코드 양쪽에서 확인한 뒤 적용했다.

값 정규식(4곳 공통):

```
(?im)^[ \t]*(?:export[ \t]+)?(-[ \t]+)?["']?[\w.-]+["']?[ \t]*[:=][ \t]*["'`]?
(?=[A-Za-z0-9_-]*[A-Za-z0-9])([A-Za-z0-9_-]{2,12})\2{2,}[A-Za-z0-9_-]*
["'`]?[ \t]*[,;)]*[ \t]*(?:#.*|//.*)?$
```

이슈 지시대로 트레일링은 `\s*` 가 아니라 `[ \t]*` 로 뒀다.

원안 정규식에서 바꾼 점이 하나 있다. 원안은 반복이 **값 끝까지 정확히 타일링**되는 경우만 잡는데(`(...)\1{2,}` 뒤에 바로 `$`), 실코드 근거인 `secret-key: testkeytestkeytestkeytestkeytest` 는 마지막 반복이 잘려 있어 **원안 정규식으로는 매칭되지 않는다**(semgrep 1.169.0 으로 실측 확인). 값이 `[A-Za-z0-9_-]` 로만 이루어져 줄 끝까지 이어진다는 조건을 유지한 채, 반복 뒤 잔여 문자를 허용하도록 고쳤다.

오탐을 줄이려고 의도적으로 좁힌 부분:

- 값에 `[A-Za-z0-9_-]` 외의 문자가 있으면 보지 않는다 → `P@ssw0rd!2026`·`금융보안1234!`·base64 `...==` 는 시크릿 룰 소관으로 남는다.
- 토큰 최소 2자 × 3회 = **최소 6자**. `aaa` 같은 짧은 값은 판단 근거가 약하다.
- 반복 토큰이 영숫자를 포함해야 한다 → `______`·`------` 같은 구분선은 제외.
- **연속 문자(`12345678`·`qwerty`)·사전어 단독값은 넣지 않았다.** 이슈 본문 목록에는 있지만, 그 값들은 지금도 시크릿 룰이 **ERROR** 로 잡고 있다. 여기서 다시 잡으면 같은 줄에 ERROR+WARNING 이 중복으로 달리고, 중복을 피하려 시크릿 룰에서 억제하면 기존 ERROR 통제를 WARNING 으로 **낮추는** 결정이 된다. 그건 이 이슈의 "보상통제 신설" 과 방향이 반대라 별도 판단으로 남긴다.

## ④ 실코드 전/후 비교 (10개 레포)

⚠️ 기존 `/private/tmp/.../campaign` 코퍼스는 macOS 정리로 10개 중 5개가 통째로, 나머지도 부분 소실돼 있었다(`r0b` 1192 / `r1b` 288 / `r2` 17 / `r4` 1 / `r5` 7 / `r6` 27 / `r9` 5, 나머지 0). `campaign2` 에 전량 재클론된 사본을 확인하고 그쪽으로 스캔했다. 스캔 전 파일 수를 전수 확인했다(총 3176 파일, 최소 레포 10 파일).

스캔은 `finguard scan --dir` 로 운영 경로를 그대로 태웠다(`.semgrepignore` 심기 + `DefaultExcludes` 포함). 수치는 **매핑되어 실제 코멘트가 달리는 건수**다.

| # | 레포 | 파일 수 | 전 | 후 | 증감 |
| :-- | :--- | --: | --: | --: | :-- |
| r0 | koreainvestment/open-trading-api | 1193 | 45 | 45 | 0 |
| r1 | samchon/payments | 289 | 15 | 15 | 0 |
| r2 | DingdingKim/CoinNow | 109 | 1 | 1 | 0 |
| r3 | Gosrock/DuDoong-Backend | 1035 | 11 | 11 | 0 (구성 변경 1건) |
| r4 | iamport/iamport-rest-client-python | 43 | 0 | 0 | 0 |
| r5 | banksalad/AXSnapshot | 21 | 0 | 0 | 0 |
| r6 | namjug-kim/reactive-crypto | 340 | 2 | 2 | 0 |
| r7 | sharebook-kr/pybithumb | 10 | 0 | 0 | 0 |
| r8 | iamport/iamport-rest-client-java | 90 | 7 | 7 | 0 |
| r9 | techinpark/upbitBar | 46 | 2 | 2 | 0 |
| | **합계** | **3176** | **83** | **83** | **0** |

**변화는 한 줄뿐이다.**

| 위치 | 전 | 후 |
| :--- | :--- | :--- |
| `DuDoong-Common/src/main/resources/application-common-local.yml:3` | `FIN-KEY-015` 로컬·테스트 프로파일 평문 시크릿 (WARNING) | `FIN-PWD-001` 약한 자격증명(반복 패턴 값) (WARNING) |

증가분 전수 검증: 신규 검출은 이 1건이고, 값은 7자 토큰이 반복된 형태다(값 자체는 기재하지 않는다). **정탐**이다 — 반복 패턴 자격증명은 평가기준 24 의 대상이고, 코멘트 문구가 "평문 시크릿" 에서 "유추 가능한 인증정보" 로 바뀌어 실제 성격에 더 맞는다. **신규 오탐 0건, 검출 손실 0건.**

이슈 본문은 이 줄이 "현재 `finguard.config.plaintext-secret` ERROR 로 발화하는 오탐" 이라고 적고 있는데, #25 로 로컬 프로파일이 분리된 뒤로는 `plaintext-secret-nonprod`(WARNING)가 잡고 있다. 억제·인계 대상 룰을 그 실측에 맞춰 잡았다.

## ⑤ 변이 시험

`testdata/rule-fixtures/` 픽스처 4종(정탐 3 + 대조군 `safe_` 1)을 넣고, 테스트가 실제로 실패하는지 3가지로 확인한 뒤 원복했다.

| 변이 | 결과 |
| :--- | :--- |
| `db-password: aaaaaaaaaa` 의 `# EXPECT:` 마커 제거 | `오탐 회귀 — 마커가 없는데 검출됐다: config_weak_credential.yml:12` 로 FAIL |
| 검출되지 않는 `short-pwd: aaa` 에 마커 추가 | `미탐 회귀 — 마커가 있는데 검출되지 않았다: config_weak_credential.yml:40` 로 FAIL |
| `plaintext-secret` 의 (d) 억제를 무력화(`\2{2,}` → `\2{9,}`) | `오탐 회귀` 5건 — 반복 필러 5줄에 ERROR 코멘트가 **중복으로** 달림. 상호배타가 실제로 동작 중임을 확인 |

세 번째가 이 PR 의 핵심 불변식(억제 정규식 ↔ 탐지 정규식 동기화)을 고정한다.

## ⑥ 매핑 `basis`·`kisa_item` 출처

```yaml
basis:     개발보안가이드 「보안기능 - 취약한 비밀번호 허용」
kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 24 (유추 가능한 인증정보 이용 방지)"
```

- `kisa_item` 은 레포의 `docs/평가기준_웹모바일HTS_66항목.md` 33행 `| 24 | 유추 가능한 인증정보 이용 방지 | 5 |` 과 **항목번호·항목명을 글자 그대로 대조**해 확인했다. 표기 형식은 기존 122개 엔트리와 동일하다.
- `basis` 는 기존 매핑에 선례가 없는 신규 문구다(기존 `보안기능` 항목은 「하드코드된 중요정보」·「중요정보 평문 저장」 등). #63 본문에 검증 렌즈가 제시한 값을 그대로 옮겼다 — 지어낸 문구가 아니다. 「취약한 비밀번호 허용」 은 개발보안가이드 '보안기능' 분류의 실재 항목이며 CWE-521 에 대응한다. 표기가 사내 기준과 다르면 이 필드만 고치면 된다(룰 로직과 무관).

## 검증 명령

| 명령 | 결과 |
| :--- | :--- |
| `semgrep --validate --config rules/` | `Configuration is valid — 0 error(s), 123 rule(s)` |
| 룰 수 ↔ 매핑 수 대조(python) | `rules: 123 / mapping: 123`, 중복 0 · 매핑 없는 룰 0 · 룰 없는 매핑 0 |
| `go build -mod=vendor ./... && go vet -mod=vendor ./...` | 통과 |
| `go test -race -count=1 -mod=vendor ./...` | 전 패키지 ok |
| `go test -race -count=1 -mod=vendor -tags semgrep_integration ./internal/scanner/` | ok — `기대 177건 · 검출 177건 · 전부 일치` |

## 파일 소유권

`rules/config.yaml` · `mapping/rules.yaml`(append) · `testdata/rule-fixtures/` 신규 4개만 건드렸다. `rules/typescript.yaml`·`internal/scanner/*.go`(`integration_test.go` 포함)는 손대지 않았다. 픽스처는 `testdata/rule-fixtures/` 최상위에 평평하게 두었고 파일명은 다른 진행 중 작업과 겹치지 않는다.
