### PR TITLE
fix(#75): 벤더 경로 스코프를 전역 제외에서 룰별 exclude 로 이관

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,6 +295,19 @@ block_on: [ERROR, WARNING]
   룰 설정과 무관하게 통째로 사라진다. 운영 스캔에서는 `internal/scanner` 가 대상 루트에
   같은 파일을 심는다(레포가 자기 것을 갖고 있으면 건드리지 않는다).
 
+### 스코프는 룰 파일이 소유한다
+
+`DefaultExcludes`(`internal/scanner/exclude.go`)의 전역 `--exclude` 는 semgrep 의 **타겟
+선정 단계**에서 작동해 룰의 `paths.include` 보다 먼저 파일을 걷어낸다. 그래서 전역에서
+제외한 경로는 어떤 룰도 볼 수 없다 — 그 경로를 의도적으로 점검하는 룰이 있어도 마찬가지다.
+
+- 특정 경로를 **의도적으로 점검하는 룰**(예: `finguard.swift.insecure-trust-vendor` 는
+  벤더 코드의 인증서 검증 무력화를 본다)이 존재하면, 그 경로를 `DefaultExcludes` 에
+  넣으면 안 된다. 제외가 필요한 다른 룰들은 각자 `paths.exclude` 에 적는다 (#75).
+- `Pods`·`Carthage` 가 이 경우다. `DefaultExcludes` 에 넣으면
+  `TestDefaultExcludesLeavesVendorScopeToRules` 가 실패한다.
+- 전역 제외에 새 항목을 추가할 때는 **그 경로를 대상으로 하는 룰이 없는지** 먼저 확인하라.
+
 ## 작업 방식
 
 - 한 번에 한 패키지씩. 완료 후 빌드와 테스트 통과를 확인하고 다음으로 넘어간다.

--- a/internal/scanner/exclude.go
+++ b/internal/scanner/exclude.go
@@ -18,7 +18,11 @@ var DefaultExcludes = []string{
 	"third_party",
 	"thirdparty",
 	"bower_components",
-	"Pods",
+	// "Pods" 는 여기서 빼고 rules/swift.yaml 의 룰별 paths.exclude 로 옮겼다 (#75).
+	// 전역에서 제외하면 semgrep 이 타겟 단계에서 걸러버려, 벤더 경로를 **의도적으로**
+	// 점검하는 룰(finguard.swift.insecure-trust-vendor — 벤더 Swift 코드의 인증서 검증
+	// 무력화는 최종 바이너리에 그대로 실려 나간다)의 include 가 도달하지 못했다.
+	// Carthage 가 원래 여기 없었던 것과의 비대칭도 이 이관으로 해소된다.
 	".venv",
 	"site-packages",
 

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -61,6 +61,23 @@ func TestDefaultExcludesCoversBuildOutputAndDeps(t *testing.T) {
 	}
 }
 
+// 벤더 경로는 전역이 아니라 룰별 paths.exclude 가 소유한다 (#75).
+//
+// 전역 `--exclude` 는 semgrep 의 타겟 선정 단계에서 걸러버려 룰의 paths.include 보다
+// 먼저 작동한다. 그래서 여기에 "Pods" 를 되돌려 놓으면, 벤더 경로를 **의도적으로**
+// 점검하는 finguard.swift.insecure-trust-vendor 의 include 가 다시 도달 불가가 된다
+// (벤더 Swift 코드의 인증서 검증 무력화는 최종 바이너리에 그대로 실려 나간다).
+//
+// 일반 Swift 룰 9개의 벤더 제외는 rules/swift.yaml 의 룰별 exclude 로 이관돼 있다.
+func TestDefaultExcludesLeavesVendorScopeToRules(t *testing.T) {
+	for _, notWant := range []string{"Pods", "Carthage"} {
+		if contains(DefaultExcludes, notWant) {
+			t.Errorf("기본 제외 목록에 %q 가 있다 — 벤더 경로를 점검하는 룰의 include 가 도달 불가가 된다 (#75). "+
+				"제외가 필요하면 rules/swift.yaml 의 룰별 paths.exclude 에 넣어라", notWant)
+		}
+	}
+}
+
 func contains(ss []string, s string) bool { return indexOf(ss, s) >= 0 }
 
 func indexOf(ss []string, s string) int {

--- a/rules/swift.yaml
+++ b/rules/swift.yaml
@@ -16,7 +16,17 @@ rules:
     message: 소스코드에 비밀정보(비밀번호·API 키·토큰)가 하드코드되어 있습니다.
     paths:
       include: ["*.swift"]
-      exclude: ["**/build/**", "**/DerivedData/**", "**/*.xcframework/**"]
+      exclude:
+        - "**/build/**"
+        - "**/DerivedData/**"
+        - "**/*.xcframework/**"
+        # 벤더 의존성 — 전역 DefaultExcludes 가 아니라 여기서 제외한다 (#75).
+        # 벤더 경로를 의도적으로 점검하는 룰(insecure-trust-vendor)이 존재하므로,
+        # 스코프 판단은 룰 파일이 단일 진실원천이어야 한다.
+        - "Pods/**"
+        - "**/Pods/**"
+        - "Carthage/**"
+        - "**/Carthage/**"
     patterns:
       # 식별자 어휘는 6개 언어 공통 목록이다 (#36). 단독 `key` 는 넣지 않는다.
       # 단독 `token` 은 이 룰에 원래 있던 항목이라 유지한다 — 공통 목록으로 대체하면
@@ -37,7 +47,17 @@ rules:
     message: 평문 HTTP URL 이 사용되고 있습니다. TLS(https) 로 전환해야 합니다.
     paths:
       include: ["*.swift"]
-      exclude: ["**/build/**", "**/DerivedData/**", "**/*.xcframework/**"]
+      exclude:
+        - "**/build/**"
+        - "**/DerivedData/**"
+        - "**/*.xcframework/**"
+        # 벤더 의존성 — 전역 DefaultExcludes 가 아니라 여기서 제외한다 (#75).
+        # 벤더 경로를 의도적으로 점검하는 룰(insecure-trust-vendor)이 존재하므로,
+        # 스코프 판단은 룰 파일이 단일 진실원천이어야 한다.
+        - "Pods/**"
+        - "**/Pods/**"
+        - "Carthage/**"
+        - "**/Carthage/**"
     pattern-regex: '(?im)^(?![ \t]*(?://|\*|/\*)).*"http://(?!localhost|127\.0\.0\.1|0\.0\.0\.0|schemas\.|xmlns|(?:www\.)?w3\.org|(?:[\w.]+\.)?apache\.org|[\w.]*xml\.org|java\.sun\.com|(?:www\.)?example\.(?:com|org)|(?:www\.)?unicode\.org|(?:www\.)?jflex\.de|purl\.org|iana\.org|ietf\.org|slf4j\.org|json-schema\.org)[^"]+"'
 
   # 금융 실시간 채널(시세·체결통보)은 대부분 웹소켓이고 접속키가 함께 흐른다 (#30).
@@ -49,7 +69,17 @@ rules:
     message: 평문 WebSocket(ws://) 으로 통신하고 있습니다. 실시간 시세·체결통보 채널에는 접속키와 거래내역이 흐르므로 wss:// 로 전환해야 합니다.
     paths:
       include: ["*.swift"]
-      exclude: ["**/build/**", "**/DerivedData/**", "**/*.xcframework/**"]
+      exclude:
+        - "**/build/**"
+        - "**/DerivedData/**"
+        - "**/*.xcframework/**"
+        # 벤더 의존성 — 전역 DefaultExcludes 가 아니라 여기서 제외한다 (#75).
+        # 벤더 경로를 의도적으로 점검하는 룰(insecure-trust-vendor)이 존재하므로,
+        # 스코프 판단은 룰 파일이 단일 진실원천이어야 한다.
+        - "Pods/**"
+        - "**/Pods/**"
+        - "Carthage/**"
+        - "**/Carthage/**"
     pattern-regex: '(?im)^(?![ \t]*(?://|\*|/\*)).*"ws://(?!localhost|127\.0\.0\.1|0\.0\.0\.0|schemas\.|xmlns|(?:www\.)?w3\.org|(?:[\w.]+\.)?apache\.org|[\w.]*xml\.org|java\.sun\.com|(?:www\.)?example\.(?:com|org)|(?:www\.)?unicode\.org|(?:www\.)?jflex\.de|purl\.org|iana\.org|ietf\.org|slf4j\.org|json-schema\.org)[^"]+"'
 
   # UserDefaults 평문 저장 (#31).
@@ -65,7 +95,17 @@ rules:
     message: UserDefaults 에 중요정보를 평문 저장하고 있습니다. Keychain 을 사용해야 합니다.
     paths:
       include: ["*.swift"]
-      exclude: ["**/build/**", "**/DerivedData/**", "**/*.xcframework/**"]
+      exclude:
+        - "**/build/**"
+        - "**/DerivedData/**"
+        - "**/*.xcframework/**"
+        # 벤더 의존성 — 전역 DefaultExcludes 가 아니라 여기서 제외한다 (#75).
+        # 벤더 경로를 의도적으로 점검하는 룰(insecure-trust-vendor)이 존재하므로,
+        # 스코프 판단은 룰 파일이 단일 진실원천이어야 한다.
+        - "Pods/**"
+        - "**/Pods/**"
+        - "Carthage/**"
+        - "**/Carthage/**"
     pattern-either:
       - pattern-regex: '(?i)UserDefaults[^\n]*\.set\([^\n]*(password|passwd|token|secret|pin|cardno|card_no|accountno)'
       # UserDefaults 를 감싸는 커스텀 propertyWrapper 의 사용부 (@UserDefault/@Storage/@UserInfo …)
@@ -79,7 +119,17 @@ rules:
     message: 폐기된 UIWebView 를 사용하고 있습니다. WKWebView 로 교체해야 합니다.
     paths:
       include: ["*.swift"]
-      exclude: ["**/build/**", "**/DerivedData/**", "**/*.xcframework/**"]
+      exclude:
+        - "**/build/**"
+        - "**/DerivedData/**"
+        - "**/*.xcframework/**"
+        # 벤더 의존성 — 전역 DefaultExcludes 가 아니라 여기서 제외한다 (#75).
+        # 벤더 경로를 의도적으로 점검하는 룰(insecure-trust-vendor)이 존재하므로,
+        # 스코프 판단은 룰 파일이 단일 진실원천이어야 한다.
+        - "Pods/**"
+        - "**/Pods/**"
+        - "Carthage/**"
+        - "**/Carthage/**"
     pattern-regex: '\bUIWebView\b'
 
   - id: finguard.swift.weak-hash
@@ -88,7 +138,17 @@ rules:
     message: 취약한 해시 알고리즘(MD5/SHA-1)을 사용하고 있습니다.
     paths:
       include: ["*.swift"]
-      exclude: ["**/build/**", "**/DerivedData/**", "**/*.xcframework/**"]
+      exclude:
+        - "**/build/**"
+        - "**/DerivedData/**"
+        - "**/*.xcframework/**"
+        # 벤더 의존성 — 전역 DefaultExcludes 가 아니라 여기서 제외한다 (#75).
+        # 벤더 경로를 의도적으로 점검하는 룰(insecure-trust-vendor)이 존재하므로,
+        # 스코프 판단은 룰 파일이 단일 진실원천이어야 한다.
+        - "Pods/**"
+        - "**/Pods/**"
+        - "Carthage/**"
+        - "**/Carthage/**"
     pattern-regex: '\b(CC_MD5|CC_SHA1|Insecure\.MD5|Insecure\.SHA1)\b'
 
   - id: finguard.swift.print-sensitive
@@ -97,7 +157,17 @@ rules:
     message: 로그/콘솔에 중요정보가 출력될 수 있습니다.
     paths:
       include: ["*.swift"]
-      exclude: ["**/build/**", "**/DerivedData/**", "**/*.xcframework/**"]
+      exclude:
+        - "**/build/**"
+        - "**/DerivedData/**"
+        - "**/*.xcframework/**"
+        # 벤더 의존성 — 전역 DefaultExcludes 가 아니라 여기서 제외한다 (#75).
+        # 벤더 경로를 의도적으로 점검하는 룰(insecure-trust-vendor)이 존재하므로,
+        # 스코프 판단은 룰 파일이 단일 진실원천이어야 한다.
+        - "Pods/**"
+        - "**/Pods/**"
+        - "Carthage/**"
+        - "**/Carthage/**"
     pattern-regex: '(?im)^(?![ \t]*(?://|\*|/\*)).*?\b(?:print|NSLog|os_log)\((?:(?:"(?:\\.|[^"\\\n])*"|[^"\n])*?(?:\b(?:password|passwd|token|secret|pin|cardno|card_no)\b|주민)|[^\n]*?\\\([^)\n]*(?:\b(?:password|passwd|token|secret|pin|cardno|card_no)\b|주민))'
 
   - id: finguard.swift.sql-interpolation
@@ -106,7 +176,17 @@ rules:
     message: SQL 문자열에 변수를 직접 보간(interpolation)하고 있습니다. 바인딩 파라미터를 사용해야 합니다.
     paths:
       include: ["*.swift"]
-      exclude: ["**/build/**", "**/DerivedData/**", "**/*.xcframework/**"]
+      exclude:
+        - "**/build/**"
+        - "**/DerivedData/**"
+        - "**/*.xcframework/**"
+        # 벤더 의존성 — 전역 DefaultExcludes 가 아니라 여기서 제외한다 (#75).
+        # 벤더 경로를 의도적으로 점검하는 룰(insecure-trust-vendor)이 존재하므로,
+        # 스코프 판단은 룰 파일이 단일 진실원천이어야 한다.
+        - "Pods/**"
+        - "**/Pods/**"
+        - "Carthage/**"
+        - "**/Carthage/**"
     pattern-regex: '"(?i)(SELECT|INSERT|UPDATE|DELETE)\b[^"]*\\\('
 
   # ATS 전역 해제 (#33).
@@ -162,7 +242,17 @@ rules:
     message: WebView 의 파일 접근 설정이 로컬 파일 탈취에 악용될 수 있습니다.
     paths:
       include: ["*.swift"]
-      exclude: ["**/build/**", "**/DerivedData/**", "**/*.xcframework/**"]
+      exclude:
+        - "**/build/**"
+        - "**/DerivedData/**"
+        - "**/*.xcframework/**"
+        # 벤더 의존성 — 전역 DefaultExcludes 가 아니라 여기서 제외한다 (#75).
+        # 벤더 경로를 의도적으로 점검하는 룰(insecure-trust-vendor)이 존재하므로,
+        # 스코프 판단은 룰 파일이 단일 진실원천이어야 한다.
+        - "Pods/**"
+        - "**/Pods/**"
+        - "Carthage/**"
+        - "**/Carthage/**"
     pattern-regex: '\b(allowFileAccessFromFileURLs|allowUniversalAccessFromFileURLs)\b'
 
   # 인증서 검증 무력화 (#33).

--- a/testdata/rule-fixtures/Carthage/Checkouts/ExampleNetworkKit/ExampleTrustBypass.swift
+++ b/testdata/rule-fixtures/Carthage/Checkouts/ExampleNetworkKit/ExampleTrustBypass.swift
@@ -7,10 +7,9 @@
 //  마커 파서가 하위 디렉터리를 순회하지 않던 동안에는 그게 불가능해서 이 룰만
 //  회귀 픽스처 없이 머지됐다 (#60).
 //
-//  경로가 Pods/ 가 아니라 Carthage/ 인 이유: finguard 의 DefaultExcludes 에
-//  "Pods" 가 들어 있어 `CLI.Scan` 이 semgrep 에 `--exclude Pods` 를 넘긴다.
-//  즉 Pods/ 하위는 룰의 include 와 무관하게 스캔 자체에서 빠진다. Carthage/ 는
-//  DefaultExcludes 에 없어 실제 운영 스캔에서도 이 룰이 발화하는 경로다.
+//  #75 이후로는 Pods/ 하위도 같은 방식으로 검증한다(ExamplePodsTrustBypass.swift).
+//  그 전에는 DefaultExcludes 의 "Pods" 가 타겟 단계에서 걸러 이 룰의 include 가
+//  도달하지 못했고, 그래서 이 픽스처만 Carthage/ 에 있었다.
 //
 //  합성 코드이며 실제 라이브러리 코드가 아니다.
 //

--- a/testdata/rule-fixtures/Pods/ExampleNetworkKit/ExamplePodsTrustBypass.swift
+++ b/testdata/rule-fixtures/Pods/ExampleNetworkKit/ExamplePodsTrustBypass.swift
@@ -1,0 +1,36 @@
+//
+//  룰 회귀 픽스처 — finguard.swift.insecure-trust-vendor, Pods/ 경로 (#75)
+//
+//  이 파일의 존재 자체가 #75 의 회귀 방어다.
+//
+//  이전에는 `DefaultExcludes` 에 "Pods" 가 있어 `CLI.Scan` 이 semgrep 에
+//  `--exclude Pods` 를 넘겼고, 전역 exclude 는 룰의 `paths.include` 보다 먼저
+//  타겟을 걸러내므로 이 룰의 `Pods/**` 분기는 **운영 스캔에서 도달 불가**였다.
+//  즉 있지도 않은 커버리지를 있는 것처럼 보이게 하는 죽은 설정이었다.
+//
+//  #75 에서 벤더 제외를 전역이 아니라 룰별 `paths.exclude` 로 옮겼다. 일반 Swift 룰
+//  9개는 각자 Pods/Carthage 를 제외하고, 벤더 경로를 의도적으로 점검하는 이 룰만
+//  거기에 도달한다. DefaultExcludes 에 "Pods" 를 되돌리면 아래 마커가 미탐 회귀로
+//  즉시 실패한다.
+//
+//  합성 코드이며 실제 라이브러리 코드가 아니다.
+//
+
+import Foundation
+
+final class PodsVendorSessionDelegate {
+
+    // 벤더 소스의 인증서 검증 무력화는 최종 바이너리에 그대로 실려 나간다.
+    func credential(for trust: SecTrust) -> URLCredential {
+        // EXPECT: finguard.swift.insecure-trust-vendor
+        return URLCredential(trust: trust)
+    }
+
+    // Starscream 3 관용구.
+    func makeSocket() -> Any {
+        let socket = ExampleWebSocket()
+        // EXPECT: finguard.swift.insecure-trust-vendor
+        socket.disableSSLCertValidation = true
+        return socket
+    }
+}


### PR DESCRIPTION
Closes #75

## 문제

`DefaultExcludes` 의 전역 `--exclude` 는 semgrep 의 **타겟 선정 단계**에서 작동해 룰의 `paths.include` 보다 먼저 파일을 걷어낸다. `"Pods"` 가 거기 있어서 `finguard.swift.insecure-trust-vendor` 의 `Pods/**` 분기는 **운영 스캔에서 도달 불가**였다 — 있지도 않은 커버리지를 있는 것처럼 보이게 하는 죽은 설정이다.

`Carthage` 는 `DefaultExcludes` 에 없어 비대칭이기도 했다.

## 선택 — 전역을 푸는 대신 스코프를 룰 파일로 이관

이슈는 A(룰에서 `Pods/**` 제거)와 B(전역에서 `Pods` 제거) 두 갈래를 제시했다. 조사해 보니 **B 를 그대로 하면 위험**했다.

`rules/swift.yaml` 13개 룰 중 **9개가 전역 제외에만 의존**하고 있었다. 전역에서 `Pods` 만 빼면 그 9개가 벤더 코드를 보게 되고, 그 노이즈 크기는 **현재 코퍼스로 측정할 수 없다**(공개 Swift 레포 3개 모두 `Pods`/`Carthage` 를 커밋하지 않음).

그래서 스코프 판단을 룰 파일로 옮겼다.

- `rules/swift.yaml` — 일반 Swift 룰 9개에 `Pods/**`·`Carthage/**` 제외를 **명시**
- `internal/scanner/exclude.go` — `"Pods"` 제거

이제 룰 파일이 스코프의 단일 진실원천이고, 벤더 경로를 의도적으로 점검하는 룰만 거기에 도달한다.

## 실측 — 합성 벤더 트리로 회귀 확인

9개 룰 전부를 자극하는 Swift 파일을 `App/`·`Pods/`·`Carthage/` 에 동일하게 두고, **수정 전(전역 `--exclude Pods`)과 수정 후**를 비교했다.

| 경로 | 전 | 후 | 변화 |
| :--- | ---: | ---: | :--- |
| `App/` (운영 코드) | 10 | 10 | **변화 없음** |
| `Pods/` | 0 | 1 | `insecure-trust-vendor` 만 신규 |
| `Carthage/` | 10 | 1 | 일반 룰 9개가 이제 `Pods` 와 동일하게 벤더를 건너뜀 |

**운영 코드 검출은 완전히 동일하다.** 동작 변화는 벤더 경로에 한정된다.

### Carthage 축소는 의도된 것이다

이게 비대칭 해소의 실제 내용이다. "벤더 코드에 일반 룰을 돌리면 개발자가 고칠 수 없는 코드에 코멘트가 달리고 실제 지적이 노이즈에 묻힌다" 는 `DefaultExcludes` 의 원칙을 `Carthage` 에도 **동일하게** 적용한 것이고, 보안상 가장 중요한 클래스(인증서 검증 무력화)는 벤더 전용 룰(WARNING)이 계속 덮는다.

반대 방향(= `Pods` 도 모든 룰로 스캔)을 택하지 않은 이유는 위의 측정 불가 문제다. 필요하면 실제 `Pods` 커밋 레포를 확보한 뒤 재검토할 수 있다.

## 회귀 방어 — 이중

1. **`TestDefaultExcludesLeavesVendorScopeToRules`** — `"Pods"`/`"Carthage"` 가 전역 목록에 되돌아오면 실패. 실패 메시지가 어디에 넣어야 하는지까지 안내한다.
2. **`testdata/rule-fixtures/Pods/ExampleNetworkKit/ExamplePodsTrustBypass.swift`** — 이 픽스처의 존재 자체가 회귀 방어다. 되돌리면 마커 2건이 미탐 회귀로 실패한다.

변이 시험으로 둘 다 실제 실패하는 것을 확인했다.

```
① 전역에 "Pods" 되돌림 → FAIL: 기본 제외 목록에 "Pods" 가 있다 — ... 도달 불가가 된다 (#75)
② 통합 테스트      → FAIL: 미탐 회귀 — Pods/.../ExamplePodsTrustBypass.swift:26, :33
③ 원복             → ok
```

## 검증

- `semgrep --validate --config rules/` → valid, 125 rules
- `go build` · `go vet` · `go test -race -count=1 ./...` 전 패키지 통과
- `go test -tags semgrep_integration ./internal/scanner/` → **기대 203건 · 검출 203건 전부 일치**

## 문서

`AGENTS.md` 에 「스코프는 룰 파일이 소유한다」 절을 추가했다 — 전역 제외가 `paths.include` 를 이긴다는 사실과, 전역 목록에 항목을 추가하기 전에 그 경로를 대상으로 하는 룰이 없는지 확인하라는 규칙.

기존 `Carthage/` 픽스처의 헤더 주석도 갱신했다(“Pods 는 전역 제외라 쓸 수 없다” 는 설명이 이 PR 로 더 이상 사실이 아니다).
