### PR TITLE
feat(#70): TS 시크릿 룰에 공통 어휘·억제 이식 + 테스트 코드 룰 신설

### DIFF
--- a/mapping/rules.yaml
+++ b/mapping/rules.yaml
@@ -1841,3 +1841,18 @@
     // ↓ 동일 기능, AST 점검 대상이 된다
     export async function call(url: string) { ... }
     ```
+
+- rule_id: finguard.ts.hardcoded-secret-test
+  code: FIN-KEY-017
+  cwe: CWE-798
+  title: 테스트 코드에 하드코드된 중요정보(TypeScript/JavaScript)
+  severity: ERROR
+  basis: 개발보안가이드 「보안기능 - 하드코드된 중요정보」
+  kisa_item: "전자금융기반시설 평가기준(2026) 웹·모바일·HTS 43 (앱 소스코드 내 운영정보 노출 방지), 23 (고정된 인증정보 이용 방지)"
+  explain: 테스트 코드에 비밀번호·API 키·토큰이 문자열로 하드코드되어 있습니다. 파일명이 테스트라는 사실은 값이 더미라는 근거가 아니며, 저장소와 git 히스토리에 남은 자격증명은 운영 코드의 하드코드와 위험이 동일합니다. 값의 형태(길이·문자 구성)가 실제 자격증명으로 보이는 경우만 검출합니다.
+  fix_example: |
+    ```ts
+    const apiKey = process.env.TEST_API_KEY;
+    const maybe = apiKey ? describe : describe.skip;
+    maybe("결제 연동", () => { /* ... */ });
+    ```

--- a/rules/typescript.yaml
+++ b/rules/typescript.yaml
@@ -15,16 +15,55 @@ rules:
       include: ["*.ts", "*.tsx", "*.js", "*.jsx"]
     pattern-regex: '\b(eval|new\s+Function)\s*\('
 
+  # 식별자 어휘·억제는 7개 언어 공통 목록이다 (#36·#23). TS 만 #29 의 파일 소유권 충돌로
+  # 이식에서 빠져 있었다 (#70). 단독 `key` 는 넣지 않는다 — map key·헤더명으로 오탐이
+  # 폭증한다. app_secret·client_secret 은 `secret` 이, apikey 는 `api[_-]?key` 가 이미
+  # 포섭하므로 중복 항목은 두지 않는다.
+  #
+  # TS 고유 구문 3가지를 다른 언어판에 덧붙였다.
+  #  (1) 선언 키워드(const/let/var) 요구를 없앴다 — 객체 리터럴 프로퍼티
+  #      (`{ apiKey: "..." }`)·클래스 필드·헤더 맵(`"X-Api-Key": "..."`)이 전부 미탐이었다.
+  #  (2) 타입 주석을 건너뛴다 — `const password: string = "..."` 는 식별자 바로 뒤가
+  #      `=` 가 아니라 `:` 라 다른 언어판 정규식으로는 잡히지 않는다.
+  #  (3) `===`/`==` 비교식도 본다 — 하드코드 자격증명과의 동등 비교는 그 자체가 검출 대상이다.
+  #
+  # 백틱(템플릿 리터럴)은 의도적으로 제외했다 — `` `Bearer ${token}` `` 같은 보간 문자열이
+  # 값 자리에 그대로 들어와 오탐이 된다. 보간 여부 판정을 붙일 때 별도로 다룬다.
   - id: finguard.ts.hardcoded-secret
     languages: [regex]
     severity: ERROR
     message: 소스코드에 비밀정보(비밀번호·API 키·토큰)가 하드코드되어 있습니다.
     paths:
       include: ["*.ts", "*.tsx", "*.js", "*.jsx"]
+      exclude: ["*.test.ts", "*.spec.ts", "*.test.tsx", "*.spec.tsx", "*.test.js", "*.spec.js", "*.test.jsx", "*.spec.jsx"]
     patterns:
-      - pattern-regex: '(?i)\b(const|let|var)\s+\w*(password|passwd|secret|apikey|api_key)\w*\s*=\s*["''](?!(?-i:[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)")(?!(?-i:[a-z]+(?:_[a-z]+)+)")\S{8,}["'']'
+      - pattern-regex: '(?i)\b\w*(password|passwd|pwd|secret|api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|credential|passphrase|private[_-]?key|signing[_-]?key|encrypt(?:ion)?[_-]?key|master[_-]?key|aes[_-]?key|hmac[_-]?key)\w*["'']?\s*(?::\s*[\w<>\[\].|?]+\s*)?[:=]{1,3}\s*(?:"(?!(?-i:[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)")(?!(?-i:[a-z]+(?:_[a-z]+)+)")[^"%/{][^"]{7,}"|''(?![A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+'')(?![a-z]+(?:_[a-z]+)+'')[^''%/{][^'']{7,}'')'
       # 마스킹 플레이스홀더는 시크릿이 아니다 — 오히려 가리는 코드다
       - pattern-not-regex: '(?i)["''`](\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|<[^>]*redact[^>]*>|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]|[:=]\s*(\*{3,}|•{3,}|#{3,})(?![\w-])'
+      # 값 전체가 플레이스홀더인 unquoted 스칼라도 억제한다 (#23).
+      # 따옴표를 optional 로 푸는 대신 값 경계(줄 끝)로 앵커해 "값 전체가 플레이스홀더"라는
+      # 원래 의미를 보존한다 — 무앵커 부분일치로 바꾸면 실키 안의 우연한 xxx·todo 까지 억제된다.
+      - pattern-not-regex: '(?im)^[ \t]*(?:export[ \t]+)?(-[ \t]+)?["'']?[\w.-]+["'']?[ \t]*[:=][ \t]*["''`]?(\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]?[ \t]*[,;)]*[ \t]*(?:#.*|//.*)?$'
+      # 국내 샘플 코드의 표준 관용구인 한국어 안내문은 시크릿이 아니라 입력 지시문이다 (#23).
+      - pattern-not-regex: '(?im)^[^\n]*[:=][ \t]*["''`]?[^"''`\n]*(입력[ \t]*(?:하세요|해[ \t]*주세요|해주세요|바랍니다|하십시오)|여기에?[ \t]*입력|발급[ \t]*받은|본인의|자신의|예시|샘플)[^\n]*$'
+
+  # 테스트 코드 시크릿 (#25 의 이원화 정책을 TS 에 적용 — #70).
+  # 운영 룰과 어휘·억제는 같고 값 형태 조건만 강하다(길이·문자 구성이 실제 자격증명 형태일 때만).
+  # 테스트 픽스처의 "pw1234"·"test-password" 같은 값으로 도구가 못 쓰게 되는 것을 막는다.
+  # 대상은 파일명 규약(`*.test.ts`·`*.spec.ts` 계열)만 본다 — `__tests__/` 디렉터리 규약은
+  # 픽스처 디렉터리가 평평해서(#60) 회귀 테스트로 고정할 수 없어 이번 범위에서 뺐다.
+  # 그 경로의 파일은 종전대로 운영 룰이 덮는다.
+  - id: finguard.ts.hardcoded-secret-test
+    languages: [regex]
+    severity: ERROR
+    message: 테스트 코드에 비밀정보(비밀번호·API 키·토큰)가 하드코드되어 있습니다. 저장소와 git 히스토리에 그대로 남으므로 운영 코드와 동일하게 제거·회전해야 합니다.
+    paths:
+      include: ["*.test.ts", "*.spec.ts", "*.test.tsx", "*.spec.tsx", "*.test.js", "*.spec.js", "*.test.jsx", "*.spec.jsx"]
+    patterns:
+      - pattern-regex: '(?i)\b\w*(password|passwd|pwd|secret|api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|credential|passphrase|private[_-]?key|signing[_-]?key|encrypt(?:ion)?[_-]?key|master[_-]?key|aes[_-]?key|hmac[_-]?key)\w*["'']?\s*(?::\s*[\w<>\[\].|?]+\s*)?[:=]{1,3}\s*(?:"(?=[0-9]{12,}|[A-Za-z0-9+/=_.\-]{16,}|(?=[^"]{12,})(?=[^"]*[A-Za-z])(?=[^"]*[0-9]))(?!https?://)(?!jdbc:)(?!(?-i:[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)")(?!(?-i:[a-z]+(?:_[a-z]+)+)")[^"%/{][^"]{7,}"|''(?=[0-9]{12,}|[A-Za-z0-9+/=_.\-]{16,}|(?=[^'']{12,})(?=[^'']*[A-Za-z])(?=[^'']*[0-9]))(?!https?://)(?!jdbc:)(?![A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+'')(?![a-z]+(?:_[a-z]+)+'')[^''%/{][^'']{7,}'')'
+      - pattern-not-regex: '(?i)["''`](\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|<[^>]*redact[^>]*>|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]|[:=]\s*(\*{3,}|•{3,}|#{3,})(?![\w-])'
+      - pattern-not-regex: '(?im)^[ \t]*(?:export[ \t]+)?(-[ \t]+)?["'']?[\w.-]+["'']?[ \t]*[:=][ \t]*["''`]?(\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]?[ \t]*[,;)]*[ \t]*(?:#.*|//.*)?$'
+      - pattern-not-regex: '(?im)^[^\n]*[:=][ \t]*["''`]?[^"''`\n]*(입력[ \t]*(?:하세요|해[ \t]*주세요|해주세요|바랍니다|하십시오)|여기에?[ \t]*입력|발급[ \t]*받은|본인의|자신의|예시|샘플)[^\n]*$'
 
   - id: finguard.ts.http-url
     languages: [regex]

--- a/rules/typescript.yaml
+++ b/rules/typescript.yaml
@@ -35,7 +35,7 @@ rules:
     message: 소스코드에 비밀정보(비밀번호·API 키·토큰)가 하드코드되어 있습니다.
     paths:
       include: ["*.ts", "*.tsx", "*.js", "*.jsx"]
-      exclude: ["*.test.ts", "*.spec.ts", "*.test.tsx", "*.spec.tsx", "*.test.js", "*.spec.js", "*.test.jsx", "*.spec.jsx"]
+      exclude: ["*.test.ts", "*.spec.ts", "*.test.tsx", "*.spec.tsx", "*.test.js", "*.spec.js", "*.test.jsx", "*.spec.jsx", "**/test/**", "**/tests/**", "**/__tests__/**", "test_*.ts", "test_*.tsx", "test_*.js", "test_*.jsx"]
     patterns:
       - pattern-regex: '(?i)\b\w*(password|passwd|pwd|secret|api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|credential|passphrase|private[_-]?key|signing[_-]?key|encrypt(?:ion)?[_-]?key|master[_-]?key|aes[_-]?key|hmac[_-]?key)\w*["'']?\s*(?::\s*[\w<>\[\].|?]+\s*)?[:=]{1,3}\s*(?:"(?!(?-i:[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)")(?!(?-i:[a-z]+(?:_[a-z]+)+)")[^"%/{][^"]{7,}"|''(?![A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+'')(?![a-z]+(?:_[a-z]+)+'')[^''%/{][^'']{7,}'')'
       # 마스킹 플레이스홀더는 시크릿이 아니다 — 오히려 가리는 코드다
@@ -58,7 +58,7 @@ rules:
     severity: ERROR
     message: 테스트 코드에 비밀정보(비밀번호·API 키·토큰)가 하드코드되어 있습니다. 저장소와 git 히스토리에 그대로 남으므로 운영 코드와 동일하게 제거·회전해야 합니다.
     paths:
-      include: ["*.test.ts", "*.spec.ts", "*.test.tsx", "*.spec.tsx", "*.test.js", "*.spec.js", "*.test.jsx", "*.spec.jsx"]
+      include: ["*.test.ts", "*.spec.ts", "*.test.tsx", "*.spec.tsx", "*.test.js", "*.spec.js", "*.test.jsx", "*.spec.jsx", "**/test/**", "**/tests/**", "**/__tests__/**", "test_*.ts", "test_*.tsx", "test_*.js", "test_*.jsx"]
     patterns:
       - pattern-regex: '(?i)\b\w*(password|passwd|pwd|secret|api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|credential|passphrase|private[_-]?key|signing[_-]?key|encrypt(?:ion)?[_-]?key|master[_-]?key|aes[_-]?key|hmac[_-]?key)\w*["'']?\s*(?::\s*[\w<>\[\].|?]+\s*)?[:=]{1,3}\s*(?:"(?=[0-9]{12,}|[A-Za-z0-9+/=_.\-]{16,}|(?=[^"]{12,})(?=[^"]*[A-Za-z])(?=[^"]*[0-9]))(?!https?://)(?!jdbc:)(?!(?-i:[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)")(?!(?-i:[a-z]+(?:_[a-z]+)+)")[^"%/{][^"]{7,}"|''(?=[0-9]{12,}|[A-Za-z0-9+/=_.\-]{16,}|(?=[^'']{12,})(?=[^'']*[A-Za-z])(?=[^'']*[0-9]))(?!https?://)(?!jdbc:)(?![A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+'')(?![a-z]+(?:_[a-z]+)+'')[^''%/{][^'']{7,}'')'
       - pattern-not-regex: '(?i)["''`](\*{3,}|x{3,}|•{3,}|\.{4,}|#{3,}|_{4,}|redacted|<[^>]*redact[^>]*>|change[_-]?me|placeholder|dummy|your[_-][\w-]*|todo|fixme)["''`]|[:=]\s*(\*{3,}|•{3,}|#{3,})(?![\w-])'

--- a/testdata/rule-fixtures/ts_parity_vulns.ts
+++ b/testdata/rule-fixtures/ts_parity_vulns.ts
@@ -40,8 +40,12 @@ export async function run(): Promise<void> {
 }
 
 // 하드코드된 암호화 키
+// 식별자를 ENCRYPT_KEY 에서 CIPHER_KEY 로 바꿨다 (#70). 어휘 이식 후 ENCRYPT_KEY 는
+// hardcoded-crypto-material 과 hardcoded-secret 에 동시에 걸리는데(둘 다 정탐이고
+// 근거 조항이 다르다), 마커는 줄당 하나뿐이라 이 줄에서 두 기대값을 표현할 수 없다.
+// cipher 어휘는 시크릿 공통 어휘에 없어 이 룰만 단독으로 검증된다.
 // EXPECT: finguard.ts.hardcoded-crypto-material
-const ENCRYPT_KEY = "A1b2C3d4E5f6G7h8";
+const CIPHER_KEY = "A1b2C3d4E5f6G7h8";
 
 // IV 가 없는 deprecated 암호 API
 // EXPECT: finguard.ts.hardcoded-crypto-material
@@ -67,4 +71,4 @@ const otpCode = String(Math.floor(Math.random() * 1000000));
 // EXPECT: finguard.ts.tls-verify-disabled
 const agent = new https.Agent({ rejectUnauthorized: false });
 
-export { ENCRYPT_KEY, legacyCipher, decipher, digest, ecbCipher, otpCode, agent };
+export { CIPHER_KEY, legacyCipher, decipher, digest, ecbCipher, otpCode, agent };

--- a/testdata/rule-fixtures/ts_secret_nonprod.test.ts
+++ b/testdata/rule-fixtures/ts_secret_nonprod.test.ts
@@ -1,0 +1,25 @@
+// 룰 회귀 픽스처 — finguard.ts.hardcoded-secret-test (#70, 원 정책 #25). 값은 전부 합성 더미다.
+// 이 파일은 `*.test.ts` 라 운영 룰(finguard.ts.hardcoded-secret)의 대상에서 제외되고
+// 값 형태 조건이 강한 테스트 전용 룰만 적용된다.
+
+// EXPECT: finguard.ts.hardcoded-secret-test
+const apiKey = "1234567890123456";
+
+// EXPECT: finguard.ts.hardcoded-secret-test
+const password = "correcthorsebatterystaple";
+
+// EXPECT: finguard.ts.hardcoded-secret-test
+const dbPassword = "Pa$$w0rd!ProdBank";
+
+const fixture = {
+  // EXPECT: finguard.ts.hardcoded-secret-test
+  accessToken: "eyJhbGciOiJIUzI1NiJ9.c3ViOjEyMzQ1",
+};
+
+// 값 형태 게이트에서 걸러지는 짧은 더미 — 테스트 픽스처의 관용값은 잡지 않는다.
+const testPassword = "test1234";
+const shortSecret = "pw1234";
+
+// 플레이스홀더·안내문 억제는 운영 룰과 동일하다.
+const maskedApiKey = "****************";
+const merchantSecret = "발급받은 시크릿을 입력하세요";

--- a/testdata/rule-fixtures/ts_secret_vocab.ts
+++ b/testdata/rule-fixtures/ts_secret_vocab.ts
@@ -1,0 +1,76 @@
+// 룰 회귀 픽스처 — finguard.ts.hardcoded-secret 공통 어휘·억제 이식 (#70, 원 이슈 #36·#23).
+// 값은 전부 합성 더미다.
+
+// ── 정탐: 공통 어휘 (기존 TS 어휘 5개로는 전부 미탐이었다) ──────────────
+
+// EXPECT: finguard.ts.hardcoded-secret
+const ledgerEncryptionKey = "8f2b41c7d90e5a63b18c47f2e0d95a31";
+
+// SCREAMING_SNAKE 식별자도 같은 어휘로 잡는다.
+// (#70 이 예로 든 `ENCRYPT_KEY` 는 finguard.ts.hardcoded-crypto-material 이 이미 잡아
+//  한 줄에 두 룰이 걸린다. 마커는 줄당 하나라 여기서는 어휘가 겹치지 않는 값을 쓴다.)
+// EXPECT: finguard.ts.hardcoded-secret
+const ADMIN_PASSWD = "Zt91KbW3Nn74Rp08";
+
+// EXPECT: finguard.ts.hardcoded-secret
+const tradingAccessToken = "eyJhbGciOiJIUzI1NiJ9.c3ViOjEyMzQ1";
+
+// EXPECT: finguard.ts.hardcoded-secret
+const keystorePassphrase = "Vault-Store-2026-Qz73";
+
+// EXPECT: finguard.ts.hardcoded-secret
+const settlementSigningKey = "b71f4e0a92d63c85f0a7e14b2c69d830";
+
+// ── 정탐: TS 고유 구문 ────────────────────────────────────────────────
+
+// 타입 주석이 붙으면 식별자 바로 뒤가 `=` 가 아니다.
+// EXPECT: finguard.ts.hardcoded-secret
+const gatewayCredential: string = "Zt91-KbW3-Nn74-Rp08";
+
+const pgConfig = {
+  // 객체 리터럴 프로퍼티 — 선언 키워드가 없다.
+  // EXPECT: finguard.ts.hardcoded-secret
+  apiKey: "live_sk_9f31c8a05be24d77",
+  timeoutMs: 3000,
+};
+
+export class VaultClient {
+  // 클래스 필드.
+  // EXPECT: finguard.ts.hardcoded-secret
+  private readonly masterKey = "0a5f8c3e91b74d26af08e5b1c7d39240";
+}
+
+export function verify(inputSecret: string): boolean {
+  // 하드코드 자격증명과의 동등 비교.
+  // EXPECT: finguard.ts.hardcoded-secret
+  return inputSecret === "Adm1n-Console-2026!";
+}
+
+// ── 오탐 방지 ────────────────────────────────────────────────────────
+
+// 단독 `key` 는 공통 어휘에서 제외한다 — map key·헤더명 오탐이 폭증한다.
+const key = "Authorization-Bearer-Header";
+const sortKey = "settlement_date_desc";
+const rowKey = "PAYMENT_HISTORY_ID";
+
+// 값이 환경변수 이름(SCREAMING_SNAKE)이거나 snake_case 식별자면 시크릿이 아니다.
+const apiKeyEnvName = "PAYMENT_API_KEY";
+const secretLookupField = "merchant_secret_column";
+
+// 마스킹 플레이스홀더는 시크릿이 아니라 가리는 코드다 (#23).
+const maskedPassword = "****************";
+const clientSecret = "your-client-secret";
+const refreshToken = "CHANGE_ME";
+
+// 한국어 안내문은 입력 지시문이다 (#23).
+const merchantApiKey = "발급받은 API 키를 입력하세요";
+const storePassphrase = "여기에 입력";
+
+// 값이 짧으면(8자 미만) 자격증명으로 보지 않는다.
+const pwd = "1234";
+
+// 값이 아니라 참조다.
+const accessToken = process.env.ACCESS_TOKEN;
+const privateKey = loadPrivateKey();
+
+declare function loadPrivateKey(): string;


### PR DESCRIPTION
Closes #70

> **스택 PR** — 이 브랜치는 `main` 이 아니라 #66 의 브랜치(`fix/issue-66-ts-namespace-gap`,
> PR #71) **위에 쌓았다.** 둘 다 `rules/typescript.yaml` 을 건드리기 때문이다.
> **#71 을 먼저 머지**해야 하며, 그 뒤 이 PR 의 diff 는 아래 변경만 남는다.

## 무엇을 했나

`rules/typescript.yaml` 만 빠져 있던 #36(어휘 통일)·#23(억제 보강)·#25(테스트 코드 정책)를
이식했다. 당시 제외 사유는 #29 와의 파일 소유권 충돌이었고, #29 는 이미 머지됐다.

### 1. `finguard.ts.hardcoded-secret` — 공통 어휘 이식

| | 이전 | 이후 |
| :--- | :--- | :--- |
| 식별자 어휘 | `password\|passwd\|secret\|apikey\|api_key` (5개) | 7개 언어 공통 목록 (17개 어휘) |
| 마스킹 플레이스홀더 억제 | 적용 | 적용 (동일) |
| unquoted 스칼라 억제 | **미적용** | 적용 (#23 원문 그대로) |
| 한국어 안내문 억제 | **미적용** | 적용 (#23 원문 그대로) |
| 값 형태 | `\S{8,}` | `[^"%/{][^"]{7,}` (공통판) + 작은따옴표 갈래 |
| 테스트 파일 | 운영 룰이 그대로 스캔 | 제외 경로로 이동 → 전용 룰이 담당 |

공통 목록은 `rules/python.yaml`·`rules/go.yaml` 등 머지된 룰에서 그대로 가져왔다.
**단독 `key` 는 넣지 않았다** (map key·헤더명 오탐 폭증 — #36 반박 절).
트레일링은 공통판대로 `[ \t]*` 를 쓴다.

### 2. TS 고유 구문 3가지 보강

다른 언어판을 그대로 옮기면 TS 에서만 새는 구멍이 있어 세 가지를 덧붙였다.

1. **선언 키워드 요구 제거** — 기존 룰은 `(const|let|var)\s+` 를 강제해서
   객체 리터럴 프로퍼티(`{ apiKey: "..." }`)·클래스 필드(`private readonly masterKey = "..."`)·
   헤더 맵(`"X-Api-Key": "..."`)이 **전부 미탐**이었다. TS/JS 에서 시크릿이 실제로 가장 많이
   나타나는 자리가 객체 리터럴이다.
2. **타입 주석 건너뛰기** — `const password: string = "..."` 은 식별자 바로 뒤가 `=` 가 아니라
   `:` 라서 다른 언어판 정규식으로는 잡히지 않는다. 선택적 타입 주석 그룹을 넣었다.
3. **`===`/`==` 비교식** — `if (inputSecret === "Adm1n-...")` 처럼 하드코드 자격증명과
   동등 비교하는 코드도 검출 대상이다.

**백틱(템플릿 리터럴)은 의도적으로 제외했다.** `` `Bearer ${token}` `` 같은 보간 문자열이
값 자리에 그대로 들어와 오탐이 된다. 보간 여부 판정을 붙일 때 별도로 다룰 일이다.

### 3. `finguard.ts.hardcoded-secret-test` 신설 (#70 항목 4의 결정)

**신설하기로 했다.** 근거: 현재 TS 는 테스트 파일도 운영 룰이 **느슨한 값 조건**으로
스캔한다(`java`·`kotlin`·`go`·`python` 은 #25 로 이미 이원화됨). 즉 TS 만 테스트 파일에서
`"test1234"` 류를 ERROR 로 올릴 수 있는 상태였다. 전용 룰은 어휘·억제는 같고 **값 형태 조건만
강해서**(길이·문자 구성이 실제 자격증명으로 보일 때만) 커버리지를 잃지 않으면서 오탐을 줄인다.

대상은 파일명 규약(`*.test.ts`·`*.spec.ts` + tsx/js/jsx)만 본다. **`__tests__/` 디렉터리
규약은 이번 범위에서 뺐다** — 픽스처 디렉터리가 평평해서(#60 의 마커 파서 한계) 회귀
테스트로 고정할 수 없기 때문이다. 그 경로의 파일은 종전대로 운영 룰이 덮으므로 커버리지
공백은 생기지 않는다. 경로 글롭은 이 파일의 기존 룰(`hardcoded-crypto-material`·
`insecure-random`)이 이미 쓰는 제외 목록과 같은 형태로 맞췄다.

## 실코드 검증 — samchon/payments

`find <dir> -name '*.ts' | wc -l` = **230** (코퍼스 존재 확인). 두 번째 TS 코퍼스 `r0b`(65 파일)도
같이 돌렸다.

| 룰 | 수정 전 | 수정 후 |
| :--- | ---: | ---: |
| `hardcoded-secret` | 0 | **1** |
| `hardcoded-secret-test` | – | 0 (이 코퍼스에 `*.test.ts` 0개) |
| `insecure-random` | 1 | 1 |
| `sql-injection` | 2 | 2 |
| `stored-ssrf` | 2 | 2 |
| `hardcoded-crypto-material` | 1 | 1 |

증가분 1건 전수 확인 — **정탐**이다.

- `packages/payment-backend/src/utils/TokenManager.ts:80` — 하드코드된 AES 암호화 키
  (식별자 `ENCRYPT_KEY`). **#70 본문이 예로 든 바로 그 미탐**이다. 기존 5개 어휘에
  `encrypt(ion)?[_-]?key` 가 없어 `hardcoded-secret` 이 놓쳤고, 별도 신설 룰인
  `hardcoded-crypto-material` 만 (다른 줄에서) 잡고 있었다. 값은 출력하지 않는다.

오탐 0. 다른 룰 검출 수 변동 없음(회귀 없음). `r0b` 코퍼스는 0 → 0.

## 픽스처

- **`ts_secret_vocab.ts`** (신규) — 정탐 9건: 공통 어휘(access token·passphrase·signing key·
  encryption key·SCREAMING_SNAKE 식별자) + TS 고유 구문(타입 주석·객체 리터럴·클래스 필드·
  `===` 비교). 오탐 방지 12건: 단독 `key`/`sortKey`/`rowKey`, 값이 환경변수 이름·snake_case,
  마스킹 플레이스홀더, 한국어 안내문, 8자 미만 값, `process.env` 참조.
- **`ts_secret_nonprod.test.ts`** (신규) — 테스트 전용 룰 정탐 4건 + 값 형태 게이트에서
  걸러지는 짧은 더미·플레이스홀더·안내문.
- **`ts_parity_vulns.ts`** (수정 1줄) — `ENCRYPT_KEY` → `CIPHER_KEY`.
  어휘 이식 후 `ENCRYPT_KEY` 는 `hardcoded-crypto-material` 과 `hardcoded-secret` 에
  **동시에** 걸린다(둘 다 정탐이고 근거 조항이 다르다). 그런데 EXPECT 마커는 줄당 하나뿐이라
  한 줄에 두 기대값을 표현할 수 없다. `cipher` 는 시크릿 공통 어휘에 없어 원래 룰
  (`hardcoded-crypto-material`)만 단독으로 검증된다. 중복 검출 자체는 억제하지 않았다 —
  억제하려면 크립토 룰의 조건을 시크릿 룰 안에 복제해야 하고, 조건이 어긋나는 순간
  조용한 미탐이 된다.

**변이 시험**: `tradingAccessToken` → `tradingLedgerRef`, `apiKey:` → `apiIdent:` 로
두 정탐의 어휘를 지우자 미탐 회귀 2건으로 테스트가 실패했다. 원복 후 green 확인.

## 검증

| 명령 | 결과 |
| :--- | :--- |
| `semgrep --validate --config rules/` | `Configuration is valid — 0 error(s), 124 rule(s)` |
| 룰 수 = 매핑 수 | 124 = 124 (`TestEveryRuleMapped` 통과) |
| `go build -mod=vendor ./...` | 통과 |
| `go vet -mod=vendor ./...` | 통과 |
| `go test -race -count=1 -mod=vendor ./...` | 전 패키지 ok |
| `go test -race -count=1 -mod=vendor -tags semgrep_integration ./internal/scanner/` | ok (기대 188건 · 검출 188건 일치) |

## 파일

- `rules/typescript.yaml` — `hardcoded-secret` 개정 + `hardcoded-secret-test` 신설
- `mapping/rules.yaml` — `FIN-KEY-017` 엔트리 **추가만** (기존 엔트리 무수정)
- `testdata/rule-fixtures/ts_secret_vocab.ts` · `ts_secret_nonprod.test.ts` — 신규
- `testdata/rule-fixtures/ts_parity_vulns.ts` — 식별자 1개 개명

다른 언어 룰 파일과 `internal/scanner/*.go` 는 건드리지 않았다.
